### PR TITLE
Change to get_data to skip irrelevant examples when filtering with target_columns

### DIFF
--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -180,9 +180,8 @@ def get_data(path: str,
             targets = [float(row[column]) if row[column] != '' else None for column in target_columns]
 
             # Check whether all targets are None -- this is relevant when specifying target_columns
-            num_none = sum([x is None for x in targets])
-            if num_none == len(targets):
-                continue # skip this example
+            if all(x is None for x in targets):
+                continue
 
             all_smiles.append(smiles)
             all_targets.append(targets)

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -179,6 +179,11 @@ def get_data(path: str,
 
             targets = [float(row[column]) if row[column] != '' else None for column in target_columns]
 
+            # Check whether all targets are None -- this is relevant when specifying target_columns
+            num_none = sum([x is not None for x in targets])
+            if num_none == len(targets):
+                continue # skip this example
+
             all_smiles.append(smiles)
             all_targets.append(targets)
 

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -180,7 +180,7 @@ def get_data(path: str,
             targets = [float(row[column]) if row[column] != '' else None for column in target_columns]
 
             # Check whether all targets are None -- this is relevant when specifying target_columns
-            num_none = sum([x is not None for x in targets])
+            num_none = sum([x is None for x in targets])
             if num_none == len(targets):
                 continue # skip this example
 

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -111,7 +111,8 @@ def get_data(path: str,
              features_generator: List[str] = None,
              max_data_size: int = None,
              store_row: bool = False,
-             logger: Logger = None) -> MoleculeDataset:
+             logger: Logger = None,
+             skip_none_targets: bool = False) -> MoleculeDataset:
     """
     Gets SMILES and target values from a CSV file.
 
@@ -129,6 +130,8 @@ def get_data(path: str,
     :param max_data_size: The maximum number of data points to load.
     :param logger: A logger for recording output.
     :param store_row: Whether to store the raw CSV row in each :class:`~chemprop.data.data.MoleculeDatapoint`.
+    :param skip_none_targets: Whether to skip targets that are all 'None'. This is mostly relevant when --target_columns
+                              are passed in, so only a subset of tasks are examined.
     :return: A :class:`~chemprop.data.MoleculeDataset` containing SMILES and target values along
              with other info such as additional features when desired.
     """
@@ -179,8 +182,8 @@ def get_data(path: str,
 
             targets = [float(row[column]) if row[column] != '' else None for column in target_columns]
 
-            # Check whether all targets are None -- this is relevant when specifying target_columns
-            if all(x is None for x in targets):
+            if skip_none_targets and all(x is None for x in targets):
+            # Check whether all targets are None and skip if so
                 continue
 
             all_smiles.append(smiles)

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -51,7 +51,7 @@ def run_training(args: TrainArgs, logger: Logger = None) -> List[float]:
 
     # Get data
     debug('Loading data')
-    data = get_data(path=args.data_path, args=args, logger=logger)
+    data = get_data(path=args.data_path, args=args, logger=logger, skip_none_targets=True)
     validate_dataset_type(data, dataset_type=args.dataset_type)
     args.features_size = data.features_size()
     debug(f'Number of tasks = {args.num_tasks}')


### PR DESCRIPTION
Hello!

First, huge fan of ChemProp. Thanks for open sourcing such great code. 

I was running ChemProp on particular tasks in the ChEMBL dataset (using --target_columns) and observed that sometimes my losses would explode or be NaN -- after digging through what was going on I realized that I was running into an edge case where, as ChEMBL is a sparse dataset, several of the datapoints in the chembl.csv dataset are irrelevant to the specified --target_columns at hand, so unlabelled datapoints were being surfaced during training.

I fixed the issue with this 3-liner. I hoped this was the simplest fix that wouldn't break other functionality, but let me know if this doesn't play well with other uses of ChemProp (e.g. when running on other datasets).

Thanks again!