### PR TITLE
Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**.git*
+.dockerignore
+Dockerfile

--- a/README.md
+++ b/README.md
@@ -80,9 +80,14 @@ Chemprop can also be installed with Docker. Docker makes it possible to isolate 
 2. `cd chemprop`
 3. Install Docker from [https://docs.docker.com/install/](https://docs.docker.com/install/)
 4. `docker build -t chemprop .`
-5. `docker run -it chemprop:latest /bin/bash`
+5. `docker run -it chemprop:latest`
 
 Note that you will need to run the latter command with nvidia-docker if you are on a GPU machine in order to be able to access the GPUs.
+Alternatively, with Docker 19.03+, you can specify the `--gpus` command line option instead.
+
+In addition, you will also need to ensure that the CUDA toolkit version in the Docker image is compatible with the CUDA driver on your host machine.
+Newer CUDA driver versions are backward-compatible with older CUDA toolkit versions.
+To set a specific CUDA toolkit version, add `cudatoolkit=X.Y` to `environment.yml` before building the Docker image.
 
 ## Web Interface
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -42,6 +42,11 @@ Chemprop can also be installed with Docker. Docker makes it possible to isolate 
 2. :code:`cd chemprop`
 3. Install Docker from `<https://docs.docker.com/install/>`_
 4. :code:`docker build -t chemprop .`
-5. :code:`docker run -it chemprop:latest /bin/bash`
+5. :code:`docker run -it chemprop:latest`
 
 Note that you will need to run the latter command with nvidia-docker if you are on a GPU machine in order to be able to access the GPUs.
+Alternatively, with Docker 19.03+, you can specify the :code:`--gpus` command line option instead.
+
+In addition, you will also need to ensure that the CUDA toolkit version in the Docker image is compatible with the CUDA driver on your host machine.
+Newer CUDA driver versions are backward-compatible with older CUDA toolkit versions.
+To set a specific CUDA toolkit version, add :code:`cudatoolkit=X.Y` to :code:`environment.yml` before building the Docker image.


### PR DESCRIPTION
Modifications:
- Use miniconda as base image
- Install most dependencies using conda (due to #129)
- Use conda installed cuda toolkit instead of system installation (via cuda base image) - I think this approach avoids potential mismatch between the cuda version that pytorch is compiled with and the installed cuda runtime
- Use base conda environment to avoid duplicating packages into separate chemprop environment and fix #100
- Set bash login shell as entrypoint to work better with anaconda when using interactively

Testing done:
- Ran unit tests
- Confirmed that chemprop can be imported
- Confirmed that `torch.cuda.is_available()` is True

The main question I have left is how to confirm that chemprop runs correctly using cuda. Would the unit tests do so automatically if cuda is available?