### PR TITLE
update support for custom atomic descriptors in format of `.sdf` and `.npz`

### DIFF
--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -239,7 +239,7 @@ def get_data(path: str,
             try:
                 descriptors = load_valid_atom_features(atom_descriptors_path, [x[0] for x in all_smiles])
             except Exception as e:
-                raise ValueError('Failed to load or valid custom atomic descriptors: {}'.format(e))
+                raise ValueError(f'Failed to load or valid custom atomic descriptors: {e}')
 
             if args.atom_descriptors == 'feature':
                 atom_features = descriptors

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -239,7 +239,7 @@ def get_data(path: str,
             try:
                 descriptors = load_valid_atom_features(atom_descriptors_path, [x[0] for x in all_smiles])
             except Exception as e:
-                print('Error: failed to load or valid custom atomic descriptors: {}'.format(e))
+                raise ValueError('Failed to load or valid custom atomic descriptors: {}'.format(e))
 
             if args.atom_descriptors == 'feature':
                 atom_features = descriptors

--- a/chemprop/features/__init__.py
+++ b/chemprop/features/__init__.py
@@ -3,7 +3,7 @@ from .features_generators import get_available_features_generators, get_features
     rdkit_2d_normalized_features_generator, register_features_generator
 from .featurization import atom_features, bond_features, BatchMolGraph, get_atom_fdim, get_bond_fdim, mol2graph, \
     MolGraph, onek_encoding_unk, set_extra_atom_fdim
-from .utils import load_features, save_features, load_atom_features
+from .utils import load_features, save_features, load_valid_atom_features
 
 __all__ = [
     'get_available_features_generators',

--- a/chemprop/features/__init__.py
+++ b/chemprop/features/__init__.py
@@ -23,5 +23,5 @@ __all__ = [
     'onek_encoding_unk',
     'load_features',
     'save_features',
-    'load_atom_features'
+    'load_valid_atom_features'
 ]

--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -94,9 +94,7 @@ def load_valid_atom_features(path: str, smiles: List[str]) -> List[np.ndarray]:
 
         # locate atomic descriptors columns
         features_df = features_df.iloc[:, features_df.iloc[0, :].apply(lambda x: isinstance(x, str) and ',' in x).to_list()]
-
         features_df = features_df.reindex(smiles)
-        print(features_df)
         if features_df.isnull().any().any():
             raise ValueError(f'Invalid custom atomic descriptors file, Nan found in data')
 

--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -59,7 +59,12 @@ def load_features(path: str) -> np.ndarray:
 
 def load_valid_atom_features(path: str, smiles: List[str]) -> List[np.ndarray]:
     """
-    Loads features saved in a .pkl file.
+    Loads features saved in a variety of formats.
+
+    Supported formats:
+
+    * :code:`.pkl` / :code:`.pckl` / :code:`.pickle` containing a pandas dataframe with smiles as index and numpy array of descriptors as columns
+    * :code:'.sdf' containing all mol blocks with descriptors as entries
 
     :param path: Path to file containing atomwise features.
     :return: A list of 2D array.

--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -6,6 +6,7 @@ from typing import List
 import numpy as np
 import pandas as pd
 from rdkit import Chem
+from rdkit.Chem import PandasTools
 
 
 def save_features(path: str, features: List[np.ndarray]) -> None:
@@ -87,7 +88,6 @@ def load_valid_atom_features(path: str, smiles: List[str]) -> List[np.ndarray]:
             raise ValueError(f'Atom descriptors input {path} format not supported')
 
     elif extension == '.sdf':
-        from rdkit.Chem import PandasTools
         features_df = PandasTools.LoadSDF(path).drop(['ID', 'ROMol'], axis=1).set_index('SMILES')
 
         features_df = features_df[~features_df.index.duplicated()]
@@ -96,7 +96,7 @@ def load_valid_atom_features(path: str, smiles: List[str]) -> List[np.ndarray]:
         features_df = features_df.iloc[:, features_df.iloc[0, :].apply(lambda x: isinstance(x, str) and ',' in x).to_list()]
         features_df = features_df.reindex(smiles)
         if features_df.isnull().any().any():
-            raise ValueError(f'Invalid custom atomic descriptors file, Nan found in data')
+            raise ValueError('Invalid custom atomic descriptors file, Nan found in data')
 
         features_df = features_df.applymap(lambda x: np.array(x.replace('\r', '').replace('\n', '').split(',')).astype(float))
 
@@ -110,9 +110,7 @@ def load_valid_atom_features(path: str, smiles: List[str]) -> List[np.ndarray]:
 
         features = features_df.apply(lambda x: np.stack(x.tolist(), axis=1), axis=1).tolist()
 
+    else:
+        raise ValueError(f'Extension "{extension}" is not supported.')
+
     return features
-
-
-
-
-

--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -63,6 +63,7 @@ def load_valid_atom_features(path: str, smiles: List[str]) -> List[np.ndarray]:
 
     Supported formats:
 
+    * :code:`.npz` descriptors are saved as 2D array for each molecule in the order of that in the data.csv
     * :code:`.pkl` / :code:`.pckl` / :code:`.pickle` containing a pandas dataframe with smiles as index and numpy array of descriptors as columns
     * :code:'.sdf' containing all mol blocks with descriptors as entries
 
@@ -72,7 +73,11 @@ def load_valid_atom_features(path: str, smiles: List[str]) -> List[np.ndarray]:
 
     extension = os.path.splitext(path)[1]
 
-    if extension in ['.pkl', '.pckl', '.pickle']:
+    if extension == '.npz':
+        container = np.load(path)
+        features = [container[key] for key in container]
+
+    elif extension in ['.pkl', '.pckl', '.pickle']:
         features_df = pd.read_pickle(path)
         if features_df.iloc[0, 0].ndim == 1:
             features = features_df.apply(lambda x: np.stack(x.tolist(), axis=1), axis=1).tolist()
@@ -81,7 +86,7 @@ def load_valid_atom_features(path: str, smiles: List[str]) -> List[np.ndarray]:
         else:
             raise ValueError(f'Atom descriptors input {path} format not supported')
 
-    if extension == '.sdf':
+    elif extension == '.sdf':
         from rdkit.Chem import PandasTools
         features_df = PandasTools.LoadSDF(path).drop(['ID', 'ROMol'], axis=1).set_index('SMILES')
 


### PR DESCRIPTION
custom atomic descriptors can be put in through `.sdf` and `.npz`. The original `.pkl` input that stores a dataframe may cause error when a different version of Pandas was used to prepare the `.pkl`.