### PR TITLE
Fix check if logger already exists

### DIFF
--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -359,10 +359,11 @@ def create_logger(name: str, save_dir: str = None, quiet: bool = False) -> loggi
     :param quiet: Whether the stream handler should be quiet (i.e., print only important info).
     :return: The logger.
     """
-    logger = logging.getLogger(name)
 
-    if logging.getLogger().hasHandlers():
-        return logger
+    if name in logging.root.manager.loggerDict:
+        return logging.getLogger(name)
+    
+    logger = logging.getLogger(name)
 
     logger.setLevel(logging.DEBUG)
     logger.propagate = False


### PR DESCRIPTION
Closes #106 observed that logs (verbose or quiet) are no longer being written by chemprop. The failure is coming in `create_logger()` when checking to see if the specified logger already exists. Previously, `logging.getLogger()hasHandlers()` worked as a way to see if a log had been previously initiated, but its default return is True now instead of False. Not clear what changed that behavior, but it looks like the logging root has a handler `stderr` by the time this function is run that it detects. As an alternative now, running the check to see if the specified logger exists by seeing if it is in `logging.root.manager.loggerDict`. This appears to have reenabled logging.