### PR TITLE
New Function - Save the latent representation for a molecules

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,28 @@ chemprop_predict --test_path data/tox21.csv --checkpoint_path tox21_checkpoints/
 
 If installed from source, `chemprop_predict` can be replaced with `python predict.py`.
 
+## Encode Fingerprint Latent Representation
+
+To load a trained model and encode the fingerprint latent representation of molecules, run `fingerprint.py` and specify:
+* `--test_path <path>` Path to the data to predict on.
+* A checkpoint by using either:
+  * `--checkpoint_dir <dir>` Directory where the model checkpoint is saved (i.e. `--save_dir` during training).
+  * `--checkpoint_path <path>` Path to a model checkpoint file (`.pt` file).
+* `--preds_path` Path where a CSV file containing the encoded fingerprint vectors will be saved.
+
+SMILES from the provided file are encoded using the MPNN weights loaded from a trained checkpoint file. Fingerprint encoding uses the same set of arguments as making predictions. Unlike making predictions, fingerprint encoding only supports a single saved checkpoint file.
+
+For example:
+```
+chemprop_fingerprint --test_path data/tox21.csv --checkpoint_dir tox21_checkpoints --preds_path tox21_fingerprint.csv
+```
+or
+```
+chemprop_fingerprint --test_path data/tox21.csv --checkpoint_path tox21_checkpoints/fold_0/model_0/model.pt --preds_path tox21_fingerprint.csv
+```
+
+If installed from source, `chemprop_fingerprint` can be replaced with `python fingerprint.py`.
+
 ## Interpreting
 
 It is often helpful to provide explanation of model prediction (i.e., this molecule is toxic because of this substructure). Given a trained model, you can interpret the model prediction using the following command:

--- a/chemprop/models/model.py
+++ b/chemprop/models/model.py
@@ -118,6 +118,22 @@ class MoleculeModel(nn.Module):
         return self.ffn[:-1](self.encoder(batch, features_batch, atom_descriptors_batch,
                                           atom_features_batch, bond_features_batch))
 
