### PR TITLE
bugfix for training within git repo

### DIFF
--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -5,7 +5,7 @@ from logging import Logger
 import os
 import sys
 from typing import Callable, Dict, List, Tuple
-
+import subprocess
 import numpy as np
 import pandas as pd
 
@@ -54,7 +54,11 @@ def cross_validate(args: TrainArgs,
 
     # Save args
     makedirs(args.save_dir)
-    args.save(os.path.join(args.save_dir, 'args.json'))
+    try:
+        args.save(os.path.join(args.save_dir, 'args.json'))
+    except subprocess.CalledProcessError:
+        debug('Could not write the reproducibility section of the arguments to file, thus omitting this section.')
+        args.save(os.path.join(args.save_dir, 'args.json'), with_reproducibility=False)
 
     #set explicit H option and reaction option
     set_explicit_h(args.explicit_h)


### PR DESCRIPTION
Currently, tap causes an issue when training a model within a git repo that has no origin specified. To reproduce the error:
`mkdir test; cd test; git init`
`python <path_to_chemprop>/train.py --data_path <path_to_data_csv> --dataset_type regression`
This is a tap issue since when writing arguments to file, it runs `git remote get-url origin`, in the current folder, not in the chemprop folder (which would be correct). I will open a tap issue too, but to stay compatible with older versions of tap (and until they fix it), I think it would be good to have a workaround.