### PR TITLE
Add smiles selection to loading atom/bond features

### DIFF
--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -79,6 +79,7 @@ def load_valid_atom_or_bond_features(path: str, smiles: List[str]) -> List[np.nd
 
     elif extension in ['.pkl', '.pckl', '.pickle']:
         features_df = pd.read_pickle(path)
+        features_df = features_df.loc[smiles]
         if features_df.iloc[0, 0].ndim == 1:
             features = features_df.apply(lambda x: np.stack(x.tolist(), axis=1), axis=1).tolist()
         elif features_df.iloc[0, 0].ndim == 2:

--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -67,7 +67,8 @@ def load_valid_atom_or_bond_features(path: str, smiles: List[str]) -> List[np.nd
     * :code:`.pkl` / :code:`.pckl` / :code:`.pickle` containing a pandas dataframe with smiles as index and numpy array of descriptors as columns
     * :code:'.sdf' containing all mol blocks with descriptors as entries
 
-    :param path: Path to file containing atomwise features.
+    :param path: Path to file containing atomwise or bondwise features.
+    :param smiles: List of smiles strings associated with features to be loaded. May be only a subset of the molecules stored in the features file.
     :return: A list of 2D array.
     """
 
@@ -76,6 +77,8 @@ def load_valid_atom_or_bond_features(path: str, smiles: List[str]) -> List[np.nd
     if extension == '.npz':
         container = np.load(path)
         features = [container[key] for key in container]
+        if len(features) != len(smiles):
+            raise ValueError(f'Different number of valid smiles than features in {path}. Features saved in npz files cannot be filtered to include only valid molecules. When using npz, all molecule datapoints must be valid and in the order corresponding to the features file.')
 
     elif extension in ['.pkl', '.pckl', '.pickle']:
         features_df = pd.read_pickle(path)


### PR DESCRIPTION
During loading of features for datasets, there is a filter applied for valid smiles and molecules where there are targets present. Features are only associated with valid datapoints, and invalid datapoints are excluded from the dataset.

This functionality does not currently work for atom specific features. Currently they load all atomic features in the pandas dataframe without filtering and then apply them to a filtered list of molecules, leading to mismatches. This change filters the features loaded by valid smiles.