### PR TITLE
Fix type annotations for MPN.forward

### DIFF
--- a/chemprop/models/mpn.py
+++ b/chemprop/models/mpn.py
@@ -185,7 +185,7 @@ class MPN(nn.Module):
                                           for _ in range(args.number_of_molecules)])
 
     def forward(self,
-                batch: Union[List[List[str]], List[List[Chem.Mol]], BatchMolGraph],
+                batch: Union[List[List[str]], List[List[Chem.Mol]], List[BatchMolGraph]],
                 features_batch: List[np.ndarray] = None,
                 atom_descriptors_batch: List[np.ndarray] = None,
                 atom_features_batch: List[np.ndarray] = None,
@@ -194,7 +194,7 @@ class MPN(nn.Module):
         Encodes a batch of molecules.
 
         :param batch: A list of list of SMILES, a list of list of RDKit molecules, or a
-                      :class:`~chemprop.features.featurization.BatchMolGraph`.
+                      list of :class:`~chemprop.features.featurization.BatchMolGraph`.
         :param features_batch: A list of numpy arrays containing additional features.
         :param atom_descriptors_batch: A list of numpy arrays containing additional atom descriptors.
         :param atom_features_batch: A list of numpy arrays containing additional atom features.


### PR DESCRIPTION
This fixes the type annotation for `MPN.forward` and the corresponding docstring. 
`forward` cannot receive a single BatchMolGraph instance as its batch argument with the current implementation.

An alternative fix would be to add this line before line 204:
```if type(batch) == BatchMolGraph: batch = [batch]```
and to have both `BatchMolGraph` and `List[BatchMolGraph]` as valid types for `batch`. If you prefer I do that fix I can delete this pull request and pull request [this branch](https://github.com/bengioe/chemprop/blob/mpn_fix/chemprop/models/mpn.py) instead. I'm not familiar with chemprop so I don't know if that would be a bad change.

This alternative fix would also make chemprop backwards compatible, as c6dee25c breaks this behavior (because of [this](https://github.com/chemprop/chemprop/commit/c6dee25c9c5be5d562d70f2d8b3bd33ef7c20a75#diff-b333f29d146f5212f8107b81c5ef9b8f8a7de1229ced3970b13768045a6c862fR162) change).

For obscure reasons I need this annotation to be correct because I have to maintain two codebases, one of which uses an older chemprop, pre c6dee25c (and c6dee25c breaks passing a single `BatchMolGraph` argument to `forward`). Having the correct annotation allows me to detect which chemprop version is being used.