### PR TITLE
bugfix for batch dimensions in mpnn forward pass

### DIFF
--- a/chemprop/models/mpn.py
+++ b/chemprop/models/mpn.py
@@ -195,6 +195,8 @@ class MPN(nn.Module):
 
         :param batch: A list of list of SMILES, a list of list of RDKit molecules, or a
                       list of :class:`~chemprop.features.featurization.BatchMolGraph`.
+                      The outer list is of length :code:`number_of_molecules` (number of molecules per datapoint), 
+                      the inner list or BatchMolGraph is of length :code:`num_molecules` (number of datapoints in batch).
         :param features_batch: A list of numpy arrays containing additional features.
         :param atom_descriptors_batch: A list of numpy arrays containing additional atom descriptors.
         :param atom_features_batch: A list of numpy arrays containing additional atom features.
@@ -204,7 +206,7 @@ class MPN(nn.Module):
         if type(batch[0]) != BatchMolGraph:
             # TODO: handle atom_descriptors_batch with multiple molecules per input
             if self.atom_descriptors == 'feature':
-                if len(batch[0]) > 1:
+                if len(batch) > 1:
                     raise NotImplementedError('Atom/bond descriptors are currently only supported with one molecule '
                                               'per input (i.e., number_of_molecules = 1).')
 
@@ -213,7 +215,7 @@ class MPN(nn.Module):
                                    overwrite_default_bond_features=self.overwrite_default_bond_features)
                          for b in batch]
             elif bond_features_batch is not None:
-                if len(batch[0]) > 1:
+                if len(batch) > 1:
                     raise NotImplementedError('Atom/bond descriptors are currently only supported with one molecule '
                                               'per input (i.e., number_of_molecules = 1).')
 


### PR DESCRIPTION
The author of issue #153 correctly noted that for checking the dimensions of `batch` in the MPN forward pass, there is a small bug when checking the dimensions of the batch for multiple-molecule input (the check is needed to raise an error when multi-molecule input is combined with custom atom/bond features, which is currently not supported) - the current code wrongly checks the batch size (the dimension of the inner list) instead of `args.number_of_molecules` (the dimension of the outer list) to be 1. I corrected this, and added a description to the docstring about which dimension is which.

Since this is connected to atom/bond descriptors, could you take a look, @fhvermei.