### PR TITLE
correction adding_h option

### DIFF
--- a/chemprop/rdkit.py
+++ b/chemprop/rdkit.py
@@ -11,9 +11,8 @@ def make_mol(s: str, keep_h: bool, add_h: bool):
     if keep_h:
         mol = Chem.MolFromSmiles(s, sanitize = False)
         Chem.SanitizeMol(mol, sanitizeOps = Chem.SanitizeFlags.SANITIZE_ALL^Chem.SanitizeFlags.SANITIZE_ADJUSTHS)
-    elif add_h:
-        mol = Chem.MolFromSmiles(s)
-        mol = Chem.AddHs(mol)
     else:
         mol = Chem.MolFromSmiles(s)
+    if add_h:
+        mol = Chem.AddHs(mol)
     return mol


### PR DESCRIPTION
Fix for adding_h option making explicit_h (keeping hydrogens from input smiles) and adding_h (adding hydrogens to input smiles) separate, as we might need both for some edge cases in reaction mode.