### PR TITLE
Binary cross entropy as a metric function and split_sizes bug fix

### DIFF
--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -12,7 +12,7 @@ from chemprop.data import set_cache_mol
 from chemprop.features import get_available_features_generators
 
 
-Metric = Literal['auc', 'prc-auc', 'rmse', 'mae', 'mse', 'r2', 'accuracy', 'cross_entropy']
+Metric = Literal['auc', 'prc-auc', 'rmse', 'mae', 'mse', 'r2', 'accuracy', 'cross_entropy', 'binary_cross_entropy']
 
 
 def get_checkpoint_paths(checkpoint_path: Optional[str] = None,
@@ -334,7 +334,7 @@ class TrainArgs(CommonArgs):
     @property
     def minimize_score(self) -> bool:
         """Whether the model should try to minimize the score metric or maximize it."""
-        return self.metric in {'rmse', 'mae', 'mse', 'cross_entropy'}
+        return self.metric in {'rmse', 'mae', 'mse', 'cross_entropy', 'binary_cross_entropy'}
 
     @property
     def use_input_features(self) -> bool:
@@ -418,7 +418,7 @@ class TrainArgs(CommonArgs):
                              f'Please only include it once.')
 
         for metric in self.metrics:
-            if not ((self.dataset_type == 'classification' and metric in ['auc', 'prc-auc', 'accuracy']) or
+            if not ((self.dataset_type == 'classification' and metric in ['auc', 'prc-auc', 'accuracy', 'binary_cross_entropy']) or
                     (self.dataset_type == 'regression' and metric in ['rmse', 'mae', 'mse', 'r2']) or
                     (self.dataset_type == 'multiclass' and metric in ['cross_entropy', 'accuracy'])):
                 raise ValueError(f'Metric "{metric}" invalid for dataset type "{self.dataset_type}".')

--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -270,6 +270,7 @@ def get_metric_func(metric: str) -> Callable[[Union[List[int], List[float]], Lis
     * :code:`r2`: Coefficient of determination R\ :superscript:`2`
     * :code:`accuracy`: Accuracy (using a threshold to binarize predictions)
     * :code:`cross_entropy`: Cross entropy
+    * :code:`binary_cross_entropy`: Binary cross entropy
 
     :param metric: Metric name.
     :return: A metric function which takes as arguments a list of targets and a list of predictions and returns.

--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -179,7 +179,7 @@ def get_loss_func(args: TrainArgs) -> nn.Module:
 
     if args.dataset_type == 'regression':
         return nn.MSELoss(reduction='none')
-    
+
     if args.dataset_type == 'multiclass':
         return nn.CrossEntropyLoss(reduction='none')
 
@@ -196,6 +196,23 @@ def prc_auc(targets: List[int], preds: List[float]) -> float:
     """
     precision, recall, _ = precision_recall_curve(targets, preds)
     return auc(recall, precision)
+
+def bce(targets: List[int], preds: List[float]) -> float:
+    """
+    Computes the binary cross entropy loss.
+
+    :param targets: A list of binary targets.
+    :param preds: A list of prediction probabilities.
+    :return: The computed prc-auc.
+    """
+
+    # don't use logits because the sigmoid is added in all places
+    # except training itself
+
+    bce_func = nn.BCELoss(reduction='mean')
+    loss = bce_func(target=torch.Tensor(targets),
+                    input=torch.Tensor(preds)).item()
+    return loss
 
 
 def rmse(targets: List[float], preds: List[float]) -> float:
@@ -265,7 +282,7 @@ def get_metric_func(metric: str) -> Callable[[Union[List[int], List[float]], Lis
 
     if metric == 'rmse':
         return rmse
-    
+
     if metric == 'mse':
         return mse
 
@@ -274,12 +291,15 @@ def get_metric_func(metric: str) -> Callable[[Union[List[int], List[float]], Lis
 
     if metric == 'r2':
         return r2_score
-    
+
     if metric == 'accuracy':
         return accuracy
-    
+
     if metric == 'cross_entropy':
         return log_loss
+
+    if metric == 'binary_cross_entropy':
+        return bce
 
     raise ValueError(f'Metric "{metric}" not supported.')
 

--- a/scripts/split_data.py
+++ b/scripts/split_data.py
@@ -20,7 +20,7 @@ class Args(Tap):
     save_dir: str  # Directory where train, validation, and test sets will be saved
     smiles_column: str = None  # Name of the column containing SMILES strings. By default, uses the first column.
     split_type: Literal['random', 'scaffold_balanced'] = 'random'  # Split type
-    split_sizes: Tuple[int, int, int] = (0.8, 0.1, 0.1)  # Split sizes
+    split_sizes: Tuple[float, float, float] = (0.8, 0.1, 0.1)  # Split sizes
     seed: int = 0  # Random seed
 
 


### PR DESCRIPTION
Hi everyone,
I have a small pull request that adds binary cross entropy as a metric. It also fixes the bug that split_sizes were expected to be integers instead of floats in split_data.py (I know this bug was already fixed in args.py, but I don't think it was fixed in the script).
Let me know what you think!
Simon