### PR TITLE
Parallel hyperopt

### DIFF
--- a/chemprop/__init__.py
+++ b/chemprop/__init__.py
@@ -13,5 +13,7 @@ import chemprop.utils
 import chemprop.rdkit
 import chemprop.sklearn_predict
 import chemprop.sklearn_train
+import chemprop.spectra_utils
+import chemprop.hyperopt_utils
 
 from chemprop._version import __version__

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -500,7 +500,7 @@ class TrainArgs(CommonArgs):
     def process_args(self) -> None:
         super(TrainArgs, self).process_args()
 
-        global temp_dir  # Prevents the temporary directory from being deleted upon function return
+        global temp_save_dir  # Prevents the temporary directory from being deleted upon function return
 
         # Process SMILES columns
         self.smiles_columns = chemprop.data.utils.preprocess_smiles_columns(
@@ -518,8 +518,8 @@ class TrainArgs(CommonArgs):
 
         # Create temporary directory as save directory if not provided
         if self.save_dir is None:
-            temp_dir = TemporaryDirectory()
-            self.save_dir = temp_dir.name
+            temp_save_dir = TemporaryDirectory()
+            self.save_dir = temp_save_dir.name
 
         # Fix ensemble size if loading checkpoints
         if self.checkpoint_paths is not None and len(self.checkpoint_paths) > 0:
@@ -714,6 +714,24 @@ class HyperoptArgs(TrainArgs):
     """Path to :code:`.json` file where best hyperparameter settings will be written."""
     log_dir: str = None
     """(Optional) Path to a directory where all results of the hyperparameter optimization will be written."""
+    hyperopt_checkpoint_dir: str = None
+    """Path to a directory where hyperopt completed trial data is stored. Hyperopt job will include these trials if restarted.
+    Can also be used to run multiple instances in parallel if they share the same checkpoint directory."""
+    startup_random_iters: int = 10
+    """The initial number of trials that will be randomly specified before TPE algorithm is used to select the rest."""
+    manual_trial_dirs: List[str] = None
+    """Paths to save directories for manually trained models in the same search space as the hyperparameter search.
+    Results will be considered as part of the trial history of the hyperparameter search."""
+
+
+    def process_args(self) -> None:
+        super(HyperoptArgs, self).process_args()
+
+        # Assign log and checkpoint directories if none provided
+        if self.log_dir is None:
+            self.log_dir = self.save_dir
+        if self.hyperopt_checkpoint_dir is None:
+            self.hyperopt_checkpoint_dir = self.log_dir
 
 
 class SklearnTrainArgs(TrainArgs):

--- a/chemprop/constants.py
+++ b/chemprop/constants.py
@@ -5,3 +5,4 @@ HYPEROPT_LOGGER_NAME = 'hyperparameter-optimization'
 # Save file names
 MODEL_FILE_NAME = 'model.pt'
 TEST_SCORES_FILE_NAME = 'test_scores.csv'
+HYPEROPT_SEED_FILE_NAME = 'hyperopt_seeds.txt'

--- a/chemprop/hyperopt_utils.py
+++ b/chemprop/hyperopt_utils.py
@@ -1,0 +1,205 @@
+from chemprop.args import HyperoptArgs
+import os
+import pickle
+from typing import List, Dict
+import csv
+import json
+
+from hyperopt import Trials
+
+from chemprop.constants import HYPEROPT_SEED_FILE_NAME
+from chemprop.utils import makedirs
+
+def merge_trials(trials: Trials, new_trials_data: List[Dict]) -> Trials:
+    """
+    Merge a hyperopt trials object with the contents of another hyperopt trials object.
+
+    :param trials: A hyperopt trials object containing trials data, organized into hierarchical dictionaries.
+    :param trials_data: The contents of a hyperopt trials object, `Trials.trials`.
+    :return: A hyperopt trials object, merged from the two inputs.
+    """
+    max_tid = 0
+    if len(trials.trials) > 0:
+        max_tid = max([trial['tid'] for trial in trials.trials])
+
+    for trial in new_trials_data:
+        tid = trial['tid'] + max_tid + 1 #trial id needs to be unique among this list of ids.
+        hyperopt_trial = Trials().new_trial_docs(
+                tids=[None],
+                specs=[None],
+                results=[None],
+                miscs=[None])
+        hyperopt_trial[0] = trial
+        hyperopt_trial[0]['tid'] = tid
+        hyperopt_trial[0]['misc']['tid'] = tid
+        for key in hyperopt_trial[0]['misc']['idxs'].keys():
+            hyperopt_trial[0]['misc']['idxs'][key] = [tid]
+        trials.insert_trial_docs(hyperopt_trial) 
+        trials.refresh()
+    return trials
+
+
+def load_trials(dir_path: str, previous_trials: Trials = None) -> Trials:
+    """
+    Load in trials from each pickle file in the hyperopt checkpoint directory.
+    Checkpoints are newly loaded in at each iteration to allow for parallel entries
+    into the checkpoint folder by independent hyperoptimization instances.
+
+    :param dir_path: Path to the directory containing hyperopt checkpoint files.
+    :param previous_trials: Any previously generated trials objects that the loaded trials will be merged with.
+    :return: A trials object containing the merged trials from all checkpoint files.
+    """
+
+    # List out all the pickle files in the hyperopt checkpoint directory
+    hyperopt_checkpoint_files = [os.path.join(dir_path, path) for path in os.listdir(dir_path) if '.pkl' in path]
+
+    # Load hyperopt trials object from each file
+    loaded_trials = Trials()
+    if previous_trials is not None:
+        loaded_trials = merge_trials(loaded_trials, previous_trials.trials)
+
+    for path in hyperopt_checkpoint_files:
+        with open(path,'rb') as f:
+            trial = pickle.load(f)
+            loaded_trials = merge_trials(loaded_trials, trial.trials)
+    
+    return loaded_trials
+
+
+def save_trials(dir_path: str, trials: Trials, hyperopt_seed: int) -> None:
+    """
+    Saves hyperopt trial data as a `.pkl` file.
+
+    :param dir_path: Path to the directory containing hyperopt checkpoint files.
+    :param trials: A trials object containing information on a completed hyperopt iteration.
+    """
+    new_fname = f'{hyperopt_seed}.pkl'
+    existing_files = os.listdir(dir_path)
+    if new_fname in existing_files:
+        raise ValueError(f'When saving trial with unique seed {hyperopt_seed}, found that a trial with this seed already exists.')
+    pickle.dump(trials, open(os.path.join(dir_path, new_fname), 'wb'))
+
+
+def get_hyperopt_seed(seed: int, dir_path: str) -> int:
+    """
+    Assigns a seed for hyperopt calculations. Each iteration will start with a different seed.
+
+    :param seed: The initial attempted hyperopt seed.
+    :param dir_path: Path to the directory containing hyperopt checkpoint files.
+    :return: An integer for use as hyperopt random seed.
+    """
+
+    seed_path = os.path.join(dir_path,HYPEROPT_SEED_FILE_NAME)
+    
+    seeds = []
+    if os.path.exists(seed_path):
+        with open(seed_path, 'r') as f:
+            seed_line = next(f)
+            seeds.extend(seed_line.split())
+    else:
+        makedirs(seed_path, isfile=True)
+
+    seeds = [int(sd) for sd in seeds]
+
+    while seed in seeds:
+        seed += 1
+    seeds.append(seed)
+
+    write_line = " ".join(map(str, seeds)) + '\n'
+
+    with open(seed_path, 'w') as f:
+        f.write(write_line)
+    
+    return seed
+
+
+def load_manual_trials(manual_trials_dirs: List[str], param_keys: List[str], hyperopt_args: HyperoptArgs) -> Trials:
+    """
+    Function for loading in manual training runs as trials for inclusion in hyperparameter search.
+    Trials must be consistent in all arguments with trials that would be generated in hyperparameter optimization.
+
+    :param manual_trials_dirs: A list of paths to save directories for the manual trials, as would include test_scores.csv and args.json.
+    :param param_keys: A list of the parameters included in the hyperparameter optimization.
+    :param hyperopt_args: The arguments for the hyperparameter optimization job.
+    :return: A hyperopt trials object including all the loaded manual trials.
+    """
+    matching_args = [ # manual trials must occupy the same space as the hyperparameter optimization search. This is a non-extensive list of arguments to check to see if they are consistent.
+        'number_of_molecules',
+        'aggregation',
+        'num_folds',
+        'ensemble_size',
+        'max_lr',
+        'init_lr',
+        'final_lr',
+        'activation',
+        'metric',
+        'bias',
+        'epochs',
+        'explicit_h',
+        'reaction',
+        'split_type',
+        'warmup_epochs',
+    ]
+
+    manual_trials_data = []
+    for i, trial_dir in enumerate(manual_trials_dirs):
+
+        # Extract trial data from test_scores.csv
+        with open(os.path.join(trial_dir, 'test_scores.csv')) as f:
+            reader=csv.reader(f)
+            next(reader)
+            read_line=next(reader)
+        mean_score = float(read_line[1])
+        std_score = float(read_line[2])
+        loss = (1 if hyperopt_args.minimize_score else -1) * mean_score
+
+        # Extract argument data from args.json
+        with open(os.path.join(trial_dir, 'args.json')) as f:
+            trial_args = json.load(f)
+
+        # Check for differences in manual trials and hyperopt space
+        if 'hidden_size' in param_keys:
+            if trial_args['hidden_size'] != trial_args['ffn_hidden_size']:
+                raise ValueError(f'The manual trial in {trial_dir} has a hidden_size {trial_args["hidden_size"]} '
+                f'that does not match its ffn_hidden_size {trial_args["ffn_hidden_size"]}, as it would in hyperparameter search.')
+        for arg in matching_args:
+            if arg not in param_keys:
+                if getattr(hyperopt_args,arg) != trial_args[arg]:
+                    raise ValueError(f'Manual trial {trial_dir} has different training argument {arg} than the hyperparameter optimization search trials.')
+
+        # Construct data dict
+        param_dict = {key: trial_args[key] for key in param_keys}
+        vals_dict = {key: [param_dict[key]] for key in param_keys}
+        idxs_dict = {key: [i] for key in param_keys}
+        results_dict = {
+            'loss': loss,
+            'status': 'ok',
+            'mean_score': mean_score,
+            'std_score': std_score,
+            'hyperparams': param_dict,
+            'num_params': 0,
+        }
+        misc_dict = {
+            'tid': i,
+            'cmd': ('domain_attachment', 'FMinIter_Domain'),
+            'workdir': None,
+            'idxs': idxs_dict,
+            'vals': vals_dict,
+        }
+        trial_data = {
+            'state': 2,
+            'tid': i,
+            'spec': None,
+            'result': results_dict,
+            'misc': misc_dict,
+            'exp_key': None,
+            'owner': None,
+            'version': 0,
+            'book_time': None,
+            'refresh_time': None,
+        }
+        manual_trials_data.append(trial_data)
+
+    trials = Trials()
+    trials = merge_trials(trials=trials, new_trials_data=manual_trials_data)
+    return trials

--- a/chemprop/hyperparameter_optimization.py
+++ b/chemprop/hyperparameter_optimization.py
@@ -4,8 +4,9 @@ from copy import deepcopy
 import json
 from typing import Dict, Union
 import os
+from functools import partial
 
-from hyperopt import fmin, hp, tpe
+from hyperopt import fmin, hp, tpe, Trials
 import numpy as np
 
 from chemprop.args import HyperoptArgs
@@ -14,6 +15,7 @@ from chemprop.models import MoleculeModel
 from chemprop.nn_utils import param_count
 from chemprop.train import cross_validate, run_training
 from chemprop.utils import create_logger, makedirs, timeit
+from chemprop.hyperopt_utils import merge_trials, load_trials, save_trials, get_hyperopt_seed, load_manual_trials
 
 
 SPACE = {
@@ -45,11 +47,18 @@ def hyperopt(args: HyperoptArgs) -> None:
     # Create logger
     logger = create_logger(name=HYPEROPT_LOGGER_NAME, save_dir=args.log_dir, quiet=True)
 
-    # Run grid search
-    results = []
+    # Load in manual trials
+    if args.manual_trial_dirs is not None:
+        manual_trials = load_manual_trials(args.manual_trial_dirs, SPACE.keys(), args)
+        logger.info(f'{len(manual_trials)} manual trials included in hyperparameter search.')
+    else:
+        manual_trials = None
+        logger.info('No manual trials loaded as part of hyperparameter search')
+
+    makedirs(args.hyperopt_checkpoint_dir)
 
     # Define hyperparameter optimization
-    def objective(hyperparams: Dict[str, Union[int, float]]) -> float:
+    def objective(hyperparams: Dict[str, Union[int, float]], seed: int) -> Dict:
         # Convert hyperparams from float to int when necessary
         for key in INT_KEYS:
             hyperparams[key] = int(hyperparams[key])
@@ -67,24 +76,16 @@ def hyperopt(args: HyperoptArgs) -> None:
 
         hyper_args.ffn_hidden_size = hyper_args.hidden_size
 
-        # Record hyperparameters
-        logger.info(hyperparams)
-
         # Cross validate
         mean_score, std_score = cross_validate(args=hyper_args, train_func=run_training)
 
         # Record results
         temp_model = MoleculeModel(hyper_args)
         num_params = param_count(temp_model)
+        logger.info(f'Trial results with seed {seed}')
+        logger.info(hyperparams)
         logger.info(f'num params: {num_params:,}')
         logger.info(f'{mean_score} +/- {std_score} {hyper_args.metric}')
-
-        results.append({
-            'mean_score': mean_score,
-            'std_score': std_score,
-            'hyperparams': hyperparams,
-            'num_params': num_params
-        })
 
         # Deal with nan
         if np.isnan(mean_score):
@@ -93,14 +94,57 @@ def hyperopt(args: HyperoptArgs) -> None:
             else:
                 raise ValueError('Can\'t handle nan score for non-classification dataset.')
 
-        return (1 if hyper_args.minimize_score else -1) * mean_score
+        loss = (1 if hyper_args.minimize_score else -1) * mean_score
 
-    fmin(objective, SPACE, algo=tpe.suggest, max_evals=args.num_iters, rstate=np.random.RandomState(args.seed))
+        return {
+            'loss': loss,
+            'status': 'ok',
+            'mean_score': mean_score,
+            'std_score': std_score,
+            'hyperparams': hyperparams,
+            'num_params': num_params,
+            'seed': seed,
+        }
+
+    # Iterate over a number of trials
+    for i in range(args.num_iters):
+        # run fmin and load trials in single steps to allow for parallel operation
+        trials = load_trials(dir_path=args.hyperopt_checkpoint_dir, previous_trials=manual_trials)
+        if len(trials) >= args.num_iters:
+            break
+
+        # Set a unique random seed for each trial. Pass it into objective function for logging purposes.
+        hyperopt_seed = get_hyperopt_seed(seed=args.seed, dir_path=args.hyperopt_checkpoint_dir)
+        fmin_objective = partial(objective, seed=hyperopt_seed)
+
+        # Log the start of the trial
+        logger.info(f'Initiating trial with seed {hyperopt_seed}')
+        logger.info(f'Loaded {len(trials)} previous trials')
+        if len(trials) < args.startup_random_iters:
+            random_remaining = args.startup_random_iters - len(trials)
+            logger.info(f'Parameters assigned with random search, {random_remaining} random trials remaining')
+        else:
+            logger.info(f'Parameters assigned with TPE directed search')
+
+        fmin(
+            fmin_objective,
+            SPACE,
+            algo=partial(tpe.suggest, n_startup_jobs=args.startup_random_iters),
+            max_evals=len(trials) + 1,
+            trials=trials,
+            rstate=np.random.RandomState(hyperopt_seed),
+        )
+
+        # Create a trials object with only the last instance by merging the last data with an empty trials object
+        last_trial = merge_trials(Trials(), [trials.trials[-1]])
+        save_trials(args.hyperopt_checkpoint_dir, last_trial, hyperopt_seed)
 
     # Report best result
+    all_trials = load_trials(dir_path=args.hyperopt_checkpoint_dir, previous_trials=manual_trials)
+    results = all_trials.results
     results = [result for result in results if not np.isnan(result['mean_score'])]
     best_result = min(results, key=lambda result: (1 if args.minimize_score else -1) * result['mean_score'])
-    logger.info('best')
+    logger.info(f'Best trial, with seed {best_result["seed"]}')
     logger.info(best_result['hyperparams'])
     logger.info(f'num params: {best_result["num_params"]:,}')
     logger.info(f'{best_result["mean_score"]} +/- {best_result["std_score"]} {args.metric}')


### PR DESCRIPTION
Added checkpoint functions hyperparameter optimization to allow hyperopt to 1) be restarted after failing 2) start again after normal termination but adding additional iterations, and 3) run with multiple instances in parallel adding checkpoints to the same directory. Also added a feature to change the number of random iterations before guided suggestions are supplied.

Potential to add an additional feature to make trial histories out of previous runs that were done outside of hyperopt, but that has more edge cases with weird behavior than these other features so am leaving this off for now.