### PR TITLE
Custom Atom features

### DIFF
--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -148,7 +148,7 @@ class TrainArgs(CommonArgs):
     """
     ignore_columns: List[str] = None
     """Name of the columns to ignore when :code:`target_columns` is not provided."""
-    dataset_type: Literal['regression', 'classification', 'multiclass']
+    dataset_type: Literal['regression', 'classification', 'multiclass'] = 'classification'
     """Type of dataset. This determines the loss function used during training."""
     multiclass_num_classes: int = 3
     """Number of classes when running multiclass classification."""

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -84,11 +84,14 @@ class CommonArgs(Tap):
     """Number of workers for the parallel data loading (0 means sequential)."""
     batch_size: int = 50
     """Batch size."""
-    atom_descriptors: Literal['None', 'feature', 'descriptor'] = 'None'
-    """Custom extra atom descriptors. feature: used as atom features to featurize a given molecule. 
-    descriptor: used as descriptor and concatenated to the machine learned atomic representation"""
+    atom_descriptors: Literal[None, 'feature', 'descriptor'] = None
+    """
+    Custom extra atom descriptors.
+    :code:`feature`: used as atom features to featurize a given molecule. 
+    :code:`descriptor`: used as descriptor and concatenated to the machine learned atomic representation.
+    """
     atom_descriptors_path: str = None
-    """Path to the extra atom descriptors"""
+    """Path to the extra atom descriptors."""
 
     @property
     def device(self) -> torch.device:
@@ -134,7 +137,7 @@ class CommonArgs(Tap):
             raise ValueError('When using rdkit_2d_normalized features, --no_features_scaling must be specified.')
 
         # Validate atom descriptors
-        if self.atom_descriptors != 'None' and self.atom_descriptors_path is None:
+        if self.atom_descriptors is not None and self.atom_descriptors_path is None:
             raise ValueError('When using atom_descriptors, --atom_descriptors_path must be specified')
 
 

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -85,7 +85,7 @@ class CommonArgs(Tap):
     """Number of workers for the parallel data loading (0 means sequential)."""
     batch_size: int = 50
     """Batch size."""
-    atom_descriptors: Literal[None, 'feature', 'descriptor'] = None
+    atom_descriptors: Literal['feature', 'descriptor'] = None
     """
     Custom extra atom descriptors.
     :code:`feature`: used as atom features to featurize a given molecule. 

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -151,7 +151,7 @@ class TrainArgs(CommonArgs):
     """
     ignore_columns: List[str] = None
     """Name of the columns to ignore when :code:`target_columns` is not provided."""
-    dataset_type: Literal['regression', 'classification', 'multiclass'] = 'classification'
+    dataset_type: Literal['regression', 'classification', 'multiclass']
     """Type of dataset. This determines the loss function used during training."""
     multiclass_num_classes: int = 3
     """Number of classes when running multiclass classification."""

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -81,6 +81,11 @@ class CommonArgs(Tap):
     """Number of workers for the parallel data loading (0 means sequential)."""
     batch_size: int = 50
     """Batch size."""
+    atom_descriptors: Literal['None', 'feature', 'descriptor'] = 'None'
+    """Custom extra atom descriptors. feature: used as atom features to featurize a given molecule. 
+    descriptor: used as descriptor and concatenated to the machine learned atomic representation"""
+    atom_descriptors_path: str = None
+    """Path to the extra atom descriptors"""
 
     @property
     def device(self) -> torch.device:
@@ -124,6 +129,10 @@ class CommonArgs(Tap):
         # Validate features
         if self.features_generator is not None and 'rdkit_2d_normalized' in self.features_generator and self.features_scaling:
             raise ValueError('When using rdkit_2d_normalized features, --no_features_scaling must be specified.')
+
+        # Validate atom descriptors
+        if self.atom_descriptors != 'None' and self.atom_descriptors_path is None:
+            raise ValueError('When using atom_descriptors, --atom_descriptors_path must be specified')
 
 
 class TrainArgs(CommonArgs):

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -60,7 +60,7 @@ def get_checkpoint_paths(checkpoint_path: Optional[str] = None,
 class CommonArgs(Tap):
     """:class:`CommonArgs` contains arguments that are used in both :class:`TrainArgs` and :class:`PredictArgs`."""
 
-    smiles_column: str = 'smiles'
+    smiles_column: str = None
     """Name of the column containing SMILES strings. By default, uses the first column."""
     checkpoint_dir: str = None
     """Directory from which to load model checkpoints (walks directory and ensembles all models that are found)."""
@@ -87,7 +87,7 @@ class CommonArgs(Tap):
     atom_descriptors: Literal['None', 'feature', 'descriptor'] = 'None'
     """Custom extra atom descriptors. feature: used as atom features to featurize a given molecule. 
     descriptor: used as descriptor and concatenated to the machine learned atomic representation"""
-    atom_descriptors_path: str = 'features.pickle'
+    atom_descriptors_path: str = None
     """Path to the extra atom descriptors"""
 
     @property
@@ -142,9 +142,9 @@ class TrainArgs(CommonArgs):
     """:class:`TrainArgs` includes :class:`CommonArgs` along with additional arguments used for training a Chemprop model."""
 
     # General arguments
-    data_path: str = 'train.csv'
+    data_path: str
     """Path to data CSV file."""
-    target_columns: List[str] = ['GSH']
+    target_columns: List[str] = None
     """
     Name of the columns containing target values.
     By default, uses all columns except the SMILES column and the :code:`ignore_columns`.

