### PR TITLE
Output options for make_predictions

### DIFF
--- a/chemprop/data/__init__.py
+++ b/chemprop/data/__init__.py
@@ -1,29 +1,10 @@
-from .data import (
-    cache_graph,
-    cache_mol,
-    MoleculeDatapoint,
-    MoleculeDataset,
-    MoleculeDataLoader,
-    MoleculeSampler,
-    set_cache_graph,
-    empty_cache,
-    set_cache_mol
-)
+from .data import cache_graph, cache_mol, MoleculeDatapoint, MoleculeDataset, MoleculeDataLoader, \
+    MoleculeSampler, set_cache_graph, empty_cache, set_cache_mol
 from .scaffold import generate_scaffold, log_scaffold_stats, scaffold_split, scaffold_to_smiles
 from .scaler import StandardScaler
-from .utils import (
-    filter_invalid_smiles,
-    get_class_sizes,
-    get_data,
-    get_data_from_smiles,
-    get_header,
-    get_smiles,
-    get_task_names,
-    preprocess_smiles_columns,
-    split_data,
-    validate_data,
-    validate_dataset_type,
-)
+from .utils import filter_invalid_smiles, get_class_sizes, get_data, get_data_from_smiles, \
+    get_header, get_smiles, get_task_names, get_data_weights, preprocess_smiles_columns, split_data, \
+    validate_data, validate_dataset_type, get_invalid_smiles_from_file, get_invalid_smiles_from_list
 
 __all__ = [
     'cache_graph',
@@ -44,6 +25,9 @@ __all__ = [
     'get_class_sizes',
     'get_data',
     'get_data_from_smiles',
+    'get_data_weights',
+    'get_invalid_smiles_from_file',
+    'get_invalid_smiles_from_list',
     'get_header',
     'get_smiles',
     'get_task_names',

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -109,7 +109,8 @@ def set_features(args: PredictArgs, train_args: TrainArgs):
 
 def predict_and_save(args: PredictArgs, train_args: TrainArgs, test_data: MoleculeDataset,
                      task_names: List[str], num_tasks: int, test_data_loader: MoleculeDataLoader, full_data: MoleculeDataset,
-                     full_to_valid_indices: dict, models: List[MoleculeModel], scalers: List[List[StandardScaler]]):
+                     full_to_valid_indices: dict, models: List[MoleculeModel], scalers: List[List[StandardScaler]],
+                     return_invalid_smiles: bool = False):
     """
     Function to predict with a model and save the predictions to file.
 
@@ -124,6 +125,7 @@ def predict_and_save(args: PredictArgs, train_args: TrainArgs, test_data: Molecu
     :param full_to_valid_indices: A dictionary dictionary mapping full to valid indices.
     :param models: A list or generator object of :class:`~chemprop.models.MoleculeModel`\ s.
     :param scalers: A list or generator object of :class:`~chemprop.features.scaler.StandardScaler` objects.
+    :param return_invalid_smiles: Whether to return predictions of "Invalid SMILES" for invalid SMILES, otherwise will skip them in returned predictions.
     :return:  A list of lists of target predictions.
     """
     # Predict with each model individually and sum predictions
@@ -243,14 +245,25 @@ def predict_and_save(args: PredictArgs, train_args: TrainArgs, test_data: Molecu
         for datapoint in full_data:
             writer.writerow(datapoint.row)
 
+    # Return predicted values
     avg_preds = avg_preds.tolist()
     
-    return avg_preds
+    if return_invalid_smiles:
+        full_preds = []
+        for full_index in range(len(full_data)):
+            valid_index = full_to_valid_indices.get(full_index, None)
+            preds = avg_preds[valid_index] if valid_index is not None else ['Invalid SMILES'] * num_tasks
+            full_preds.append(preds)
+        return full_preds
+    else:
+        return avg_preds
 
 
 @timeit()
 def make_predictions(args: PredictArgs, smiles: List[List[str]] = None,
-                     model_objects: Tuple[PredictArgs, TrainArgs, List[MoleculeModel], List[StandardScaler], int, List[str]] = None) -> List[List[Optional[float]]]:
+                     model_objects: Tuple[PredictArgs, TrainArgs, List[MoleculeModel], List[StandardScaler], int, List[str]] = None,
+                     return_invalid_smiles: bool = True,
+                     return_index_dict: bool = False) -> List[List[Optional[float]]]:
     """
     Loads data and a trained model and uses the model to make predictions on the data.
 
@@ -261,6 +274,8 @@ def make_predictions(args: PredictArgs, smiles: List[List[str]] = None,
                  loading data and a model and making predictions.
     :param smiles: List of list of SMILES to make predictions on.
     :param model_objects: Tuple of output of load_model function which can be called separately.
+    :param return_invalid_smiles: Whether to return predictions of "Invalid SMILES" for invalid SMILES, otherwise will skip them in returned predictions.
+    :param return_index_dict: Whether to return the prediction results as a dictionary keyed from the initial data indexes.
     :return: A list of lists of target predictions.
     """
     if model_objects:
@@ -270,15 +285,39 @@ def make_predictions(args: PredictArgs, smiles: List[List[str]] = None,
         
     set_features(args, train_args)
     
+    # Note: to get the invalid SMILES for your data, use the get_invalid_smiles_from_file or get_invalid_smiles_from_list functions from data/utils.py
     full_data, test_data, test_data_loader, full_to_valid_indices = load_data(args, smiles)
     
     # Edge case if empty list of smiles is provided
     if len(test_data) == 0:
-        return [None] * len(full_data)
+        avg_preds = [None] * len(full_data)
+    else:
+        avg_preds = predict_and_save(
+            args=args,
+            train_args=train_args,
+            test_data=test_data,
+            task_names=task_names,
+            num_tasks=num_tasks,
+            test_data_loader=test_data_loader,
+            full_data=full_data,
+            full_to_valid_indices=full_to_valid_indices,
+            models=models,
+            scalers=scalers,
+            return_invalid_smiles=return_invalid_smiles,
+        )
     
-    avg_preds = predict_and_save(args, train_args, test_data, task_names, num_tasks, test_data_loader, full_data, full_to_valid_indices, models, scalers)
-    
-    return avg_preds
+    if return_index_dict:
+        preds_dict = {}
+        for i in range(len(full_data)):
+            if return_invalid_smiles:
+                preds_dict[i] = avg_preds[i]
+            else:
+                valid_index = full_to_valid_indices.get(i, None)
+                if valid_index is not None:
+                    preds_dict[i] = avg_preds[valid_index]
+        return preds_dict
+    else:
+        return avg_preds
 
 
 def chemprop_predict() -> None:

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -13,6 +13,7 @@ from chemprop.utils import load_args, load_checkpoint, load_scalers, makedirs, t
 from chemprop.features import set_extra_atom_fdim, set_extra_bond_fdim, set_reaction, set_explicit_h, set_adding_hs, reset_featurization_parameters
 from chemprop.models import MoleculeModel
 
+
 def load_model(args: PredictArgs, generator: bool = False):
     """
     Function to load a model or ensemble of models from file. If generator is True, a generator of the respective model and scaler 
@@ -39,7 +40,8 @@ def load_model(args: PredictArgs, generator: bool = False):
         scalers = list(scalers)
 
     return args, train_args, models, scalers, num_tasks, task_names
-                      
+
+
 def load_data(args: PredictArgs, smiles: List[List[str]]):
     """
     Function to load data from a list of smiles or a file.
@@ -245,7 +247,7 @@ def predict_and_save(args: PredictArgs, train_args: TrainArgs, test_data: Molecu
     
     return avg_preds
 
-            
+
 @timeit()
 def make_predictions(args: PredictArgs, smiles: List[List[str]] = None,
                      model_objects: Tuple[PredictArgs, TrainArgs, List[MoleculeModel], List[StandardScaler], int, List[str]] = None) -> List[List[Optional[float]]]:


### PR DESCRIPTION
User noted that for the make_predictions function, invalid SMILES can be included in the arguments but the returned values will exclude the invalid entries without any notation of which ones are invalid. The default behavior before for the values saved to file has always been to include the entries with invalid SMILES with prediction values of "Invalid SMILES". Following the refactoring of make_predictions in #200, it's more accessible than before to use this function directly and so it's now more obvious that the saved behavior and the function return behavior do not match.

I've added two new options to the make_predictions function.

- `return_invalid_smiles`. This option indicates whether to include predictions for invalid datapoints, with the value "Invalid SMILES" in the function return. This makes it consistent with the saved value behavior. This option has been set default to True. The previous behavior before the option would have been False.
- `return_index_dict`. This option indicates whether to return a dictionary keyed with the index of the initial dataset or smiles list for the predictions rather than a list of list of values. This option defaults to False. If `return_invalid_smiles` is set to False, the invalid index values will be missing from the returned dictionary.