### PR TITLE
BugFix: Correctly split dataset if only separate validation set provided

### DIFF
--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -66,7 +66,7 @@ def run_training(args: Namespace, logger: Logger = None) -> List[float]:
     if args.separate_val_path and args.separate_test_path:
         train_data = data
     elif args.separate_val_path:
-        train_data, _, test_data = split_data(data=data, split_type=args.split_type, sizes=(0.8, 0.2, 0.0), seed=args.seed, args=args, logger=logger)
+        train_data, _, test_data = split_data(data=data, split_type=args.split_type, sizes=(0.8, 0.0, 0.2), seed=args.seed, args=args, logger=logger)
     elif args.separate_test_path:
         train_data, val_data, _ = split_data(data=data, split_type=args.split_type, sizes=(0.8, 0.2, 0.0), seed=args.seed, args=args, logger=logger)
     else:


### PR DESCRIPTION
This commit fixes a issue that If only separate validation set is provided, the resulting test set would be null.