--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -25,6 +25,7 @@ class MoleculeDatapoint:
                  row: OrderedDict = None,
                  features: np.ndarray = None,
                  features_generator: List[str] = None,
+                 atom_features: np.ndarray = None,
                  atom_descriptors: np.ndarray = None):
         """
         :param smiles: The SMILES string for the molecule.
@@ -42,6 +43,7 @@ class MoleculeDatapoint:
         self.features = features
         self.features_generator = features_generator
         self.atom_descriptors = atom_descriptors
+        self.atom_features = atom_features
         self._mol = 'None'  # Initialize with 'None' to distinguish between None returned by invalid molecule
 
         # Generate additional features if given a generator
@@ -64,6 +66,11 @@ class MoleculeDatapoint:
         if self.atom_descriptors is not None:
             replace_token = 0
             self.atom_descriptors = np.where(np.isnan(self.atom_descriptors), replace_token, self.atom_descriptors)
+
+        # Fix nans in atom_features
+        if self.atom_features is not None:
+            replace_token = 0
+            self.atom_features = np.where(np.isnan(self.atom_features), replace_token, self.atom_features)
 
     @property
     def mol(self) -> Chem.Mol:
@@ -146,7 +153,7 @@ class MoleculeDataset(Dataset):
                 if d.smiles in SMILES_TO_GRAPH:
                     mol_graph = SMILES_TO_GRAPH[d.smiles]
                 else:
-                    mol_graph = MolGraph(d.mol)
+                    mol_graph = MolGraph(d.mol, d.atom_features)
                     if cache:
                         SMILES_TO_GRAPH[d.smiles] = mol_graph
                 mol_graphs.append(mol_graph)

--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -58,18 +58,16 @@ class MoleculeDatapoint:
             self.features = np.array(self.features)
 
         # Fix nans in features
+        replace_token = 0
         if self.features is not None:
-            replace_token = 0
             self.features = np.where(np.isnan(self.features), replace_token, self.features)
 
         # Fix nans in atom_descriptors
         if self.atom_descriptors is not None:
-            replace_token = 0
             self.atom_descriptors = np.where(np.isnan(self.atom_descriptors), replace_token, self.atom_descriptors)
 
         # Fix nans in atom_features
         if self.atom_features is not None:
-            replace_token = 0
             self.atom_features = np.where(np.isnan(self.atom_features), replace_token, self.atom_features)
 
     @property
@@ -178,7 +176,7 @@ class MoleculeDataset(Dataset):
         Returns the atom descriptors associated with each molecule (if they exit).
 
         :return: A list of 2D numpy arrays containing the atom descriptors
-        for each molecule or None if there are no features.
+                 for each molecule or None if there are no features.
         """
         if len(self._data) == 0 or self._data[0].atom_descriptors is None:
             return None
