### PR TITLE
Using DataLoader in a subprocess. Fixed freezing.

### DIFF
--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -1,3 +1,4 @@
+import threading
 from collections import OrderedDict
 from functools import partial
 from random import Random
@@ -372,6 +373,12 @@ class MoleculeDataLoader(DataLoader):
         self._class_balance = class_balance
         self._shuffle = shuffle
         self._seed = seed
+        self._context = None
+        self._timeout = 0
+        is_main_thread = threading.current_thread() is threading.main_thread()
+        if not is_main_thread and self._num_workers > 0:
+            self._context = 'forkserver'  # In order to prevent a hanging
+            self._timeout = 3600  # Just for sure that the DataLoader won't hang
 
         self._sampler = MoleculeSampler(
             dataset=self._dataset,
@@ -385,7 +392,9 @@ class MoleculeDataLoader(DataLoader):
             batch_size=self._batch_size,
             sampler=self._sampler,
             num_workers=self._num_workers,
-            collate_fn=partial(construct_molecule_batch, cache=self._cache)
+            collate_fn=partial(construct_molecule_batch, cache=self._cache),
+            multiprocessing_context=self._context,
+            timeout=self._timeout
         )
 
     @property


### PR DESCRIPTION
Program may hang when torch DataLoader with multiple workers is used in a subprocess. Please see a huge comment to the torch.utils.data.dataloader._MultiProcessingDataLoaderIter class for references (near line 465 depending on your version). This problem can be solved by using another multiprocessing context. In order to enable GPU I would recommend to use the 'forkserver' context (https://pytorch.org/docs/stable/notes/multiprocessing.html). 
There is no need to use this context in case the MoleculeDataLoader is used by the main process or number of workers is zero. So, I added this check also.

/Cheers,
Artem