### PR TITLE
Refactor/featurization params

### DIFF
--- a/chemprop/data/scaffold.py
+++ b/chemprop/data/scaffold.py
@@ -156,7 +156,7 @@ def log_scaffold_stats(data: MoleculeDataset,
     index_sets = sorted(index_sets, key=lambda idx_set: len(idx_set), reverse=True)
     for scaffold_num, index_set in enumerate(index_sets[:num_scaffolds]):
         data_set = [data[i] for i in index_set]
-        targets = np.array([d.targets for d in data_set], dtype=np.float)
+        targets = np.array([d.targets for d in data_set], dtype=float)
 
         with warnings.catch_warnings():  # Likely warning of empty slice of target has no values besides NaN
             warnings.simplefilter('ignore', category=RuntimeWarning)

--- a/chemprop/data/scaffold.py
+++ b/chemprop/data/scaffold.py
@@ -156,7 +156,7 @@ def log_scaffold_stats(data: MoleculeDataset,
     index_sets = sorted(index_sets, key=lambda idx_set: len(idx_set), reverse=True)
     for scaffold_num, index_set in enumerate(index_sets[:num_scaffolds]):
         data_set = [data[i] for i in index_set]
-        targets = np.array([d.targets for d in data_set], dtype=float)
+        targets = np.array([d.targets for d in data_set], dtype=np.float)
 
         with warnings.catch_warnings():  # Likely warning of empty slice of target has no values besides NaN
             warnings.simplefilter('ignore', category=RuntimeWarning)

--- a/chemprop/features/__init__.py
+++ b/chemprop/features/__init__.py
@@ -1,9 +1,11 @@
 from .features_generators import get_available_features_generators, get_features_generator, \
     morgan_binary_features_generator, morgan_counts_features_generator, rdkit_2d_features_generator, \
     rdkit_2d_normalized_features_generator, register_features_generator
-from .featurization import atom_features, bond_features, BatchMolGraph, get_atom_fdim, get_bond_fdim, mol2graph, \
-    MolGraph, onek_encoding_unk, set_extra_atom_fdim, set_extra_bond_fdim, set_reaction, set_explicit_h, \
-    set_adding_hs, is_reaction, is_explicit_h, is_adding_hs, is_mol, reset_featurization_parameters
+from .featurization import (
+    PARAMS, atom_features, bond_features, BatchMolGraph, get_atom_fdim, get_bond_fdim, mol2graph,
+    MolGraph, onek_encoding_unk, set_reaction, is_reaction, is_explicit_h, is_adding_hs, is_mol, 
+    reset_featurization_parameters
+)
 from .utils import load_features, save_features, load_valid_atom_or_bond_features
 
 __all__ = [

--- a/chemprop/features/featurization.py
+++ b/chemprop/features/featurization.py
@@ -1,7 +1,7 @@
 from dataclasses import InitVar, dataclass, field, fields
 from itertools import zip_longest
 import logging
-from typing import Dict, List, Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 from rdkit import Chem
@@ -29,9 +29,9 @@ class AtomFeaturizationParams:
 
     def __post_init__(self, max_atomic_num: int):
         self.atomic_num = list(range(max_atomic_num))
-    
+
     def __len__(self):
-        """the dimension of an atom feature vector, adding 1 to each set of features for uncommon 
+        """the dimension of an atom feature vector, adding 1 to each set of features for uncommon
         values and 2 at the end to account for aromaticity and mass"""
         return sum(len(getattr(self, field.name)) + 1 for field in fields(self)) + 2
 
@@ -60,9 +60,11 @@ class FeaturizationParams:
         )
         self.atom_fdim = len(self.atom_features)
 
-# have to do some wonkiness to max_atomic_num to work as a property
+
+# have to do some wonkiness to get `max_atomic_num` to work as a property
 def get_max_atomic_num(self) -> int:
     return self.__max_atomic_num
+
 
 def set_max_atomic_num(self, max_atomic_num: int):
     self.__max_atomic_num = max_atomic_num
@@ -105,7 +107,7 @@ def get_atom_fdim(overwrite_default_atom: bool = False, is_reaction: bool = Fals
 def set_reaction(reaction: bool, mode: str) -> None:
     """
     Sets whether to use a reaction or molecule as input and adapts feature dimensions.
- 
+
     :param reaction: Boolean whether to except reactions as input.
     :param mode: Reaction mode to construct atom and bond feature vectors.
 
@@ -115,8 +117,8 @@ def set_reaction(reaction: bool, mode: str) -> None:
         PARAMS.extra_atom_fdim = PARAMS.atom_fdim - PARAMS.max_atomic_num - 1
         PARAMS.extra_bond_fdim = PARAMS.bond_fdim
         PARAMS.reaction_mode = mode
-        
-        
+
+
 def is_explicit_h(is_mol: bool = True) -> bool:
     r"""Returns whether to retain explicit Hs (for reactions only)"""
     if not is_mol:
@@ -129,7 +131,7 @@ def is_adding_hs(is_mol: bool = True) -> bool:
     if is_mol:
         return PARAMS.adding_H
     return False
-    
+
 
 def is_reaction(is_mol: bool = True) -> bool:
     r"""Returns whether to use reactions as input"""
@@ -180,7 +182,8 @@ def onek_encoding_unk(value: int, choices: List[int]) -> List[int]:
     return encoding
 
 
-def atom_features(atom: Chem.rdchem.Atom, functional_groups: List[int] = None
+def atom_features(
+    atom: Chem.rdchem.Atom, functional_groups: List[int] = None
 ) -> List[Union[bool, int, float]]:
     """
     Builds a feature vector for an atom.

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -14,7 +14,7 @@ from chemprop.args import TrainArgs
 from chemprop.constants import TEST_SCORES_FILE_NAME, TRAIN_LOGGER_NAME
 from chemprop.data import get_data, get_task_names, MoleculeDataset, validate_dataset_type
 from chemprop.utils import create_logger, makedirs, timeit
-from chemprop.features import set_extra_atom_fdim, set_extra_bond_fdim, set_explicit_h, set_adding_hs, set_reaction, reset_featurization_parameters
+from chemprop.features import PARAMS, set_reaction, reset_featurization_parameters
 
 
 @timeit(logger_name=TRAIN_LOGGER_NAME)
@@ -62,8 +62,8 @@ def cross_validate(args: TrainArgs,
 
     #set explicit H option and reaction option
     reset_featurization_parameters(logger=logger)
-    set_explicit_h(args.explicit_h)
-    set_adding_hs(args.adding_h)
+    PARAMS.explicit_H = args.explicit_h
+    PARAMS.adding_H = args.adding_h
     if args.reaction:
         set_reaction(args.reaction, args.reaction_mode)
     elif args.reaction_solvent:
@@ -86,10 +86,10 @@ def cross_validate(args: TrainArgs,
         args.ffn_hidden_size += args.atom_descriptors_size
     elif args.atom_descriptors == 'feature':
         args.atom_features_size = data.atom_features_size()
-        set_extra_atom_fdim(args.atom_features_size)
+        PARAMS.extra_atom_fdim = args.atom_features_size
     if args.bond_features_path is not None:
         args.bond_features_size = data.bond_features_size()
-        set_extra_bond_fdim(args.bond_features_size)
+        PARAMS.extra_bond_fdim = args.bond_features_size
 
     debug(f'Number of tasks = {args.num_tasks}')
 

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -103,7 +103,7 @@ def set_features(args: PredictArgs, train_args: TrainArgs):
 
     #set explicit H option and reaction option
     PARAMS.explicit_H = train_args.explicit_h
-    PARAMS.adding_H = train_args.adding_h
+    PARAMS.adding_H = args.adding_h
     if train_args.reaction:
         set_reaction(train_args.reaction, train_args.reaction_mode)
     elif train_args.reaction_solvent:

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -10,7 +10,7 @@ from chemprop.spectra_utils import normalize_spectra, roundrobin_sid
 from chemprop.args import PredictArgs, TrainArgs
 from chemprop.data import get_data, get_data_from_smiles, MoleculeDataLoader, MoleculeDataset, StandardScaler
 from chemprop.utils import load_args, load_checkpoint, load_scalers, makedirs, timeit, update_prediction_args
-from chemprop.features import set_extra_atom_fdim, set_extra_bond_fdim, set_reaction, set_explicit_h, set_adding_hs, reset_featurization_parameters
+from chemprop.features import PARAMS, set_reaction, reset_featurization_parameters
 from chemprop.models import MoleculeModel
 
 
@@ -96,14 +96,14 @@ def set_features(args: PredictArgs, train_args: TrainArgs):
     reset_featurization_parameters()
 
     if args.atom_descriptors == 'feature':
-        set_extra_atom_fdim(train_args.atom_features_size)
+        PARAMS.extra_atom_fdim = train_args.atom_features_size
 
     if args.bond_features_path is not None:
-        set_extra_bond_fdim(train_args.bond_features_size)
+        PARAMS.extra_bond_fdim = train_args.bond_features_size
 
     #set explicit H option and reaction option
-    set_explicit_h(train_args.explicit_h)
-    set_adding_hs(args.adding_h)
+    PARAMS.explicit_H = train_args.explicit_h
+    PARAMS.adding_H = train_args.adding_h
     if train_args.reaction:
         set_reaction(train_args.reaction, train_args.reaction_mode)
     elif train_args.reaction_solvent:

--- a/chemprop/train/molecule_fingerprint.py
+++ b/chemprop/train/molecule_fingerprint.py
@@ -9,7 +9,7 @@ from chemprop.args import FingerprintArgs, TrainArgs
 from chemprop.data import get_data, get_data_from_smiles, MoleculeDataLoader, MoleculeDataset
 from chemprop.utils import load_args, load_checkpoint, makedirs, timeit, load_scalers, update_prediction_args
 from chemprop.data import MoleculeDataLoader, MoleculeDataset
-from chemprop.features import set_reaction, set_explicit_h, set_adding_hs, reset_featurization_parameters, set_extra_atom_fdim, set_extra_bond_fdim
+from chemprop.features import PARAMS, set_reaction, reset_featurization_parameters
 from chemprop.models import MoleculeModel
 
 @timeit()
@@ -37,13 +37,13 @@ def molecule_fingerprint(args: FingerprintArgs, smiles: List[List[str]] = None) 
     #set explicit H option and reaction option
     reset_featurization_parameters()
     if args.atom_descriptors == 'feature':
-        set_extra_atom_fdim(train_args.atom_features_size)
+        PARAMS.extra_atom_fdim = train_args.atom_features_size
 
     if args.bond_features_path is not None:
-        set_extra_bond_fdim(train_args.bond_features_size)
+        PARAMS.extra_bond_fdim = train_args.bond_features_size
 
-    set_explicit_h(train_args.explicit_h)
-    set_adding_hs(args.adding_h)
+    PARAMS.explicit_H = train_args.explicit_h
+    PARAMS.adding_H = train_args.adding_h
     if train_args.reaction:
         set_reaction(train_args.reaction, train_args.reaction_mode)
     elif train_args.reaction_solvent:

--- a/chemprop/train/molecule_fingerprint.py
+++ b/chemprop/train/molecule_fingerprint.py
@@ -43,7 +43,7 @@ def molecule_fingerprint(args: FingerprintArgs, smiles: List[List[str]] = None) 
         PARAMS.extra_bond_fdim = train_args.bond_features_size
 
     PARAMS.explicit_H = train_args.explicit_h
-    PARAMS.adding_H = train_args.adding_h
+    PARAMS.adding_H = args.adding_h
     if train_args.reaction:
         set_reaction(train_args.reaction, train_args.reaction_mode)
     elif train_args.reaction_solvent:

--- a/scripts/examine_split_balance.py
+++ b/scripts/examine_split_balance.py
@@ -21,7 +21,7 @@ class Args(Tap):
 
 
 def compute_ratios(data: MoleculeDataset) -> np.ndarray:
-    ratios = np.nanmean(np.array(data.targets(), dtype=np.float), axis=0)
+    ratios = np.nanmean(np.array(data.targets(), dtype=float), axis=0)
     ratios = np.minimum(ratios, 1 - ratios)
 
     return ratios

--- a/scripts/examine_split_balance.py
+++ b/scripts/examine_split_balance.py
@@ -21,7 +21,7 @@ class Args(Tap):
 
 
 def compute_ratios(data: MoleculeDataset) -> np.ndarray:
-    ratios = np.nanmean(np.array(data.targets(), dtype=float), axis=0)
+    ratios = np.nanmean(np.array(data.targets(), dtype=np.float), axis=0)
     ratios = np.minimum(ratios, 1 - ratios)
 
     return ratios

--- a/tests/test_featurization.py
+++ b/tests/test_featurization.py
@@ -1,0 +1,62 @@
+import pytest
+from rdkit.Chem import rdchem
+
+from chemprop.features import featurization
+
+@pytest.fixture(params=[0, 10, 50, 100])
+def max_atomic_num(request):
+    return request.param
+
+@pytest.fixture(params=range(10))
+def atom(request):
+    return rdchem.Atom(request.param + 1)
+
+def test_atom_feat_params_atomic_num(max_atomic_num: int):
+    params = featurization.AtomFeaturizationParams(max_atomic_num)
+
+    assert params.atomic_num == list(range(max_atomic_num))
+
+def test_feat_params_max_atomic_num(max_atomic_num: int):
+    params = featurization.FeaturizationParams(max_atomic_num)
+
+    assert params.atom_features.atomic_num == list(range(max_atomic_num))
+
+def test_feat_params_set_max_atomic_num(max_atomic_num: int):
+    params = featurization.FeaturizationParams()
+    params.max_atomic_num = max_atomic_num
+
+    assert params.max_atomic_num == max_atomic_num
+    assert params.atom_features.atomic_num == list(range(params.max_atomic_num))
+    assert params.atom_fdim == len(params.atom_features)
+
+def test_feat_params_atom_fdim(max_atomic_num: int):
+    params = featurization.FeaturizationParams(max_atomic_num)
+
+    assert params.atom_fdim == len(params.atom_features)
+
+@pytest.mark.parametrize("x", [10, 20, 40])
+def test_reset_featurization(x: int):
+    featurization.PARAMS.max_atomic_num += x
+
+    old_max_atomic_num = featurization.PARAMS.max_atomic_num
+    featurization.reset_featurization_parameters()
+
+    new_max_atomic_num = featurization.PARAMS.max_atomic_num
+
+    assert old_max_atomic_num != new_max_atomic_num
+
+def test_atom_features_None():
+    features = featurization.atom_features(None)
+
+    assert not any(features)
+
+def test_atom_features_zeros(atom):
+    features = featurization.atom_features_zeros(atom)
+    idx = atom.GetAtomicNum() - 1
+
+    assert not any(features[:idx]) and features[idx] and not any(features[idx+1:])
+
+def test_bond_features_None():
+    features = featurization.bond_features(None)
+
+    assert features[0] and not any(features[1:])


### PR DESCRIPTION
## Description
This PR updates the featurization module to use dataclasses to store featurization parameters

## Current status
The featurization module currently uses what amounts to a storage container to organize molecule featurization together

## Updated code
The module has now been switched over to using python dataclasses to store these parameters. Specifically, `Featurization_params` has been moved to `FeaturizationParams` and the former `ATOM_FEATURES` `Dict` attribute has been moved to its own dataclass. This was done for a few reasons:
1. **cleanliness:** there's no need to define a length `__init__` function for data classes
2. **inspectability:** dataclasses support automatic `__repr__` definitions. You can now `print(features.PARAMS)` and it will give you this nicely formatted output:
```python
>>> from chemprop import features
>>> print(features.PARAMS)
FeaturizationParams(max_atomic_num=100,
    atom_features=AtomFeaturizationParams(
        atomic_num=[...], degree=[0, 1, 2, 3, 4, 5], formal_charge=[-1, -2, 1, 2, 0],
        chiral_tag=[0, 1, 2, 3], num_Hs=[0, 1, 2, 3, 4], hybridization=[...]
    ),
    path_distance_bins=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], three_d_distance_max=20, three_d_distance_step=1,
    three_d_distance_bins=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
    atom_fdim=133, extra_atom_fdim=0, bond_fdim=14,
    extra_bond_fdim=0, reaction_mode=None, explicit_H=False, reaction=False, adding_H=False
)
```
3. **typing:** dataclasses support native type annotation, so we can more easily communicate the value/meaning of each attribute

## Additional updates
This PR also introduces some new changes:
- elimination of a few `get_*` and `set_*` functions in the `featurization` module. All these functions did was mutate the global `PARAMS` variable of the `featurization` module, so for cleanliness, I've removed these. I get that there was probably some intention about hiding/obscuring data with these functions, but it's not the way to do it and just made the code harder to read. I've changed all occurrences to now directly mutate the global `PARAMS` variable
- tied `Featurization_params.max_atomic_num` to the `atomic_num` attribute of the `AtomFeaturizationParams`. The two are logically connected, so the former is now a property that updates the latter whenever it is set. There was some lettuce that needed to be introduced to get this to work, but I believe it's worth the (minimal) clutter
- some unit tests
- renaming of attributes. All the attributes of the `Featurization_params` object were named in all caps before. I think this was to indicate that they were intended to be CONSTANT, but this is python, so they weren't and I've renamed them to be lowercase. However, with the dataclass implementation, we can now actually enforce this, if desired (they've currently been left as proper variables.)

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
