### PR TITLE
bugfix new rdkit version

### DIFF
--- a/chemprop/interpret.py
+++ b/chemprop/interpret.py
@@ -179,8 +179,11 @@ def extract_subgraph(smiles: str, selected_atoms: Set[int]) -> Tuple[str, List[i
     mol = Chem.MolFromSmiles(smiles)
     Chem.Kekulize(mol)
     subgraph, roots = __extract_subgraph(mol, selected_atoms)
-    subgraph = Chem.MolToSmiles(subgraph, kekuleSmiles=True)
-    subgraph = Chem.MolFromSmiles(subgraph)
+    try:
+        subgraph = Chem.MolToSmiles(subgraph, kekuleSmiles=True)
+        subgraph = Chem.MolFromSmiles(subgraph)
+    except Exception:
+        subgraph = None
 
     mol = Chem.MolFromSmiles(smiles)  # de-kekulize
     if subgraph is not None and mol.HasSubstructMatch(subgraph):


### PR DESCRIPTION
RDKit version >= 2021.03.01 changes the default behavior of how molecule fragments are kekulized (and how failures are treated, previously resulting in a None smiles string, now in an exception being raised), leading to an incompatibility with the interpretation script in Chemprop (see #178). 

I have discussed with Wengong on the best way to fix this, he agreed on adding a try/except clause. This is compatible with all rdkit versions, including new ones. 

On a side note: The default behaviour of rdkit changed due to a bugfix, which involves fragments being incorrectly kekulized - I am therefore not sure whether new versions of rdkit might lead to slightly different results in the interpretation scripts regardless of the fix proposed here (for all tests I ran, the results were the same, but my scans were not exhaustive by any means). If there were any differences, newer rdkit versions would produce the technically more "correct" answer.