### PR TITLE
Avoids building mol when it is cached

### DIFF
--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -108,7 +108,12 @@ class MoleculeDatapoint:
     @property
     def mol(self) -> List[Chem.Mol]:
         """Gets the corresponding list of RDKit molecules for the corresponding SMILES list."""
-        mol = [SMILES_TO_MOL.get(s, Chem.MolFromSmiles(s)) for s in self.smiles]
+        mol = []
+        for s in self.smiles:
+            if s in SMILES_TO_MOL:
+                mol.append(SMILES_TO_MOL[s])
+            else:
+                mol.append(Chem.MolFromSmiles(s))
         
         if cache_mol():
             for s, m in zip(self.smiles, mol):

--- a/chemprop/sklearn_train.py
+++ b/chemprop/sklearn_train.py
@@ -45,7 +45,11 @@ def predict(model: Union[RandomForestRegressor, RandomForestClassifier, SVR, SVC
                 preds = [[preds[i][j, 1] for i in range(num_tasks)] for j in range(num_preds)]
             else:
                 # One task
-                preds = [[preds[i, 1]] for i in range(len(preds))]
+                try:
+                    preds = [[preds[i, 1]] for i in range(len(preds))]
+                except IndexError:
+                    # Only one type of training data
+                    preds = [[preds[i, 0]] for i in range(len(preds))]
         elif model_type == 'svm':
             preds = model.decision_function(features)
             preds = [[pred] for pred in preds]

--- a/chemprop/sklearn_train.py
+++ b/chemprop/sklearn_train.py
@@ -8,6 +8,7 @@ import numpy as np
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.svm import SVC, SVR
 from tqdm import trange, tqdm
+from collections import defaultdict
 
 from chemprop.args import SklearnTrainArgs
 from chemprop.data import MoleculeDataset, split_data, get_task_names, get_data
@@ -76,7 +77,7 @@ def single_task_sklearn(model: Union[RandomForestRegressor, RandomForestClassifi
     :param logger: A logger to record output.
     :return: A dictionary mapping each metric in :code:`metrics` to a list of values for each task.
     """
-    scores = []
+    scores = defaultdict(list)
     num_tasks = train_data.num_tasks()
     for task_num in trange(num_tasks):
         # Only get features and targets for molecules where target is not None
@@ -105,7 +106,8 @@ def single_task_sklearn(model: Union[RandomForestRegressor, RandomForestClassifi
             dataset_type=args.dataset_type,
             logger=logger
         )
-        scores.append(score[0])
+        for metric in metrics:
+            scores[metric].append(score[metric][0])
 
     return scores
 
@@ -186,7 +188,8 @@ def run_sklearn(args: SklearnTrainArgs,
     debug('Loading data')
     data = get_data(path=args.data_path,
                     smiles_columns=args.smiles_columns,
-                    target_columns=args.target_columns)
+                    target_columns=args.target_columns,
+                    ignore_columns=args.ignore_columns)
     args.task_names = get_task_names(path=args.data_path,
                                      smiles_columns=args.smiles_columns,
                                      target_columns=args.target_columns,

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -61,7 +61,7 @@ def cross_validate(args: TrainArgs,
         path=args.data_path,
         args=args,
         logger=logger,
-        skip_none_targets=True
+        skip_none_targets=True,
     )
     validate_dataset_type(data, dataset_type=args.dataset_type)
     args.features_size = data.features_size()

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -68,13 +68,14 @@ def run_training(args: TrainArgs,
                   f'{", ".join(f"{cls}: {size * 100:.2f}%" for cls, size in enumerate(task_class_sizes))}')
 
     if args.save_smiles_splits:
+        assert len(args.smiles_columns) == 1
         save_smiles_splits(
             data_path=args.data_path,
             save_dir=args.save_dir,
             train_data=train_data,
             val_data=val_data,
             test_data=test_data,
-            smiles_column=args.smiles_column
+            smiles_column=args.smiles_columns[0]
         )
 
     if args.features_scaling:
@@ -150,7 +151,7 @@ def run_training(args: TrainArgs,
         # Load/build model
         if args.checkpoint_paths is not None:
             debug(f'Loading model {model_idx} from {args.checkpoint_paths[model_idx]}')
-            model = load_checkpoint(args.checkpoint_paths[model_idx], logger=logger)
+            model = load_checkpoint(args.checkpoint_paths[model_idx], logger=logger, cur_args=args)
         else:
             debug(f'Building model {model_idx}')
             model = MoleculeModel(args)

--- a/chemprop/train/train.py
+++ b/chemprop/train/train.py
@@ -59,6 +59,7 @@ def train(model: MoleculeModel,
         targets = targets.to(preds.device)
         class_weights = torch.ones(targets.shape, device=preds.device)
 
+
         if args.dataset_type == 'multiclass':
             targets = targets.long()
             loss = torch.cat([loss_func(preds[:, target_index, :], targets[:, target_index]).unsqueeze(1) for target_index in range(preds.size(1))], dim=1) * class_weights * mask

--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -73,7 +73,8 @@ def save_checkpoint(path: str,
 
 def load_checkpoint(path: str,
                     device: torch.device = None,
-                    logger: logging.Logger = None) -> MoleculeModel:
+                    logger: logging.Logger = None,
+                    cur_args: TrainArgs = None) -> MoleculeModel:
     """
     Loads a model checkpoint.
 
@@ -90,7 +91,10 @@ def load_checkpoint(path: str,
     # Load model and args
     state = torch.load(path, map_location=lambda storage, loc: storage)
     args = TrainArgs()
-    args.from_dict(vars(state['args']), skip_unsettable=True)
+    if cur_args is None:
+        args.from_dict(vars(state['args']), skip_unsettable=True)
+    else:
+        args = cur_args
     loaded_state_dict = state['state_dict']
 
     if device is not None:


### PR DESCRIPTION
https://github.com/chemprop/chemprop/blob/8b9d9857447b3a7dbea45829e3e7dd3afb1db610/chemprop/data/data.py#L109-L117

I find that `SMILES_TO_MOL.get(s, Chem.MolFromSmiles(s))` evaluates `Chem.MolFromSmiles(s)` even when `s in SMILES_TO_MOL`. This slows down the graph batching after all the mols are cached, because `d.mol` runs `Chem.MolFromSmiles(s)` anyway. 

https://github.com/chemprop/chemprop/blob/8b9d9857447b3a7dbea45829e3e7dd3afb1db610/chemprop/data/data.py#L229-L231

This pull request avoids building mol when it is cached, which can accelerate the data loading (bottleneck) for large molecules significantly.