+    def fingerprint(self,
+                  batch: Union[List[str], List[Chem.Mol], BatchMolGraph],
+                  features_batch: List[np.ndarray] = None,
+                  atom_descriptors_batch: List[np.ndarray] = None) -> torch.FloatTensor:
+        """
+        Encodes the fingerprint vectors of the input molecules by passing the inputs through the MPNN and returning
+        the latent representation before the FFNN.
+
+        :param batch: A list of SMILES, a list of RDKit molecules, or a
+                      :class:`~chemprop.features.featurization.BatchMolGraph`.
+        :param features_batch: A list of numpy arrays containing additional features.
+        :param atom_descriptors_batch: A list of numpy arrays containing additional atom descriptors.
+        :return: The fingerprint vectors calculated through the MPNN.
+        """
+        return self.encoder(batch, features_batch, atom_descriptors_batch)
+
     def forward(self,
                 batch: Union[List[str], List[Chem.Mol], BatchMolGraph],
                 features_batch: List[np.ndarray] = None,

--- a/chemprop/train/__init__.py
+++ b/chemprop/train/__init__.py
@@ -1,6 +1,7 @@
 from .cross_validate import chemprop_train, cross_validate, TRAIN_LOGGER_NAME
 from .evaluate import evaluate, evaluate_predictions
 from .make_predictions import chemprop_predict, make_predictions
+from .molecule_fingerprint import chemprop_fingerprint
 from .predict import predict
 from .run_training import run_training
 from .train import train
@@ -12,6 +13,7 @@ __all__ = [
     'evaluate',
     'evaluate_predictions',
     'chemprop_predict',
+    'chemprop_fingerprint',
     'make_predictions',
     'predict',
     'run_training',

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -36,6 +36,12 @@ def make_predictions(args: PredictArgs, smiles: List[List[str]] = None) -> List[
         raise ValueError('Features were used during training so they must be specified again during prediction '
                          'using the same type of features as before (with either --features_generator or '
                          '--features_path and using --no_features_scaling if applicable).')
+    
+    # Same number of molecules must be used in training as in making predictions
+    if train_args.number_of_molecules != args.number_of_molecules:
+        raise ValueError('A different number of molecules was used in training '
+                        f'model than is specified for prediction, {train_args.number_of_molecules} '
+                         'smiles fields must be provided')
 
     # if atom or bond features were scaled, the same must be done during prediction
     if train_args.features_scaling != args.features_scaling:

--- a/chemprop/train/molecule_fingerprint.py
+++ b/chemprop/train/molecule_fingerprint.py
@@ -1,0 +1,152 @@
+import csv
+from typing import List, Optional, Union
+
+import torch
+from tqdm import tqdm
+
+from chemprop.args import PredictArgs, TrainArgs
+from chemprop.data import get_data, get_data_from_smiles, MoleculeDataLoader, MoleculeDataset
+from chemprop.utils import load_args, load_checkpoint, makedirs, timeit
+from chemprop.data import MoleculeDataLoader, MoleculeDataset
+from chemprop.models import MoleculeModel
+
+@timeit()
+def molecule_fingerprint(args: PredictArgs, smiles: List[List[str]] = None) -> List[List[Optional[float]]]:
+    """
+    Loads data and a trained model and uses the model to encode fingerprint vectors for the data.
+
+    :param args: A :class:`~chemprop.args.PredictArgs` object containing arguments for
+                 loading data and a model and making predictions.
+    :param smiles: List of list of SMILES to make predictions on.
+    :return: A list of fingerprint vectors (list of floats)
+    """
+
+    print('Loading training args')
+    train_args = load_args(args.checkpoint_paths[0])
+    num_tasks, task_names = train_args.num_tasks, train_args.task_names
+
+    # Update args with training arguments
+    for key, value in vars(train_args).items():
+        if not hasattr(args, key):
+            setattr(args, key, value)
+    args: Union[PredictArgs, TrainArgs]
+
+    # Same number of molecules must be used in training as in making predictions
+    if train_args.number_of_molecules != args.number_of_molecules:
+        raise ValueError('A different number of molecules was used in training '
+                        f'model than is specified for prediction, {train_args.number_of_molecules} '
+                         'smiles fields must be provided')
+
+    # If atom-descriptors were used during training, they must be used when predicting and vice-versa
+    if train_args.atom_descriptors != args.atom_descriptors:
+        raise ValueError('The use of atom descriptors is inconsistent between training and prediction. If atom descriptors '
+                         ' were used during training, they must be specified again during prediction using the same type of '
+                         ' descriptors as before. If they were not used during training, they cannot be specified during prediction.')
+
+    print('Loading data')
+    if smiles is not None:
+        full_data = get_data_from_smiles(
+            smiles=smiles,
+            skip_invalid_smiles=False,
+            features_generator=args.features_generator
+        )
+    else:
+        full_data = get_data(path=args.test_path, smiles_columns=args.smiles_columns, target_columns=[], ignore_columns=[], skip_invalid_smiles=False,
+                             args=args, store_row=True)
+
+    print('Validating SMILES')
+    full_to_valid_indices = {}
+    valid_index = 0
+    for full_index in range(len(full_data)):
+        if all(mol is not None for mol in full_data[full_index].mol):
+            full_to_valid_indices[full_index] = valid_index
+            valid_index += 1
+
+    test_data = MoleculeDataset([full_data[i] for i in sorted(full_to_valid_indices.keys())])
+
+    # Edge case if empty list of smiles is provided
+    if len(test_data) == 0:
+        return [None] * len(full_data)
+
+    print(f'Test size = {len(test_data):,}')
+
+    # Create data loader
+    test_data_loader = MoleculeDataLoader(
+        dataset=test_data,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers
+    )
+
+    # Load model
+    print(f'Encoding smiles into a fingerprint vector from a single model')
+    if len(args.checkpoint_paths) != 1:
+        raise ValueError("Fingerprint generation only supports one model, cannot use an ensemble")
+
+    model = load_checkpoint(args.checkpoint_paths[0], device=args.device)
+
+    model_preds = model_fingerprint(
+        model=model,
+        data_loader=test_data_loader
+    )
+
+    # Save predictions
+    print(f'Saving predictions to {args.preds_path}')
+    assert len(test_data) == len(model_preds)
+    makedirs(args.preds_path, isfile=True)
+
+    # Copy predictions over to full_data
+    total_hidden_size = args.hidden_size * args.number_of_molecules
+    for full_index, datapoint in enumerate(full_data):
+        valid_index = full_to_valid_indices.get(full_index, None)
+        preds = model_preds[valid_index] if valid_index is not None else ['Invalid SMILES'] * total_hidden_size
+
+        fingerprint_columns=[f'fp_{i}' for i in range(total_hidden_size)]
+        for i in range(len(fingerprint_columns)):
+            datapoint.row[fingerprint_columns[i]] = preds[i]
+
+    # Write predictions
+    with open(args.preds_path, 'w') as f:
+        writer = csv.DictWriter(f, fieldnames=args.smiles_columns+fingerprint_columns,extrasaction='ignore')
+        writer.writeheader()
+        for datapoint in full_data:
+            writer.writerow(datapoint.row)
+
+    return model_preds
+
+def model_fingerprint(model: MoleculeModel,
+            data_loader: MoleculeDataLoader,
+            disable_progress_bar: bool = False) -> List[List[float]]:
+    """
+    Encodes the provided molecules into the latent fingerprint vectors, according to the provided model.
+
+    :param model: A :class:`~chemprop.models.model.MoleculeModel`.
+    :param data_loader: A :class:`~chemprop.data.data.MoleculeDataLoader`.
+    :param disable_progress_bar: Whether to disable the progress bar.
+    :return: A list of fingerprint vector lists.
+    """
+    model.eval()
+
+    fingerprints = []
+
+    for batch in tqdm(data_loader, disable=disable_progress_bar, leave=False):
+        # Prepare batch
+        batch: MoleculeDataset
+        mol_batch, features_batch, atom_descriptors_batch = batch.batch_graph(), batch.features(), batch.atom_descriptors()
+
+        # Make predictions
+        with torch.no_grad():
+            batch_fp = model.fingerprint(mol_batch, features_batch, atom_descriptors_batch)
+
+        # Collect vectors
+        batch_fp = batch_fp.data.cpu().tolist()
+
+        fingerprints.extend(batch_fp)
+
+    return fingerprints
+
+def chemprop_fingerprint() -> None:
+    """
+    Parses Chemprop predicting arguments and returns the latent representation vectors for
+    provided molecules, according to a previously trained model.
+    """
+    molecule_fingerprint(args=PredictArgs().parse_args())

--- a/fingerprint.py
+++ b/fingerprint.py
@@ -1,0 +1,7 @@
+"""Loads a trained chemprop model checkpoint and encode latent fingerprint vectors for the molecules in a dataset.
+    Uses the same command line arguments as predict."""
+
+from chemprop.train import chemprop_fingerprint
+
+if __name__ == '__main__':
+    chemprop_fingerprint()

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'console_scripts': [
             'chemprop_train=chemprop.train:chemprop_train',
             'chemprop_predict=chemprop.train:chemprop_predict',
+            'chemprop_fingerprint=chemprop.train:chemprop_fingerprint',
             'chemprop_hyperopt=chemprop.hyperparameter_optimization:chemprop_hyperopt',
             'chemprop_interpret=chemprop.interpret:chemprop_interpret',
             'chemprop_web=chemprop.web.run:chemprop_web',


### PR DESCRIPTION
I added a new function that saves the fingerprint vector for a set of provided molecules. The function mirrors what is going on in predictions, except that the output is what is provided by the MPN before it runs through the FFN (excludes features concatenated onto the vector).

The function works through the command line (when `pip install -e .` is run again) and when using two molecules.

Brief explanation of the file changes:
- Readme - Add explanation for the new function
- chemprop.data.utils - Saves the names of the smiles columns used in the get_data step even if the columns are not provided in the initial arguments.
- chemprop.models.model - Adds a class function to MoleculeModel that returns the MPNN output without passing it through the FFN.
- chemprop.train.molecule_fingerprint - The main function file for encoding fingerprints. This is analogous to chemprop.train.make_predictions and chemprop.train.predict. The entry function is chemprop_fingerprint.
- chemprop.train.__init__ - Adds import for the chemprop_fingerprint function.
- chemprop.train.make_predictions - an addition that isn't part of the fingerprint function but is the same as an assertion that was necessary in chemprop.train.molecule_fingerprint. Prevents people from training a model with two molecules and then predicting (or making a fingerprint) with just one.
- fingerprint - the top level file for this function. Calls chemprop_fingerprint.
- setup - added the command line function for chemprop_fingerprint.