### PR TITLE
Global featurization params

### DIFF
--- a/chemprop/features/__init__.py
+++ b/chemprop/features/__init__.py
@@ -3,7 +3,7 @@ from .features_generators import get_available_features_generators, get_features
     rdkit_2d_normalized_features_generator, register_features_generator
 from .featurization import atom_features, bond_features, BatchMolGraph, get_atom_fdim, get_bond_fdim, mol2graph, \
     MolGraph, onek_encoding_unk, set_extra_atom_fdim, set_extra_bond_fdim, set_reaction, set_explicit_h, \
-    is_reaction, is_explicit_h
+    is_reaction, is_explicit_h, reset_featurization_parameters
 from .utils import load_features, save_features, load_valid_atom_or_bond_features
 
 __all__ = [
@@ -29,5 +29,6 @@ __all__ = [
     'onek_encoding_unk',
     'load_features',
     'save_features',
-    'load_valid_atom_or_bond_features'
+    'load_valid_atom_or_bond_features',
+    'reset_featurization_parameters'
 ]

--- a/chemprop/features/featurization.py
+++ b/chemprop/features/featurization.py
@@ -6,6 +6,9 @@ import numpy as np
 from chemprop.rdkit import make_mol
 
 class Featurization_parameters:
+    """
+    A class holding molecule featurization parameters as attributes.
+    """
     def __init__(self) -> None:
 
         # Atom feature sizes

--- a/chemprop/features/featurization.py
+++ b/chemprop/features/featurization.py
@@ -1,8 +1,11 @@
 from typing import List, Tuple, Union
 from itertools import zip_longest
+import logging
+
 from rdkit import Chem
 import torch
 import numpy as np
+
 from chemprop.rdkit import make_mol
 
 class Featurization_parameters:
@@ -47,10 +50,15 @@ class Featurization_parameters:
 PARAMS = Featurization_parameters()
 
 
-def reset_featurization_parameters() -> None:
+def reset_featurization_parameters(logger: logging.Logger = None) -> None:
     """
     Function resets feature parameter values to defaults by replacing the parameters instance.
     """
+    if logger is not None:
+        debug = logger.debug
+    else:
+        debug = print
+    debug('Setting molecule featurization parameters to default.')
     global PARAMS
     PARAMS = Featurization_parameters()
 

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -14,7 +14,7 @@ from chemprop.args import TrainArgs
 from chemprop.constants import TEST_SCORES_FILE_NAME, TRAIN_LOGGER_NAME
 from chemprop.data import get_data, get_task_names, MoleculeDataset, validate_dataset_type
 from chemprop.utils import create_logger, makedirs, timeit
-from chemprop.features import set_extra_atom_fdim, set_extra_bond_fdim, set_explicit_h, set_reaction
+from chemprop.features import set_extra_atom_fdim, set_extra_bond_fdim, set_explicit_h, set_reaction, reset_featurization_parameters
 
 
 @timeit(logger_name=TRAIN_LOGGER_NAME)
@@ -61,6 +61,7 @@ def cross_validate(args: TrainArgs,
         args.save(os.path.join(args.save_dir, 'args.json'), with_reproducibility=False)
 
     #set explicit H option and reaction option
+    reset_featurization_parameters()
     set_explicit_h(args.explicit_h)
     set_reaction(args.reaction, args.reaction_mode)
         

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -61,7 +61,7 @@ def cross_validate(args: TrainArgs,
         args.save(os.path.join(args.save_dir, 'args.json'), with_reproducibility=False)
 
     #set explicit H option and reaction option
-    reset_featurization_parameters()
+    reset_featurization_parameters(logger=logger)
     set_explicit_h(args.explicit_h)
     set_reaction(args.reaction, args.reaction_mode)
         

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -10,7 +10,7 @@ from chemprop.spectra_utils import normalize_spectra, roundrobin_sid
 from chemprop.args import PredictArgs, TrainArgs
 from chemprop.data import get_data, get_data_from_smiles, MoleculeDataLoader, MoleculeDataset, StandardScaler
 from chemprop.utils import load_args, load_checkpoint, load_scalers, makedirs, timeit, update_prediction_args
-from chemprop.features import set_extra_atom_fdim, set_extra_bond_fdim, set_reaction, set_explicit_h
+from chemprop.features import set_extra_atom_fdim, set_extra_bond_fdim, set_reaction, set_explicit_h, reset_featurization_parameters
 from chemprop.models import MoleculeModel
 
 def load_model(args: PredictArgs, generator: bool = False):
@@ -91,6 +91,8 @@ def set_features(args: PredictArgs, train_args: TrainArgs):
                  loading data and a model and making predictions.
     :param train_args: A :class:`~chemprop.args.TrainArgs` object containing arguments for training the model.
     """
+    reset_featurization_parameters()
+
     if args.atom_descriptors == 'feature':
         set_extra_atom_fdim(train_args.atom_features_size)
 

--- a/chemprop/train/molecule_fingerprint.py
+++ b/chemprop/train/molecule_fingerprint.py
@@ -9,7 +9,7 @@ from chemprop.args import FingerprintArgs, TrainArgs
 from chemprop.data import get_data, get_data_from_smiles, MoleculeDataLoader, MoleculeDataset
 from chemprop.utils import load_args, load_checkpoint, makedirs, timeit, load_scalers, update_prediction_args
 from chemprop.data import MoleculeDataLoader, MoleculeDataset
-from chemprop.features import set_reaction, set_explicit_h
+from chemprop.features import set_reaction, set_explicit_h, reset_featurization_parameters
 from chemprop.models import MoleculeModel
 
 @timeit()
@@ -35,6 +35,7 @@ def molecule_fingerprint(args: FingerprintArgs, smiles: List[List[str]] = None) 
     args: Union[FingerprintArgs, TrainArgs]
 
     #set explicit H option and reaction option
+    reset_featurization_parameters()
     set_explicit_h(train_args.explicit_h)
     set_reaction(train_args.reaction, train_args.reaction_mode)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -718,7 +718,7 @@ class ChempropTests(TestCase):
                 ['--reaction', '--data_path', os.path.join(TEST_DATA_DIR, 'reaction_regression.csv'), '--explicit_h']
          )
     ])
-    def test_z_train_single_task_regression_reaction(self,
+    def test_train_single_task_regression_reaction(self,
                                           name: str,
                                           model_type: str,
                                           expected_score: float,


### PR DESCRIPTION
This PR is after PR #197. Fixes the vector length conflicts in testing caused by running multiple trainings of different types serially in one script.

Changed the global parameters in `featurization.py` to be attributes of a class `Featurization_parameters`. Added a function for resetting the global featurization parameters which is called early in `cross_validate`, `make_predictions`, and `molecule_fingerprints`. Function could also be called separately in python api usage.

There may be a more preferred stylistic approach. Also unclear if the reset function should be added to the `interpret.py` file.