### PR TITLE
pip bugfix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-	mamba-version: "*"
+        mamba-version: "*"
         environment-file: environment.yml
 
         channels: conda-forge, defaults


### PR DESCRIPTION
This is a dummy pr to test why GitHub actions fails to install Chemprop correctly. Recently, Pip updated to version 10 and some of its behavior changed. I have a few ideas how to fix the problem, and am trying them here.