### PR TITLE
bugfix for atom meassages concerning bond feature vector

### DIFF
--- a/chemprop/features/featurization.py
+++ b/chemprop/features/featurization.py
@@ -265,7 +265,7 @@ class BatchMolGraph:
                  and scope of the atoms and bonds (i.e., the indices of the molecules they belong to).
         """
         if atom_messages:
-            f_bonds = self.f_bonds[:, :get_bond_fdim(atom_messages=atom_messages)]
+            f_bonds = self.f_bonds[:, -get_bond_fdim(atom_messages=atom_messages):]
         else:
             f_bonds = self.f_bonds
 


### PR DESCRIPTION
Just confirmed a bug when using atom messages: 

We set up the bond features in the order atom(length 133)-bond(length 14):

https://github.com/chemprop/chemprop/blob/8258fcbea2bc4bd22889ba284389382ced97ae61/chemprop/features/featurization.py#L171-L172

but then cut out the first (!) 14 values, instead of the last:

https://github.com/chemprop/chemprop/blob/8258fcbea2bc4bd22889ba284389382ced97ae61/chemprop/features/featurization.py#L267-L270

Have added a few print statements, and we indeed used the wrong features for atom messages (which are the first 14 one-hot encoded elements, and thus rather meaningless). I have corrected this bug by simply cutting out the last values instead of the first (alternatively, we could change the order of setting up the bond vectors, but this would not be backwards compatible even if atom-messages were not used).

A quick check of how this affects performance:

- Freesolv dataset: With wrong atom messages: RMSE=0.96, corrected atom messages 0.93
- Delaney dataset: With wrong atom messages: RMSE=1.02, corrected atom messages 0.82 (!!!)