### PR TITLE
Smiles processing

### DIFF
--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal
 import torch
 from tap import Tap  # pip install typed-argument-parser (https://github.com/swansonk14/typed-argument-parser)
 
+import chemprop.data.utils
 from chemprop.data import set_cache_mol
 from chemprop.features import get_available_features_generators
 
@@ -167,11 +168,6 @@ class CommonArgs(Tap):
         # Validate features
         if self.features_generator is not None and 'rdkit_2d_normalized' in self.features_generator and self.features_scaling:
             raise ValueError('When using rdkit_2d_normalized features, --no_features_scaling must be specified.')
-
-        if self.smiles_columns is None:
-            self.smiles_columns = [None] * self.number_of_molecules
-        elif len(self.smiles_columns) != self.number_of_molecules:
-            raise ValueError('Length of smiles_columns must match number_of_molecules.')
 
         # Validate atom descriptors
         if (self.atom_descriptors is None) != (self.atom_descriptors_path is None):
@@ -388,6 +384,13 @@ class TrainArgs(CommonArgs):
 
         global temp_dir  # Prevents the temporary directory from being deleted upon function return
 
+        # Process SMILES columns
+        self.smiles_columns = chemprop.data.utils.preprocess_smiles_columns(
+            path=self.data_path,
+            smiles_columns=self.smiles_columns,
+            number_of_molecules=self.number_of_molecules,
+        )
+
         # Load config file
         if self.config_path is not None:
             with open(self.config_path) as f:
@@ -479,6 +482,12 @@ class PredictArgs(CommonArgs):
     def process_args(self) -> None:
         super(PredictArgs, self).process_args()
 
+        self.smiles_columns = chemprop.data.utils.preprocess_smiles_columns(
+            path=self.test_path,
+            smiles_columns=self.smiles_columns,
+            number_of_molecules=self.number_of_molecules,
+        )
+
         if self.checkpoint_paths is None or len(self.checkpoint_paths) == 0:
             raise ValueError('Found no checkpoints. Must specify --checkpoint_path <path> or '
                              '--checkpoint_dir <dir> containing at least one checkpoint.')
@@ -506,6 +515,13 @@ class InterpretArgs(CommonArgs):
 
     def process_args(self) -> None:
         super(InterpretArgs, self).process_args()
