### PR TITLE
Enable preloading of a model

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Please see [aicures.mit.edu](https://aicures.mit.edu) and the associated [data G
   * [Option 2: Installing from source](#option-2-installing-from-source)
   * [Docker](#docker)
 - [Web Interface](#web-interface)
+- [Within Python](#within-python)
 - [Data](#data)
 - [Training](#training)
   * [Train/Validation/Test Splits](#trainvalidationtest-splits)
@@ -121,6 +122,12 @@ Next, navigate to `chemprop/web` and run `gunicorn --bind {host}:{port} 'wsgi:bu
    * To run this server in the background, add the `--daemon` flag.
    * Arguments including `init_db` and `demo` can be passed with this pattern: `'wsgi:build_app(init_db=True, demo=True)'` 
    * Gunicorn documentation can be found [here](http://docs.gunicorn.org/en/stable/index.html).
+
+## Within Python
+
+For information on the use of Chemprop within a python script, refer to the [Within a python script](https://chemprop.readthedocs.io/en/latest/tutorial.html#within-a-python-script)
+section of the documentation.
+
 
 ## Data
 
@@ -249,6 +256,7 @@ Similar to molecule-, and atom-level features, the bond-level features are scale
 ### Reaction
 
 As an alternative to molecule SMILES, Chemprop can also process atom-mapped reaction SMILES (see [Daylight manual](https://www.daylight.com/meetings/summerschool01/course/basics/smirks.html) for details on reaction SMILES), which consist of three parts denoting reactants, agents and products, separated by ">". Use the option `--reaction` to enable the input of reactions, which transforms the reactants and products of each reaction to the corresponding condensed graph of reaction and changes the initial atom and bond features to hold information from both the reactant and product (option `--reaction_mode reac_prod`), or from the reactant and the difference upon reaction (option `--reaction_mode reac_diff`, default) or from the product and the difference upon reaction (option `--reaction_mode prod_diff`). In reaction mode, Chemprop thus concatenates information to each atomic and bond feature vector, for example, with option `--reaction_mode reac_prod`, each atomic feature vector holds information on the state of the atom in the reactant (similar to default Chemprop), and concatenates information on the state of the atom in the product, so that the size of the D-MPNN increases slightly. Agents are discarded. Functions incompatible with a reaction as input (scaffold splitting and feature generation) are carried out on the reactants only. If the atom-mapped reaction SMILES contain mapped hydrogens, enable explicit hydrogens via `--explicit_h`. Example of an atom-mapped reaction SMILES denoting the reaction of methanol to formaldehyde without hydrogens: `[CH3:1][OH:2]>>[CH2:1]=[O:2]` and with hydrogens: `[C:1]([H:3])([H:4])([H:5])[O:2][H:6]>>[C:1]([H:3])([H:4])=[O:2].[H:5][H:6]`. The reactions do not need to be balanced and can thus contain unmapped parts, for example leaving groups, if necessary.
+For further details and benchmarking, as well as a citable reference, please see [DOI 10.33774/chemrxiv-2021-frfhz](https://doi.org/10.33774/chemrxiv-2021-frfhz).
 
 ### Pretraining, With and Without Frozen Parameters
 

--- a/chemprop/train/__init__.py
+++ b/chemprop/train/__init__.py
@@ -1,6 +1,6 @@
 from .cross_validate import chemprop_train, cross_validate, TRAIN_LOGGER_NAME
 from .evaluate import evaluate, evaluate_predictions
-from .make_predictions import chemprop_predict, make_predictions
+from .make_predictions import chemprop_predict, make_predictions, load_model
 from .molecule_fingerprint import chemprop_fingerprint, model_fingerprint
 from .predict import predict
 from .run_training import run_training
@@ -15,6 +15,7 @@ __all__ = [
     'chemprop_predict',
     'chemprop_fingerprint',
     'make_predictions',
+    'load_model',
     'predict',
     'run_training',
     'train'


### PR DESCRIPTION
As discussed, here is an (initial, unfinished) PR of enabling model preloading. To test, run a script like:

```python
import chemprop
import time

smiles = [
    ['CC(C)C(C)(C)C'],
    ['Clc1ccc(c(Cl)c1Cl)c2c(Cl)cc(Cl)c(Cl)c2Cl'],
]

# Build arguments
arguments = [
    '--test_path', '/dev/null',
    '--preds_path', '/dev/null',
    '--checkpoint_paths', 'model.pt', #change to your model file or files, or use checkpoint_dir if needed
]

# Parse arguments
args = chemprop.args.PredictArgs().parse_args(arguments)
print(args)

# Run predictions individually
time1=time.time()
for i in range(100):
    preds = chemprop.train.make_predictions(args=args, smiles=smiles)
time2=time.time()
print(time2-time1)
print(preds)

# Run predictions together
time1=time.time()
model_args = chemprop.train.load_model(args=args)
for i in range(100):
    preds = chemprop.train.make_predictions(args=args, smiles=smiles, model_args=model_args)
time2=time.time()
print(time2-time1)
print(preds)

```

I restructured `make_predictions()`, splitting it up to smaller functions, which are also more easy to work with. I exposed `load_model()` in `__init__.py`, but not the other functions (which we might want to do, to let users e.g. also preload data!)

What do you think? This version is still missing docstrings and variable types, I just wanted to hear your thoughts before I go any further.

One downside of the current implementation is that we hold all models in an ensemble in memory, even if we don't preload. I can change that, but it will make the code slightly less pretty.