### PR TITLE
Epistemic uncertainty

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please see [aicures.mit.edu](https://aicures.mit.edu) and the associated [data G
 - [Web Interface](#web-interface)
 - [Data](#data)
 - [Training](#training)
-  * [Train/Validation/Test Splits](#train-validation-test-splits)
+  * [Train/Validation/Test Splits](#trainvalidationtest-splits)
   * [Cross validation](#cross-validation)
   * [Ensembling](#ensembling)
   * [Hyperparameter Optimization](#hyperparameter-optimization)
@@ -36,7 +36,9 @@ Please see [aicures.mit.edu](https://aicures.mit.edu) and the associated [data G
     * [Custom Features](#custom-features)
     * [Atomic Features](#atomic-features)
 - [Predicting](#predicting)
-- [Interpreting Model Prediction](#Interpreting)
+  * [Epistemic Uncertainty](#epistemic-uncertainty)
+- [Encode Fingerprint Latent Representation](encode-fingerprint-latent-representation)
+- [Interpreting Model Prediction](#interpreting)
 - [TensorBoard](#tensorboard)
 - [Results](#results)
 
@@ -259,6 +261,10 @@ chemprop_predict --test_path data/tox21.csv --checkpoint_path tox21_checkpoints/
 ```
 
 If installed from source, `chemprop_predict` can be replaced with `python predict.py`.
+
+### Epistemic Uncertainty
+
+One method of obtaining the epistemic uncertainty of a prediction is to calculate the variance of an ensemble of models. To calculate these variances and write them as an additional column in the `--preds_path` file, use `--ensemble_variance`.
 
 ## Encode Fingerprint Latent Representation
 

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -562,6 +562,8 @@ class PredictArgs(CommonArgs):
     """Path to CSV file where predictions will be saved."""
     drop_extra_columns: bool = False
     """Whether to drop all columns from the test data file besides the SMILES columns and the new prediction columns."""
+    ensemble_variance: bool = False
+    """Whether to calculate the variance of ensembles as a measure of epistemic uncertainty. If True, the variance is saved as an additional column for each target in the preds_path."""
 
     @property
     def ensemble_size(self) -> int:


### PR DESCRIPTION
I added the ability to calculate the epistemic uncertainty of predictions using `--ensemble_variance`. This writes the uncertainty as a separate column in the predictions file. I made the corresponding changes to the README. I tested this on training/predicting with the following:
1. single model, 1 molecule, 1 target
2. single model, 2 molecules, 1 target
3. ensemble model, 1 molecule, 1 target
4. ensemble model, 2 molecules, 1 target
5. ensemble model, 2 molecules, 2 targets