@@ -220,9 +218,9 @@ class MoleculeDataset(Dataset):
 
     def atom_features_size(self) -> int:
         """
-        Returns the size of custom additional atom descriptors vector associated with the molecules.
+        Returns the size of custom additional atom features vector associated with the molecules.
 
-        :return: The size of the additional atom descriptor vector.
+        :return: The size of the additional atom feature vector.
         """
         return len(self._data[0].atom_features[0]) \
             if len(self._data) > 0 and self._data[0].atom_features is not None else None

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -139,6 +139,10 @@ def get_data(path: str,
     """
     debug = logger.debug if logger is not None else print
 
+    # Load atomic descriptors
+    atom_features = None
+    atom_descriptors = None
+
     if args is not None:
         # Prefer explicit function arguments but default to args if not provided
         smiles_column = smiles_column if smiles_column is not None else args.smiles_column
@@ -149,6 +153,11 @@ def get_data(path: str,
         atom_descriptors_path = atom_descriptors_path if atom_descriptors_path is not None \
             else args.atom_descriptors_path
         max_data_size = max_data_size if max_data_size is not None else args.max_data_size
+
+        if args.atom_descriptors == 'feature':
+            atom_features = load_atom_features(atom_descriptors_path)
+        elif args.atom_descriptors == 'descriptor':
+            atom_descriptors = load_atom_features(atom_descriptors_path)
 
     max_data_size = max_data_size or float('inf')
 
@@ -201,14 +210,6 @@ def get_data(path: str,
 
             if len(all_smiles) >= max_data_size:
                 break
-
-        # Load atomic descriptors
-        atom_features = None
-        atom_descriptors = None
-        if args.atom_descriptors == 'feature':
-            atom_features = load_atom_features(atom_descriptors_path)
-        elif args.atom_descriptors == 'descriptor':
-            atom_descriptors = load_atom_features(atom_descriptors_path)
 
         data = MoleculeDataset([
             MoleculeDatapoint(

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -158,12 +158,6 @@ def get_data(path: str,
     else:
         features_data = None
 
-    # Load atomic descriptors
-    if atom_descriptors_path is not None:
-        atom_descriptors = load_atom_features(atom_descriptors_path)
-    else:
-        atom_descriptors = None
-
     skip_smiles = set()
 
     # Load data
@@ -198,14 +192,22 @@ def get_data(path: str,
             if len(all_smiles) >= max_data_size:
                 break
 
+        # Load atomic descriptors
+        atom_features = [None] * len(all_smiles)
+        atom_descriptors = [None] * len(all_smiles)
+        if args.atom_descriptors == 'feature':
+            atom_features = load_atom_features(atom_descriptors_path)
+        elif args.atom_descriptors == 'descriptor':
+            atom_descriptors = load_atom_features(atom_descriptors_path)
+
         data = MoleculeDataset([
             MoleculeDatapoint(
                 smiles=smiles,
                 targets=targets,
                 row=all_rows[i] if store_row else None,
                 features_generator=features_generator,
-                features=features_data[i] if features_data is not None else None,
-                atom_descriptors=atom_descriptors[i] if atom_descriptors is not None else None,
+                features=atom_features[i] if features_data is not None else None,
+                atom_descriptors=atom_descriptors[i],
             ) for i, (smiles, targets) in tqdm(enumerate(zip(all_smiles, all_targets)),
                                                total=len(all_smiles))
         ])

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -128,7 +128,7 @@ def get_data(path: str,
                           in place of :code:`args.features_path`.
     :param features_generator: A list of features generators to use. If provided, it is used
                                in place of :code:`args.features_generator`.
-    :param atom_descriptors_path: The path to the file containing the custom atom descriptors
+    :param atom_descriptors_path: The path to the file containing the custom atom descriptors.
     :param max_data_size: The maximum number of data points to load.
     :param logger: A logger for recording output.
     :param store_row: Whether to store the raw CSV row in each :class:`~chemprop.data.data.MoleculeDatapoint`.

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 from .data import MoleculeDatapoint, MoleculeDataset
 from .scaffold import log_scaffold_stats, scaffold_split
 from chemprop.args import PredictArgs, TrainArgs
-from chemprop.features import load_features
+from chemprop.features import load_features, load_atom_features
 
 
 def get_task_names(path: str,
@@ -109,6 +109,7 @@ def get_data(path: str,
              args: Union[TrainArgs, PredictArgs] = None,
              features_path: List[str] = None,
              features_generator: List[str] = None,
+             atom_descriptors_path: str = None,
              max_data_size: int = None,
              store_row: bool = False,
              logger: Logger = None) -> MoleculeDataset:
@@ -126,6 +127,7 @@ def get_data(path: str,
                           in place of :code:`args.features_path`.
     :param features_generator: A list of features generators to use. If provided, it is used
                                in place of :code:`args.features_generator`.
+    :param atom_descriptors_path: The path to the file containing the custom atom descriptors
     :param max_data_size: The maximum number of data points to load.
     :param logger: A logger for recording output.
     :param store_row: Whether to store the raw CSV row in each :class:`~chemprop.data.data.MoleculeDatapoint`.
@@ -141,6 +143,8 @@ def get_data(path: str,
         ignore_columns = ignore_columns if ignore_columns is not None else args.ignore_columns
         features_path = features_path if features_path is not None else args.features_path
         features_generator = features_generator if features_generator is not None else args.features_generator
+        atom_descriptors_path = atom_descriptors_path if atom_descriptors_path is not None \
+            else args.atom_descriptors_path
         max_data_size = max_data_size if max_data_size is not None else args.max_data_size
 
     max_data_size = max_data_size or float('inf')
@@ -153,6 +157,12 @@ def get_data(path: str,
         features_data = np.concatenate(features_data, axis=1)
     else:
         features_data = None
+
+    # Load atomic descriptors
+    if atom_descriptors_path is not None:
+        atom_descriptors = load_atom_features(atom_descriptors_path)
+    else:
+        atom_descriptors = None
 
     skip_smiles = set()
 
@@ -194,7 +204,8 @@ def get_data(path: str,
                 targets=targets,
                 row=all_rows[i] if store_row else None,
                 features_generator=features_generator,
-                features=features_data[i] if features_data is not None else None
+                features=features_data[i] if features_data is not None else None,
+                atom_descriptors=atom_descriptors[i] if atom_descriptors is not None else None,
             ) for i, (smiles, targets) in tqdm(enumerate(zip(all_smiles, all_targets)),
                                                total=len(all_smiles))
         ])

--- a/chemprop/features/__init__.py
+++ b/chemprop/features/__init__.py
@@ -3,7 +3,7 @@ from .features_generators import get_available_features_generators, get_features
     rdkit_2d_normalized_features_generator, register_features_generator
 from .featurization import atom_features, bond_features, BatchMolGraph, get_atom_fdim, get_bond_fdim, mol2graph, \
     MolGraph, onek_encoding_unk
-from .utils import load_features, save_features
+from .utils import load_features, save_features, load_atom_features
 
 __all__ = [
     'get_available_features_generators',
@@ -21,5 +21,6 @@ __all__ = [
     'MolGraph',
     'onek_encoding_unk',
     'load_features',
-    'save_features'
+    'save_features',
+    'load_atom_features'
 ]

--- a/chemprop/features/featurization.py
+++ b/chemprop/features/featurization.py
@@ -2,6 +2,7 @@ from typing import List, Tuple, Union
 
 from rdkit import Chem
 import torch
+import numpy as np
 
 # Atom feature sizes
 MAX_ATOMIC_NUM = 100
@@ -124,7 +125,7 @@ class MolGraph:
     * :code:`b2revb`: A mapping from a bond index to the index of the reverse bond.
     """
 
-    def __init__(self, mol: Union[str, Chem.Mol]):
+    def __init__(self, mol: Union[str, Chem.Mol], atom_descriptors: np.ndarray = None):
         """
         :param mol: A SMILES or an RDKit molecule.
         """
@@ -142,6 +143,9 @@ class MolGraph:
 
         # Get atom features
         self.f_atoms = [atom_features(atom) for atom in mol.GetAtoms()]
+        if atom_descriptors:
+            self.f_atoms = [f_atoms + descs.tolist() for f_atoms, descs in zip(self.f_atoms, atom_descriptors)]
+
         self.n_atoms = len(self.f_atoms)
 
         # Initialize atom to bond mapping for each atom
@@ -290,11 +294,15 @@ class BatchMolGraph:
         return self.a2a
 
 
-def mol2graph(mols: Union[List[str], List[Chem.Mol]]) -> BatchMolGraph:
+def mol2graph(mols: Union[List[str], List[Chem.Mol]], atom_descriptors_batch: List[np.array] = None) -> BatchMolGraph:
     """
     Converts a list of SMILES or RDKit molecules to a :class:`BatchMolGraph` containing the batch of molecular graphs.
 
     :param mols: A list of SMILES or a list of RDKit molecules.
+    :param atom_descriptors_batch: A list of 2D numpy array containing additional atom descriptors to featurize the molecule
     :return: A :class:`BatchMolGraph` containing the combined molecular graph for the molecules.
     """
-    return BatchMolGraph([MolGraph(mol) for mol in mols])
+    if atom_descriptors_batch is not None:
+        return BatchMolGraph([MolGraph(mol, atom_descriptors) for mol, atom_descriptors in zip(mols, atom_descriptors_batch)])
+    else:
+        return BatchMolGraph([MolGraph(mol) for mol in mols])

--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -4,6 +4,7 @@ import pickle
 from typing import List
 
 import numpy as np
+import pandas as pd
 
 
 def save_features(path: str, features: List[np.ndarray]) -> None:
@@ -51,5 +52,23 @@ def load_features(path: str) -> np.ndarray:
             features = np.array([np.squeeze(np.array(feat.todense())) for feat in pickle.load(f)])
     else:
         raise ValueError(f'Features path extension {extension} not supported.')
+
+    return features
+
+
+def load_atom_features(path: str) -> List[np.ndarray]:
+    """
+    Loads features saved in a .pkl file
+    :param path: Path to file containing atomwise features
+    :return: A list of 2D array
+    """
+
+    features_df = pd.read_pickle(path)
+    if features_df.iloc[0, 0].ndim == 1:
+        features = features_df.apply(lambda x: np.stack(x.tolist(), axis=1), axis=1).tolist()
+    elif features_df.iloc[0, 0].ndim == 2:
+        features = features_df.apply(lambda x: np.concatenate(x.tolist(), axis=1), axis=1).tolist()
+    else:
+        raise ValueError(f'Atom descriptors input {path} format not supported')
 
     return features

--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -58,9 +58,10 @@ def load_features(path: str) -> np.ndarray:
 
 def load_atom_features(path: str) -> List[np.ndarray]:
     """
-    Loads features saved in a .pkl file
-    :param path: Path to file containing atomwise features
-    :return: A list of 2D array
+    Loads features saved in a .pkl file.
+
+    :param path: Path to file containing atomwise features.
+    :return: A list of 2D array.
     """
 
     features_df = pd.read_pickle(path)

--- a/chemprop/models/model.py
+++ b/chemprop/models/model.py
@@ -68,7 +68,7 @@ class MoleculeModel(nn.Module):
             if args.use_input_features:
                 first_linear_dim += args.features_size
 
-        if args.atom_descriptors == 'descriptors':
+        if args.atom_descriptors == 'descriptor':
             first_linear_dim += args.atom_descriptors_size
 
         dropout = nn.Dropout(args.dropout)

--- a/chemprop/models/model.py
+++ b/chemprop/models/model.py
@@ -108,7 +108,7 @@ class MoleculeModel(nn.Module):
         :param batch: A list of SMILES, a list of RDKit molecules, or a
                       :class:`~chemprop.features.featurization.BatchMolGraph`.
         :param features_batch: A list of numpy arrays containing additional features.
-        :param atom_descriptors_batch: A list of numpy arrays containing additional atom descriptors
+        :param atom_descriptors_batch: A list of numpy arrays containing additional atom descriptors.
         :return: The feature vectors computed by the :class:`MoleculeModel`.
         """
         return self.ffn[:-1](self.encoder(batch, features_batch, atom_descriptors_batch))

--- a/chemprop/models/model.py
+++ b/chemprop/models/model.py
@@ -37,8 +37,6 @@ class MoleculeModel(nn.Module):
         if self.multiclass:
             self.multiclass_softmax = nn.Softmax(dim=2)
 
-        self.atom_descriptors = args.atom_descriptors
-
         self.create_encoder(args)
         self.create_ffn(args)
 

--- a/chemprop/models/mpn.py
+++ b/chemprop/models/mpn.py
@@ -59,15 +59,23 @@ class MPNEncoder(nn.Module):
 
         self.W_o = nn.Linear(self.atom_fdim + self.hidden_size, self.hidden_size)
 
+        # layer after concatenating the descriptors if args.atom_descriptors == descriptors
+        if args.atom_descriptors == 'descriptors':
+            self.atom_descriptors_size = args.atom_descriptors_size
+            self.atom_descriptors_layer = nn.Linear(self.atom_fdim + self.atom_descriptors_size,
+                                                    self.atom_fdim + self.atom_descriptors_size,)
+
     def forward(self,
                 mol_graph: BatchMolGraph,
-                features_batch: List[np.ndarray] = None) -> torch.FloatTensor:
+                features_batch: List[np.ndarray] = None,
+                atom_descriptors_batch: List[np.ndarray] = None) -> torch.FloatTensor:
         """
         Encodes a batch of molecular graphs.
 
         :param mol_graph: A :class:`~chemprop.features.featurization.BatchMolGraph` representing
                           a batch of molecular graphs.
         :param features_batch: A list of numpy arrays containing additional features.
+        :param atom_descriptors_batch: A list of numpy arrays containing additional atomic descriptors
         :return: A PyTorch tensor of shape :code:`(num_molecules, hidden_size)` containing the encoding of each molecule.
         """
         if self.use_input_features:
@@ -75,6 +83,9 @@ class MPNEncoder(nn.Module):
 
             if self.features_only:
                 return features_batch
+
+        if atom_descriptors_batch is not None:
+            atom_descriptors_batch = torch.from_numpy(np.concatenate(atom_descriptors_batch, axis=0)).float().to(self.device)
 
         f_atoms, f_bonds, a2b, b2a, b2revb, a_scope, b_scope = mol_graph.get_components(atom_messages=self.atom_messages)
         f_atoms, f_bonds, a2b, b2a, b2revb = f_atoms.to(self.device), f_bonds.to(self.device), a2b.to(self.device), b2a.to(self.device), b2revb.to(self.device)
@@ -118,6 +129,12 @@ class MPNEncoder(nn.Module):
         atom_hiddens = self.act_func(self.W_o(a_input))  # num_atoms x hidden
         atom_hiddens = self.dropout_layer(atom_hiddens)  # num_atoms x hidden
 
+        # concatenate the atom descriptors
+        if atom_descriptors_batch is not None:
+            atom_hiddens = torch.cat([atom_hiddens, atom_descriptors_batch], dim=1)     # num_atoms x (hidden + descriptor size)
+            atom_hiddens = self.atom_descriptors_layer(atom_hiddens)                    # num_atoms x (hidden + descriptor size)
+            atom_hiddens = self.dropout_layer(atom_hiddens)                             # num_atoms x (hidden + descriptor size)
+
         # Readout
         mol_vecs = []
         for i, (a_start, a_size) in enumerate(a_scope):
@@ -125,6 +142,7 @@ class MPNEncoder(nn.Module):
                 mol_vecs.append(self.cached_zero_vector)
             else:
                 cur_hiddens = atom_hiddens.narrow(0, a_start, a_size)
+
                 mol_vec = cur_hiddens  # (num_atoms, hidden_size)
 
                 mol_vec = mol_vec.sum(dim=0) / a_size
@@ -156,22 +174,35 @@ class MPN(nn.Module):
         super(MPN, self).__init__()
         self.atom_fdim = atom_fdim or get_atom_fdim()
         self.bond_fdim = bond_fdim or get_bond_fdim(atom_messages=args.atom_messages)
+
+        self.atom_descriptors = args.atom_descriptors
+        self.atom_fdim += args.atom_descriptors_size \
+            if args.atom_descriptors_size is not None and self.atom_descriptors == 'feature' else 0
+
         self.encoder = MPNEncoder(args, self.atom_fdim, self.bond_fdim)
 
     def forward(self,
                 batch: Union[List[str], List[Chem.Mol], BatchMolGraph],
-                features_batch: List[np.ndarray] = None) -> torch.FloatTensor:
+                features_batch: List[np.ndarray] = None,
+                atom_descriptors_batch: List[np.ndarray] = None) -> torch.FloatTensor:
         """
         Encodes a batch of molecules.
 
         :param batch: A list of SMILES, a list of RDKit molecules, or a
                       :class:`~chemprop.features.featurization.BatchMolGraph`.
         :param features_batch: A list of numpy arrays containing additional features.
+        :param atom_descriptors_batch: A list of numpy arrays containing additional atom descriptors.
         :return: A PyTorch tensor of shape :code:`(num_molecules, hidden_size)` containing the encoding of each molecule.
         """
         if type(batch) != BatchMolGraph:
-            batch = mol2graph(batch)
+            if self.atom_descriptors == 'feature':
+                batch = mol2graph(batch, atom_descriptors_batch)
+            else:
+                batch = mol2graph(batch)
 
-        output = self.encoder.forward(batch, features_batch)
+        if self.atom_descriptors == 'descriptor':
+            output = self.encoder.forward(batch, features_batch, atom_descriptors_batch)
+        else:
+            output = self.encoder.forward(batch, features_batch)
 
         return output

--- a/chemprop/models/mpn.py
+++ b/chemprop/models/mpn.py
@@ -143,7 +143,6 @@ class MPNEncoder(nn.Module):
                 mol_vecs.append(self.cached_zero_vector)
             else:
                 cur_hiddens = atom_hiddens.narrow(0, a_start, a_size)
-
                 mol_vec = cur_hiddens  # (num_atoms, hidden_size)
 
                 mol_vec = mol_vec.sum(dim=0) / a_size
@@ -156,6 +155,7 @@ class MPNEncoder(nn.Module):
             if len(features_batch.shape) == 1:
                 features_batch = features_batch.view([1, features_batch.shape[0]])
             mol_vecs = torch.cat([mol_vecs, features_batch], dim=1)  # (num_molecules, hidden_size)
+
         return mol_vecs  # num_molecules x hidden
 
 
@@ -176,7 +176,6 @@ class MPN(nn.Module):
         self.bond_fdim = bond_fdim or get_bond_fdim(atom_messages=args.atom_messages)
 
         self.atom_descriptors = args.atom_descriptors
-        self.atom_fdim
 
         self.encoder = MPNEncoder(args, self.atom_fdim, self.bond_fdim)
 

--- a/chemprop/models/mpn.py
+++ b/chemprop/models/mpn.py
@@ -60,10 +60,10 @@ class MPNEncoder(nn.Module):
         self.W_o = nn.Linear(self.atom_fdim + self.hidden_size, self.hidden_size)
 
         # layer after concatenating the descriptors if args.atom_descriptors == descriptors
-        if args.atom_descriptors == 'descriptors':
+        if args.atom_descriptors == 'descriptor':
             self.atom_descriptors_size = args.atom_descriptors_size
-            self.atom_descriptors_layer = nn.Linear(self.atom_fdim + self.atom_descriptors_size,
-                                                    self.atom_fdim + self.atom_descriptors_size,)
+            self.atom_descriptors_layer = nn.Linear(self.hidden_size + self.atom_descriptors_size,
+                                                    self.hidden_size + self.atom_descriptors_size,)
 
     def forward(self,
                 mol_graph: BatchMolGraph,
@@ -85,6 +85,7 @@ class MPNEncoder(nn.Module):
                 return features_batch
 
         if atom_descriptors_batch is not None:
+            atom_descriptors_batch = [np.zeros([1, atom_descriptors_batch[0].shape[1]])] + atom_descriptors_batch   # padding the first with 0 to match the atom_hiddens
             atom_descriptors_batch = torch.from_numpy(np.concatenate(atom_descriptors_batch, axis=0)).float().to(self.device)
 
         f_atoms, f_bonds, a2b, b2a, b2revb, a_scope, b_scope = mol_graph.get_components(atom_messages=self.atom_messages)

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from copy import deepcopy
 import csv
 from logging import Logger
 import os
@@ -84,7 +85,7 @@ def cross_validate(args: TrainArgs,
         args.seed = init_seed + fold_num
         args.save_dir = os.path.join(save_dir, f'fold_{fold_num}')
         makedirs(args.save_dir)
-        model_scores = train_func(args, data, logger)
+        model_scores = train_func(args, deepcopy(data), logger)  # deepcopy since data may be modified
         for metric, scores in model_scores.items():
             all_scores[metric].append(scores)
     all_scores = dict(all_scores)

--- a/chemprop/train/predict.py
+++ b/chemprop/train/predict.py
@@ -27,11 +27,11 @@ def predict(model: MoleculeModel,
     for batch in tqdm(data_loader, disable=disable_progress_bar):
         # Prepare batch
         batch: MoleculeDataset
-        mol_batch, features_batch = batch.batch_graph(), batch.features()
+        mol_batch, features_batch, atom_descriptors_batch = batch.batch_graph(), batch.features(), batch.atom_descriptors()
 
         # Make predictions
         with torch.no_grad():
-            batch_preds = model(mol_batch, features_batch)
+            batch_preds = model(mol_batch, features_batch, atom_descriptors_batch)
 
         batch_preds = batch_preds.data.cpu().numpy()
 

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -18,7 +18,6 @@ from chemprop.constants import MODEL_FILE_NAME
 from chemprop.data import get_class_sizes, get_data, MoleculeDataLoader, MoleculeDataset, split_data, StandardScaler
 from chemprop.models import MoleculeModel
 from chemprop.nn_utils import param_count
-from chemprop.features import set_extra_atom_fdim
 from chemprop.utils import build_optimizer, build_lr_scheduler, get_loss_func, load_checkpoint,makedirs, \
     save_checkpoint, save_smiles_splits
 

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -54,6 +54,7 @@ def run_training(args: TrainArgs, logger: Logger = None) -> List[float]:
     data = get_data(path=args.data_path, args=args, logger=logger)
     validate_dataset_type(data, dataset_type=args.dataset_type)
     args.features_size = data.features_size()
+    args.atom_descriptors_size = data.atom_descriptors_size()
     debug(f'Number of tasks = {args.num_tasks}')
 
     # Split data

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -55,6 +55,9 @@ def run_training(args: TrainArgs, logger: Logger = None) -> List[float]:
     validate_dataset_type(data, dataset_type=args.dataset_type)
     args.features_size = data.features_size()
     args.atom_descriptors_size = data.atom_descriptors_size()
+    if args.atom_descriptors == 'descriptor':
+        args.ffn_hidden_size += args.atom_descriptors_size
+
     debug(f'Number of tasks = {args.num_tasks}')
 
     # Split data

--- a/chemprop/train/train.py
+++ b/chemprop/train/train.py
@@ -45,13 +45,14 @@ def train(model: MoleculeModel,
     for batch in tqdm(data_loader, total=len(data_loader)):
         # Prepare batch
         batch: MoleculeDataset
-        mol_batch, features_batch, target_batch = batch.batch_graph(), batch.features(), batch.targets()
+        mol_batch, features_batch, target_batch, atom_descriptors_batch = \
+            batch.batch_graph(), batch.features(), batch.targets(), batch.atom_descriptors()
         mask = torch.Tensor([[x is not None for x in tb] for tb in target_batch])
         targets = torch.Tensor([[0 if x is None else x for x in tb] for tb in target_batch])
 
         # Run model
         model.zero_grad()
-        preds = model(mol_batch, features_batch)
+        preds = model(mol_batch, features_batch, atom_descriptors_batch)
 
         # Move tensors to correct device
         mask = mask.to(preds.device)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,7 +68,7 @@ class ChempropTests(TestCase):
         # Predict
         with patch('sys.argv', raw_predict_args):
             chemprop_predict()
-
+    '''
     def test_chemprop_train_single_task_regression(self):
         with TemporaryDirectory() as save_dir:
             # Train
@@ -82,7 +82,7 @@ class ChempropTests(TestCase):
 
             mean_score = test_scores.mean()
             self.assertAlmostEqual(mean_score, 1.237620, delta=0.02)
-
+    
     def test_chemprop_train_multi_task_classification(self):
         with TemporaryDirectory() as save_dir:
             # Train
@@ -96,7 +96,7 @@ class ChempropTests(TestCase):
 
             mean_score = test_scores.mean()
             self.assertAlmostEqual(mean_score, 0.679375, delta=0.02)
-
+    '''
     def test_chemprop_predict_single_task_regression(self):
         with TemporaryDirectory() as save_dir:
             # Train
@@ -117,7 +117,7 @@ class ChempropTests(TestCase):
             pred, true = pred.to_numpy(), true.to_numpy()
             mse = float(np.nanmean((pred - true) ** 2))
             self.assertAlmostEqual(mse, 0.559111, delta=0.02)
-
+    '''
     def test_chemprop_predict_multi_task_classification(self):
         with TemporaryDirectory() as save_dir:
             # Train
@@ -138,7 +138,7 @@ class ChempropTests(TestCase):
             pred, true = pred.to_numpy(), true.to_numpy()
             mse = float(np.nanmean((pred - true) ** 2))
             self.assertAlmostEqual(mse, 0.064600, delta=0.02)
-
+    '''
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,7 +68,7 @@ class ChempropTests(TestCase):
         # Predict
         with patch('sys.argv', raw_predict_args):
             chemprop_predict()
-    '''
+
     def test_chemprop_train_single_task_regression(self):
         with TemporaryDirectory() as save_dir:
             # Train
@@ -96,7 +96,7 @@ class ChempropTests(TestCase):
 
             mean_score = test_scores.mean()
             self.assertAlmostEqual(mean_score, 0.679375, delta=0.02)
-    '''
+
     def test_chemprop_predict_single_task_regression(self):
         with TemporaryDirectory() as save_dir:
             # Train
@@ -117,7 +117,7 @@ class ChempropTests(TestCase):
             pred, true = pred.to_numpy(), true.to_numpy()
             mse = float(np.nanmean((pred - true) ** 2))
             self.assertAlmostEqual(mse, 0.559111, delta=0.02)
-    '''
+
     def test_chemprop_predict_multi_task_classification(self):
         with TemporaryDirectory() as save_dir:
             # Train
@@ -138,7 +138,7 @@ class ChempropTests(TestCase):
             pred, true = pred.to_numpy(), true.to_numpy()
             mse = float(np.nanmean((pred - true) ** 2))
             self.assertAlmostEqual(mse, 0.064600, delta=0.02)
-    '''
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This merge allows custom atomic features (a counterpart of the custom molecule features). The atomic features can be embedded in two ways: 1) as extra atom features during the molecule featurization. 2) as atomic descriptors that concatenated to the atomic feature vector after MPNN. The custom atomic feature is used through flag --atom_descriptors.  