### PR TITLE
Bypasses Pickle index file when repeated SMILES or multiple data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The full list of available features for `--features_generator` is as follows.
 If you install from source, you can modify the code to load custom features as follows:
 
 1. **Generate features:** If you want to generate features in code, you can write a custom features generator function in `chemprop/features/features_generators.py`. Scroll down to the bottom of that file to see a features generator code template.
-2. **Load features:** If you have features saved as a numpy `.npy` file or as a `.csv` file, you can load the features by using `--features_path /path/to/features`. Note that the features must be in the same order as the SMILES strings in your data file. Also note that `.csv` files must have a header row and the features should be comma-separated with one line per molecule.
+2. **Load features:** If you have features saved as a numpy `.npy` file or as a `.csv` file, you can load the features by using `--features_path /path/to/features`. Note that the features must be in the same order as the SMILES strings in your data file. Also note that `.csv` files must have a header row and the features should be comma-separated with one line per molecule. By default, provided features will be normalized unless the flag `--no_features_scaling` is used.
 
 #### Atom-Level Features
 

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -105,6 +105,7 @@ def run_training(args: TrainArgs,
             val_data=val_data,
             test_data=test_data,
             smiles_columns=args.smiles_columns,
+            logger=logger,
         )
 
     if args.features_scaling:


### PR DESCRIPTION
Resolves #157 . As part of `--save_smiles_splits`, a pickle file is saved with the indices in the data file that are associated with each of the train/val/test splits. This listing of indices is inappropriate when there are more than one data file, such as when `--separate_test_path` is specified. Also, this listing of indices is constructed after-the-fact by matching SMILES in the splits to the data file, and so cannot easily distinguish between entries in the data file with the same SMILES. This PR adds a warning if either of these conditions are met and skips writing the pickle file.