### PR TITLE
Bugfix repairing individual ensemble predictions

### DIFF
--- a/chemprop/uncertainty/uncertainty_estimator.py
+++ b/chemprop/uncertainty/uncertainty_estimator.py
@@ -60,6 +60,6 @@ class UncertaintyEstimator:
 
     def individual_predictions(self):
         """
-        
+        Return separate predictions made by each individual model in an ensemble of models.
         """
-        return self.predictor.get_individual_ensemble_predictions()
+        return self.predictor.get_individual_preds()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -413,6 +413,32 @@ class ChempropTests(TestCase):
             pred, true = pred.to_numpy(), true.to_numpy()
             mse = float(np.nanmean((pred - true) ** 2))
             self.assertAlmostEqual(mse, expected_score, delta=DELTA*expected_score)
+    
+    def test_predict_individual_ensemble(self):
+        with TemporaryDirectory() as save_dir:
+            save_dir = f'../test/pred_single_regression/individual_ensemble'
+            # Train
+            dataset_type = 'regression'
+            self.train(
+                dataset_type=dataset_type,
+                metric='rmse',
+                save_dir=save_dir,
+            )
+
+            # Predict
+            preds_path = os.path.join(save_dir, 'preds.csv')
+            self.predict(
+                dataset_type=dataset_type,
+                preds_path=preds_path,
+                save_dir=save_dir,
+                flags=['--individual_ensemble_predictions']
+            )
+
+            pred = pd.read_csv(preds_path)
+            columns = list(pred.columns)
+            expected_columns = ['smiles', 'logSolubility'] + [f'logSolubility_model_{idx}' for idx in range(NUM_FOLDS)]
+            self.assertTrue(columns == expected_columns)
+
 
     @parameterized.expand([
         (


### PR DESCRIPTION
## Description
Recent restructuring of predictions functions with the addition of uncertainty functions introduced a bug in the feature to return the predictions of individual models in an ensemble separately when given the argument `--individual_ensemble_predictions` during prediction functions.

## Example / Current workflow
```
chemprop_train \
--data_path {data-file.csv} \
--dataset_type {type} \
--ensemble_size {int} \
--save_dir save_dir

chemprop_predict \
--test_path {path-to-data} \
--preds_path save_dir/preds.csv \
--checkpoint_dir save_dir \
--individual_ensemble_predictions
```
## Questions
Minor changes are flake8-compliant. Test introduced into integration tests is not flake8, but that formatting would be pending updating the formatting for the rest of flake8 as well.

## Relevant issues
If appropriate, please tag them here and include a quick summary

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
