### PR TITLE
Fixed reshape error for invalid smiles

### DIFF
--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -208,8 +208,8 @@ def predict_and_save(args: PredictArgs, train_args: TrainArgs, test_data: Molecu
         if args.dataset_type == 'multiclass':
             if isinstance(preds, np.ndarray) and preds.ndim > 1:
                 preds = preds.reshape((num_tasks))
-            if args.ensemble_variance or args. individual_ensemble_predictions:
-                ind_preds = ind_preds.reshape((num_tasks, len(args.checkpoint_paths)))
+                if args.ensemble_variance or args. individual_ensemble_predictions:
+                    ind_preds = ind_preds.reshape((num_tasks, len(args.checkpoint_paths)))
 
         # If extra columns have been dropped, add back in SMILES columns
         if args.drop_extra_columns:

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -206,7 +206,8 @@ def predict_and_save(args: PredictArgs, train_args: TrainArgs, test_data: Molecu
 
         # Reshape multiclass to merge task and class dimension, with updated num_tasks
         if args.dataset_type == 'multiclass':
-            preds = preds.reshape((num_tasks))
+            if isinstance(preds, np.ndarray) and preds.ndim > 1:
+                preds = preds.reshape((num_tasks))
             if args.ensemble_variance or args. individual_ensemble_predictions:
                 ind_preds = ind_preds.reshape((num_tasks, len(args.checkpoint_paths)))
 


### PR DESCRIPTION
When using models to predict on a multiclass task or several tasks if the smiles are invalid then they are replaced with a list containing 'Invalid SMILES' as the number of tasks.

Then when the tasks are multiclass it tries to reshape the list from a 2-dimensional array shape: (num_tasks, num_classes) to a 1-d array but press contains a list and not a ndarray anymore. This raises a value and prevents using chemprop_predict on multiclass tasks with SMILES that may be invalid.

I added a simple check before executing the reshape to check if preds is a ndarray and if the number of dimensions it has is larger than one so we'll not reshape an already 1-d array.