+
+        self.smiles_columns = chemprop.data.utils.preprocess_smiles_columns(
+            path=self.data_path,
+            smiles_columns=self.smiles_columns,
+            number_of_molecules=self.number_of_molecules,
+        )
+
 
         if self.features_path is not None:
             raise ValueError('Cannot use --features_path <path> for interpretation since features '
@@ -567,10 +583,11 @@ class SklearnPredictArgs(Tap):
 
     def process_args(self) -> None:
 
-        if self.smiles_columns is None:
-            self.smiles_columns = [None] * self.number_of_molecules
-        elif len(self.smiles_columns) != self.number_of_molecules:
-            raise ValueError('Length of smiles_columns must match number_of_molecules.')
+        self.smiles_columns = chemprop.data.utils.preprocess_smiles_columns(
+            path=self.test_path,
+            smiles_columns=self.smiles_columns,
+            number_of_molecules=self.number_of_molecules,
+        )
 
         # Load checkpoint paths
         self.checkpoint_paths = get_checkpoint_paths(

--- a/chemprop/data/__init__.py
+++ b/chemprop/data/__init__.py
@@ -18,10 +18,10 @@ from .utils import (
     get_header,
     get_smiles,
     get_task_names,
+    preprocess_smiles_columns,
     split_data,
     validate_data,
     validate_dataset_type,
-    preprocess_smiles_columns
 )
 
 __all__ = [
@@ -45,7 +45,8 @@ __all__ = [
     'get_header',
     'get_smiles',
     'get_task_names',
+    'preprocess_smiles_columns',
     'split_data',
     'validate_data',
-    'validate_dataset_type'
+    'validate_dataset_type',
 ]

--- a/chemprop/sklearn_train.py
+++ b/chemprop/sklearn_train.py
@@ -212,7 +212,7 @@ def run_sklearn(args: SklearnTrainArgs,
             features_path=args.features_path,
             train_data=train_data,
             test_data=test_data,
-            smiles_columns=args.smiles_columns
+            smiles_columns=args.smiles_columns,
         )
 
     debug(f'Total size = {len(data):,} | train size = {len(train_data):,} | test size = {len(test_data):,}')

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -60,6 +60,7 @@ def cross_validate(args: TrainArgs,
     data = get_data(
         path=args.data_path,
         args=args,
+        smiles_columns=args.smiles_columns,
         logger=logger,
         skip_none_targets=True
     )

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 from .predict import predict
 from chemprop.args import PredictArgs, TrainArgs
-from chemprop.data import get_data, get_data_from_smiles, get_header, MoleculeDataLoader, MoleculeDataset
+from chemprop.data import get_data, get_data_from_smiles, MoleculeDataLoader, MoleculeDataset
 from chemprop.utils import load_args, load_checkpoint, load_scalers, makedirs, timeit
 from chemprop.features import set_extra_atom_fdim
 
@@ -60,8 +60,8 @@ def make_predictions(args: PredictArgs, smiles: List[List[str]] = None) -> List[
             features_generator=args.features_generator
         )
     else:
-        full_data = get_data(path=args.test_path, target_columns=[], ignore_columns=[], skip_invalid_smiles=False,
-                             args=args, store_row=not args.drop_extra_columns)
+        full_data = get_data(path=args.test_path, smiles_columns=args.smiles_columns, target_columns=[], ignore_columns=[],
+                             skip_invalid_smiles=False, args=args, store_row=not args.drop_extra_columns)
 
     print('Validating SMILES')
     full_to_valid_indices = {}
@@ -136,9 +136,6 @@ def make_predictions(args: PredictArgs, smiles: List[List[str]] = None) -> List[
             datapoint.row = OrderedDict()
 
             smiles_columns = args.smiles_columns
-
-            if None in smiles_columns:
-                smiles_columns = get_header(args.test_path)[:len(smiles_columns)]
 
             for column, smiles in zip(smiles_columns, datapoint.smiles):
                 datapoint.row[column] = smiles

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -46,10 +46,10 @@ def run_training(args: TrainArgs,
     debug(f'Splitting data with seed {args.seed}')
     if args.separate_test_path:
         test_data = get_data(path=args.separate_test_path, args=args, features_path=args.separate_test_features_path,
-                             logger=logger)
+                             logger=logger, smiles_columns=args.smiles_columns)
     if args.separate_val_path:
         val_data = get_data(path=args.separate_val_path, args=args, features_path=args.separate_val_features_path,
-                            logger=logger)
+                            logger=logger, smiles_columns=args.smiles_columns)
 
     if args.separate_val_path and args.separate_test_path:
         train_data = data
@@ -76,7 +76,7 @@ def run_training(args: TrainArgs,
             train_data=train_data,
             val_data=val_data,
             test_data=test_data,
-            smiles_columns=args.smiles_columns
+            smiles_columns=args.smiles_columns,
         )
 
     if args.features_scaling:

--- a/chemprop/web/app/views.py
+++ b/chemprop/web/app/views.py
@@ -211,10 +211,10 @@ def train():
     ])
 
     # Get task names
-    args.task_names = get_task_names(path=data_path, smiles_columns=[None])
+    args.task_names = get_task_names(path=data_path, smiles_columns=args.smiles_columns)
 
     # Check if regression/classification selection matches data
-    data = get_data(path=data_path, smiles_columns=[None])
+    data = get_data(path=data_path, smiles_columns=args.smiles_columns)
     # Set the number of molecules through the length of the smiles_columns for now, we need to add an option to the site later
 
     targets = data.targets()

--- a/scripts/class_balance.py
+++ b/scripts/class_balance.py
@@ -19,14 +19,14 @@ class Args(Tap):
     split_type: Literal['random', 'scaffold'] = 'scaffold'  # Split type, either "random" or "scaffold"
 
 
-def class_balance(data_path: str, split_type: str):
+def class_balance(args: Args):
     # Update args
     args.val_fold_index, args.test_fold_index = 1, 2
     args.split_type = 'predetermined'
 
     # Load data
-    data = get_data(path=args.data_path, smiles_columns=args.smiles_column, target_columns=args.target_columns)
-    args.task_names = args.target_columns or get_task_names(path=args.data_path, smiles_columns=args.smiles_column)
+    data = get_data(path=args.data_path, smiles_columns=args.smiles_columns, target_columns=args.target_columns)
+    args.task_names = get_task_names(path=args.data_path, smiles_columns=args.smiles_columns, target_columns=args.target_columns)
 
     # Average class sizes
     all_class_sizes = {
@@ -39,8 +39,8 @@ def class_balance(data_path: str, split_type: str):
         print(f'Fold {i}')
 
         # Update args
-        data_name = os.path.splitext(os.path.basename(data_path))[0]
-        args.folds_file = f'/data/rsg/chemistry/yangk/lsc_experiments_dump_splits/data/{data_name}/{split_type}/fold_{i}/0/split_indices.pckl'
+        data_name = os.path.splitext(os.path.basename(args.data_path))[0]
+        args.folds_file = f'/data/rsg/chemistry/yangk/lsc_experiments_dump_splits/data/{data_name}/{args.split_type}/fold_{i}/0/split_indices.pckl'
 
         if not os.path.exists(args.folds_file):
             print('Fold indices do not exist')
@@ -78,9 +78,4 @@ def class_balance(data_path: str, split_type: str):
 
 
 if __name__ == '__main__':
-    args = Args().parse_args()
-
-    class_balance(
-        data_path=args.data_path,
-        split_type=args.split_type
-    )
+    class_balance(args=Args().parse_args())

--- a/scripts/create_crossval_splits.py
+++ b/scripts/create_crossval_splits.py
@@ -21,6 +21,7 @@ class Args(Tap):
     test_folds_to_test: int = 3  # Number of test folds
     val_folds_per_test: int = 3  # Number of val folds
     time_folds_per_train_set: int = 3  # X:1:1 train:val:test for time split sliding window
+    smiles_columns: List[str] = None # columns in CSV dataset file containing SMILES
 
 
 def split_indices(all_indices: List[int],
@@ -54,7 +55,7 @@ def split_indices(all_indices: List[int],
 def create_time_splits(args: Args):
     # ASSUME DATA GIVEN IN CHRONOLOGICAL ORDER.
     # this will dump a very different format of indices, with all in one file; TODO modify as convenient later.
-    data = get_data(args.data_path)
+    data = get_data(path=args.data_path, smiles_columns=args.smiles_columns)
     num_data = len(data)
     all_indices = list(range(num_data))
     fold_indices = {'random': [], 'scaffold': [], 'time': []}
@@ -86,7 +87,7 @@ def create_time_splits(args: Args):
 
 
 def create_crossval_splits(args: Args):
-    data = get_data(args.data_path)
+    data = get_data(path=args.data_path, smiles_columns=args.smiles_columns)
     num_data = len(data)
     if args.split_type == 'random':
         all_indices = list(range(num_data))

--- a/scripts/find_similar_mols.py
+++ b/scripts/find_similar_mols.py
@@ -32,6 +32,7 @@ class Args(Tap):
     checkpoint_path: str = None  # Path to .pt file containing a model checkpoint (only needed for distance_measure == "embedding")
     num_neighbors: int = 5  # Number of neighbors to search for each molecule
     batch_size: int = 50  # Batch size when making predictions
+    smiles_column: str = None # Columns in dataset CSV file containing SMILES
 
 
 def find_similar_mols(test_smiles: List[str],
@@ -112,7 +113,8 @@ def find_similar_mols_from_file(test_path: str,
                                 distance_measure: str,
                                 checkpoint_path: str = None,
                                 num_neighbors: int = -1,
-                                batch_size: int = 50) -> List[OrderedDict]:
+                                batch_size: int = 50,
+                                smiles_column: str = None) -> List[OrderedDict]:
     """
     For each test molecule, finds the N most similar training molecules according to some distance measure.
     Loads molecules and model from file.
@@ -127,7 +129,7 @@ def find_similar_mols_from_file(test_path: str,
     and other relevant distance info.
     """
     print('Loading data')
-    test_smiles, train_smiles = get_smiles(test_path, flatten=True), get_smiles(train_path, flatten=True)
+    test_smiles, train_smiles = get_smiles(test_path, flatten=True, smiles_columns=smiles_column), get_smiles(train_path, flatten=True, smiles_columns=smiles_column)
 
     if checkpoint_path is not None:
         print('Loading model')
@@ -151,7 +153,8 @@ def save_similar_mols(test_path: str,
                       distance_measure: str,
                       checkpoint_path: str = None,
                       num_neighbors: int = None,
-                      batch_size: int = 50):
+                      batch_size: int = 50,
+                      smiles_column: str = None):
     """
     For each test molecule, finds the N most similar training molecules according to some distance measure.
     Loads molecules and model from file and saves results to file.
@@ -173,7 +176,8 @@ def save_similar_mols(test_path: str,
         checkpoint_path=checkpoint_path,
         distance_measure=distance_measure,
         num_neighbors=num_neighbors,
-        batch_size=batch_size
+        batch_size=batch_size,
+        smiles_column=smiles_column,
     )
 
     # Save results
@@ -196,5 +200,6 @@ if __name__ == '__main__':
         distance_measure=args.distance_measure,
         checkpoint_path=args.checkpoint_path,
         num_neighbors=args.num_neighbors,
-        batch_size=args.batch_size
+        batch_size=args.batch_size,
+        smiles_column=args.smiles_column,
     )

--- a/scripts/overlap.py
+++ b/scripts/overlap.py
@@ -3,6 +3,7 @@
 import csv
 import os
 import sys
+from typing import List
 
 from tap import Tap  # pip install typed-argument-parser (https://github.com/swansonk14/typed-argument-parser)
 
@@ -14,17 +15,17 @@ from chemprop.data import get_smiles
 class Args(Tap):
     data_path_1: str  # Path to first data CSV file
     data_path_2: str  # Path to second data CSV file
-    smiles_column_1: str = None  # Name of the column containing SMILES strings for the first data. By default, uses the first column.
-    smiles_column_2: str = None  # Name of the column containing SMILES strings for the second data. By default, uses the first column.
+    smiles_columns_1: List[str] = None  # Name of the column containing SMILES strings for the first data. By default, uses the first column.
+    smiles_columns_2: List[str] = None  # Name of the column containing SMILES strings for the second data. By default, uses the first column.
     save_intersection_path: str = None  # Path to save intersection at; labeled with data_path 1 header
     save_difference_path: str = None  # Path to save molecules in dataset 1 that are not in dataset 2; labeled with data_path 1 header
 
 
 def overlap(args: Args):
-    smiles_1 = get_smiles(path=args.data_path_1, smiles_columns=args.smiles_column_1, flatten=True)
-    smiles_2 = get_smiles(path=args.data_path_2, smiles_columns=args.smiles_column_2, flatten=True)
+    smiles_1 = get_smiles(path=args.data_path_1, smiles_columns=args.smiles_columns_1)
+    smiles_2 = get_smiles(path=args.data_path_2, smiles_columns=args.smiles_columns_2)
 
-    smiles_1, smiles_2 = set(smiles_1), set(smiles_2)
+    smiles_1, smiles_2 = set([tuple(smiles) for smiles in smiles_1]), set([tuple(smiles) for smiles in smiles_2])
     size_1, size_2 = len(smiles_1), len(smiles_2)
     intersection = smiles_1.intersection(smiles_2)
     size_intersect = len(intersection)

--- a/scripts/split_data.py
+++ b/scripts/split_data.py
@@ -3,7 +3,7 @@
 import csv
 import os
 import sys
-from typing import Tuple
+from typing import Tuple, List
 
 from tap import Tap  # pip install typed-argument-parser (https://github.com/swansonk14/typed-argument-parser)
 from tqdm import tqdm
@@ -18,7 +18,7 @@ from chemprop.utils import makedirs
 class Args(Tap):
     data_path: str  # Path to data CSV file
     save_dir: str  # Directory where train, validation, and test sets will be saved
-    smiles_column: str = None  # Name of the column containing SMILES strings. By default, uses the first column.
+    smiles_columns: List[str] = None  # Name of the column containing SMILES strings. By default, uses the first column.
     split_type: Literal['random', 'scaffold_balanced'] = 'random'  # Split type
     split_sizes: Tuple[float, float, float] = (0.8, 0.1, 0.1)  # Split sizes
     seed: int = 0  # Random seed
@@ -32,7 +32,7 @@ def run_split_data(args: Args):
         lines = list(reader)
 
     # Load SMILES
-    smiles = get_smiles(path=args.data_path, smiles_columns=args.smiles_column)
+    smiles = get_smiles(path=args.data_path, smiles_columns=args.smiles_columns)
 
     # Make sure lines and smiles line up
     assert len(lines) == len(smiles)


### PR DESCRIPTION
This PR consolidates the logic checks and changes to `args.smiles_columns` in one function and applies it during argument processing. These checks and changes are now held within an expanded `preprocess_smiles_columns` in `chemprop.data.utils`. The redundant checks and changes have been removed from other code locations.

For normal function of chemprop, `preprocess_smiles_columns` will be run during argument processing before `args.smiles_columns` is referenced anywhere in the code. This simplifies references to `args.smiles_columns` by enforcing that it contains a list of strings corresponding to the header of the data file from early on.

The changes to `smiles_columns` consolidated into the `preprocess_smiles_columns` function, with the previous locations for the changes in parentheses:

- If `None`, make it a list of `None` (`CommonArgs`,`SklearnPredictArgs`)
- Error if the number of smiles columns is different than the number of molecules (`CommonArgs`,`SklearnPredictArgs`)
- If not a list, make it a list (`preprocess_smiles_columns` as constructed previously)
- If `None`, make the `smiles_columns` the first n columns in the data file for n number of molecules (`save_smiles_splits`,`get_task_names`,`get_smiles`,`get_data`,`make_predictions`)
- Error if the `smiles_columns` do not appear in the header of the data file (not previously checked)

Some of the utils functions are optional for the `smiles_columns` arguments with `None` as the default value: `get_smiles`, `get_task_names`, `get_data`, and `save_smiles_splits`. In these cases `preprocess_smiles_columns` will be used following a logic check to see if the value type is list, which will catch the default value `None` as well as direct references from scripts that are supplying a single string value instead of a list. Applying `preprocess_smiles_columns` here is less preferred but necessary to preserve flexible use of the functions for scripting. However, if this flexibility is not important, I would prefer to go back and make a list entry of `smiles_columns` required for these functions and remove the check.

One issue with this implementation is a circular import that happens when using the `from module import x` form of imports as is the style in chemprop. The `preprocess_smiles_columns` function is in `chemprop.data.utils` and must be imported into `chemprop.args`. However, `chemprop.data.utils` imports argument classes from `chemprop.args` for several of its functions, causing a circular import. I resolved this by using `import chemprop.data.utils` in `chemprop.args` and then referencing the function as `chemprop.data.utils.preprocess_smiles_columns`. This looks inelegant, but does resolve the circularity. I'm open to other ways of resolving it, but am not sure which is stylistically best (performing `from chemprop.data import preprocess_smiles columns` within functions or doing a broad `import chemprop.args` in the utils file instead are possible alternatives).
