### PR TITLE
bugfix for multi-molecules in scaffold split

### DIFF
--- a/scripts/create_crossval_splits.py
+++ b/scripts/create_crossval_splits.py
@@ -31,7 +31,9 @@ def split_indices(all_indices: List[int],
                   shuffle: bool = True) -> List[List[int]]:
     num_data = len(all_indices)
     if scaffold:
-        scaffold_to_indices = scaffold_to_smiles(data.mols(), use_indices=True)
+        if data.number_of_molecules > 1:
+            raise ValueError('Cannot perform a scaffold split with more than one molecule per datapoint.')
+        scaffold_to_indices = scaffold_to_smiles(data.mols(flatten=True), use_indices=True)
         index_sets = sorted(list(scaffold_to_indices.values()),
                             key=lambda index_set: len(index_set),
                             reverse=True)


### PR DESCRIPTION
Another bug fix for multi-molecule input. This is analogous to the changes that were made in [2c98bf7](https://github.com/chemprop/chemprop/commit/2c98bf743cf90893dcc7b9f2b70786a2c7735b2f) (checking if multi-molecule input is used, raise an exception, else flatten the list of molecules).