### PR TITLE
fixing smiles list error in interpret.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ Chemprop's interpretation script explains model prediction one property at a tim
 
 For computational efficiency, we currently restricted the rationale to have maximum 20 atoms and minimum 8 atoms. You can adjust these constraints through `--max_atoms` and `--min_atoms` argument.
 
+Please note that the interpreting framework is currently only available for models trained on properties of single molecules, that is, multi-molecule models generated via the `--number_of_molecules` command are not supported.
+
 ## TensorBoard
 
 During training, TensorBoard logs are automatically saved to the same directory as the model checkpoints. To view TensorBoard logs, first install TensorFlow with `pip install tensorflow`. Then run `tensorboard --logdir=<dir>` where `<dir>` is the path to the checkpoint directory. Then navigate to [http://localhost:6006](http://localhost:6006).

--- a/chemprop/interpret.py
+++ b/chemprop/interpret.py
@@ -232,7 +232,7 @@ def mcts_rollout(node: MCTSNode,
         if len(node.children) == 0:
             return node.P  # cannot find leaves
 
-        scores = scoring_function([x.smiles for x in node.children])
+        scores = scoring_function([[x.smiles] for x in node.children])
         for child, score in zip(node.children, scores):
             child.P = score
 
@@ -260,6 +260,7 @@ def mcts(smiles: str,
     :param prop_delta: The minimum required property value for a satisfactory rationale.
     :return: A list of rationales each represented by a :class:`MCTSNode`.
     """
+            
     mol = Chem.MolFromSmiles(smiles)
     if mol.GetNumAtoms() > 50:
         n_rollout = 1
@@ -282,7 +283,6 @@ def mcts(smiles: str,
 
     return rationales
 
-
 @timeit()
 def interpret(args: InterpretArgs) -> None:
     """
@@ -290,6 +290,10 @@ def interpret(args: InterpretArgs) -> None:
 
     :param args: A :class:`~chemprop.args.InterpretArgs` object containing arguments for interpretation.
     """
+
+    if args.number_of_molecules != 1:
+        raise ValueError("Interpreting is currently only available for single-molecule models.")
+    
     global C_PUCT, MIN_ATOMS
 
     chemprop_model = ChempropModel(args)
@@ -310,7 +314,7 @@ def interpret(args: InterpretArgs) -> None:
         score = scoring_function([smiles])[0]
         if score > args.prop_delta:
             rationales = mcts(
-                smiles=smiles,
+                smiles=smiles[0],
                 scoring_function=scoring_function,
                 n_rollout=args.rollout,
                 max_atoms=args.max_atoms,

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -192,6 +192,8 @@ Chemprop's interpretation script explains model prediction one property at a tim
 
 For computational efficiency, we currently restricted the rationale to have maximum 20 atoms and minimum 8 atoms. You can adjust these constraints through :code:`--max_atoms` and :code:`--min_atoms` argument.
 
+Please note that the interpreting framework is currently only available for models trained on properties of single molecules, that is, multi-molecule models generated via the :code:`--number_of_molecules` command are not supported.
+
 TensorBoard
 ^^^^^^^^^^^
 


### PR DESCRIPTION
Fixed a bug in interpret.py. The mcts and mcts_rollout functions expect a smiles string, but Chemprop expects a list of smiles after we included multiple molecules in summer.

Am now checking if we have only one molecule (otherwise raise a ValueError), and fixed the list vs. str issue in two lines.