### PR TITLE
remove `assert`s

### DIFF
--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -535,7 +535,11 @@ class MoleculeDataset(Dataset):
         :param targets: A list of lists of floats (or None) containing targets for each molecule. This must be the
                         same length as the underlying dataset.
         """
-        assert len(self._data) == len(targets)
+        if not len(self._data) == len(targets):
+            raise ValueError(
+                "number of molecules and targets must be of same length! "
+                f"num molecules: {len(self._data)}, num targets: {len(targets)}"
+            )
         for i in range(len(self._data)):
             self._data[i].set_targets(targets[i])
 

--- a/chemprop/data/scaffold.py
+++ b/chemprop/data/scaffold.py
@@ -70,7 +70,6 @@ def scaffold_split(data: MoleculeDataset,
     :return: A tuple of :class:`~chemprop.data.MoleculeDataset`\ s containing the train,
              validation, and test splits of the data.
     """
-    #TODO(degraff): floating point math could mess this up
     if not (len(sizes) == 3 and np.isclose(sum(sizes), 1)):
         raise ValueError(f"Invalid train/val/test splits! got: {sizes}")
 

--- a/chemprop/data/scaffold.py
+++ b/chemprop/data/scaffold.py
@@ -71,8 +71,8 @@ def scaffold_split(data: MoleculeDataset,
              validation, and test splits of the data.
     """
     #TODO(degraff): floating point math could mess this up
-    if sum(sizes) != 1:
-        raise ValueError(f"train/val/test fractions must add up to 1! got: {sizes}")
+    if not (len(sizes) == 3 and np.isclose(sum(sizes), 1)):
+        raise ValueError(f"Invalid train/val/test splits! got: {sizes}")
 
     # Split
     train_size, val_size, test_size = sizes[0] * len(data), sizes[1] * len(data), sizes[2] * len(data)

--- a/chemprop/data/scaffold.py
+++ b/chemprop/data/scaffold.py
@@ -70,7 +70,9 @@ def scaffold_split(data: MoleculeDataset,
     :return: A tuple of :class:`~chemprop.data.MoleculeDataset`\ s containing the train,
              validation, and test splits of the data.
     """
-    assert sum(sizes) == 1
+    #TODO(degraff): floating point math could mess this up
+    if sum(sizes) != 1:
+        raise ValueError(f"train/val/test fractions must add up to 1! got: {sizes}")
 
     # Split
     train_size, val_size, test_size = sizes[0] * len(data), sizes[1] * len(data), sizes[2] * len(data)

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -506,8 +506,8 @@ def split_data(data: MoleculeDataset,
     :return: A tuple of :class:`~chemprop.data.MoleculeDataset`\ s containing the train,
              validation, and test splits of the data.
     """
-    if not (len(sizes) == 3 and sum(sizes) == 1):
-        raise ValueError('Valid split sizes must sum to 1 and must have three sizes: train, validation, and test.')
+    if not (len(sizes) == 3 and np.isclose(sum(sizes), 1)):
+        raise ValueError(f"Invalid train/val/test splits! got: {sizes}")
 
     random = Random(seed)
 

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -571,8 +571,10 @@ def split_data(data: MoleculeDataset,
             raise ValueError('Test size must be zero since test set is created separately '
                              'and we want to put all other data in train and validation')
 
-        assert folds_file is not None
-        assert test_fold_index is not None
+        if folds_file is None:
+            raise ValueError('arg "folds_file" can not be None!')
+        if test_fold_index is None:
+            raise ValueError('arg "test_fold_index" can not be None!')
 
         try:
             with open(folds_file, 'rb') as f:

--- a/chemprop/nn_utils.py
+++ b/chemprop/nn_utils.py
@@ -140,8 +140,19 @@ class NoamLR(_LRScheduler):
         :param max_lr: The maximum learning rate (achieved after :code:`warmup_epochs`).
         :param final_lr: The final learning rate (achieved after :code:`total_epochs`).
         """
-        assert len(optimizer.param_groups) == len(warmup_epochs) == len(total_epochs) == len(init_lr) == \
-               len(max_lr) == len(final_lr)
+        if not (
+            len(optimizer.param_groups) == len(warmup_epochs) == len(total_epochs) \
+            == len(init_lr) == len(max_lr) == len(final_lr)
+        ):
+            raise ValueError(
+                "Number of param groups must match the number of epochs and learning rates! "
+                f"got: len(optimizer.param_groups)= {len(optimizer.param_groups)}, "
+                f"len(warmup_epochs)= {len(warmup_epochs)}, "
+                f"len(total_epochs)= {len(total_epochs)}, "
+                f"len(init_lr)= {len(init_lr)}, "
+                f"len(max_lr)= {len(max_lr)}, "
+                f"len(final_lr)= {len(final_lr)}"
+            )
 
         self.num_lrs = len(optimizer.param_groups)
 

--- a/chemprop/sklearn_predict.py
+++ b/chemprop/sklearn_predict.py
@@ -57,7 +57,7 @@ def predict_sklearn(args: SklearnPredictArgs) -> None:
     avg_preds = avg_preds.tolist()
 
     print(f'Saving predictions to {args.preds_path}')
-    # assert len(data) == len(avg_preds)
+    # assert len(data) == len(avg_preds)    #TODO: address with unit test later
     makedirs(args.preds_path, isfile=True)
 
     # Copy predictions over to data

--- a/chemprop/sklearn_predict.py
+++ b/chemprop/sklearn_predict.py
@@ -57,7 +57,7 @@ def predict_sklearn(args: SklearnPredictArgs) -> None:
     avg_preds = avg_preds.tolist()
 
     print(f'Saving predictions to {args.preds_path}')
-    assert len(data) == len(avg_preds)
+    # assert len(data) == len(avg_preds)
     makedirs(args.preds_path, isfile=True)
 
     # Copy predictions over to data

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -189,9 +189,10 @@ def predict_and_save(args: PredictArgs, train_args: TrainArgs, test_data: Molecu
 
     # Save predictions
     print(f'Saving predictions to {args.preds_path}')
-    assert len(test_data) == len(avg_preds)
-    if args.ensemble_variance:
-        assert len(test_data) == len(all_epi_uncs)
+    #TODO: add unit tests for this
+    # assert len(test_data) == len(avg_preds)
+    # if args.ensemble_variance:
+        # assert len(test_data) == len(all_epi_uncs)
     makedirs(args.preds_path, isfile=True)
 
     # Set multiclass column names, update num_tasks definition for multiclass

--- a/chemprop/train/molecule_fingerprint.py
+++ b/chemprop/train/molecule_fingerprint.py
@@ -132,7 +132,7 @@ def molecule_fingerprint(args: FingerprintArgs, smiles: List[List[str]] = None) 
 
     # Save predictions
     print(f'Saving predictions to {args.preds_path}')
-    assert len(test_data) == len(all_fingerprints)
+    # assert len(test_data) == len(all_fingerprints) #TODO: add unit test for this
     makedirs(args.preds_path, isfile=True)
 
     # Set column names


### PR DESCRIPTION
## Description
This PR removes some of the `assert`s in the codebase that were used to validate function inputs and has replaced them with `ValueError`s. `assert`s are fine for sanity checking output, but should generally be avoided as they slow down code and can typically be replaced by more appropriate error checking.

## Questions
This PR **does not** add new validation code. It just changes any `assert`s that were clearly for argument validation to `ValueError`s. There are a few `TODO`s in this PR too because there were some `assert`s that are more accurately described as unit tests.

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
