### PR TITLE
Atom features

### DIFF
--- a/chemprop/features/featurization.py
+++ b/chemprop/features/featurization.py
@@ -38,7 +38,7 @@ def get_atom_fdim() -> int:
     return ATOM_FDIM + EXTRA_ATOM_FDIM
 
 
-def set_extra_atom_fdim(extra) -> int:
+def set_extra_atom_fdim(extra):
     """Change the dimensionality of the atom feature vector."""
     global EXTRA_ATOM_FDIM
     EXTRA_ATOM_FDIM = extra


### PR DESCRIPTION
We found when using custom atomic features in the "feature" mode, the predict.py fails due to an error in setting EXTRA_ATOM_FEATURE in the featurization. The bug was fixed in this pull request.