### PR TITLE
Update default channels in environment.yml and refactor Dockerfile

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,8 @@
 name: chemprop
 
 channels:
-  - conda-forge
   - pytorch
-  - rdkit
+  - conda-forge
 
 dependencies:
   - python>=3.6

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -259,7 +259,6 @@ class ChempropTests(TestCase):
                                           expected_score: float,
                                           train_flags: List[str] = None):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/train_single_regression/{name}'
             # Train
             self.train(
                 dataset_type='regression',
@@ -327,7 +326,6 @@ class ChempropTests(TestCase):
                                              expected_score: float,
                                              train_flags: List[str] = None):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/train_multi_class/{name}'
             # Train
             self.train(
                 dataset_type='classification',
@@ -382,7 +380,6 @@ class ChempropTests(TestCase):
                                             train_flags: List[str] = None,
                                             predict_flags: List[str] = None):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/pred_single_regression/{name}'
             # Train
             dataset_type = 'regression'
             self.train(
@@ -416,7 +413,6 @@ class ChempropTests(TestCase):
     
     def test_predict_individual_ensemble(self):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/pred_single_regression/individual_ensemble'
             # Train
             dataset_type = 'regression'
             self.train(
@@ -468,7 +464,6 @@ class ChempropTests(TestCase):
                                                train_flags: List[str] = None,
                                                predict_flags: List[str] = None):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/pred_multi_class/{name}'
             # Train
             dataset_type = 'classification'
             self.train(
@@ -502,7 +497,6 @@ class ChempropTests(TestCase):
 
     def test_chemprop_hyperopt(self):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/hyperopt'
             # Train
             config_save_path = os.path.join(save_dir, 'config.json')
             self.hyperopt(
@@ -537,7 +531,6 @@ class ChempropTests(TestCase):
                                               train_flags: List[str] = None,
                                               interpret_flags: List[str] = None):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/interpret_single_regression/{name}'
             # Train
             dataset_type = 'regression'
             self.train(
@@ -657,7 +650,6 @@ class ChempropTests(TestCase):
                                           expected_score: float,
                                           train_flags: List[str] = None):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/train_spectra/{name}'
             # Train
             metric = 'sid'
             self.train(
@@ -715,7 +707,6 @@ class ChempropTests(TestCase):
                                             train_flags: List[str] = None,
                                             predict_flags: List[str] = None):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/pred_spectra/{name}'
             # Train
             dataset_type = 'spectra'
             self.train(
@@ -786,7 +777,6 @@ class ChempropTests(TestCase):
                                           expected_score: float,
                                           train_flags: List[str] = None):
         with TemporaryDirectory() as save_dir:
-            save_dir = f'../test/train_single_reaction/{name}'
             # Train
             metric = 'rmse'
             self.train(


### PR DESCRIPTION
## Description
This updates default conda channels to prefer the pytorch channel over conda-forge.

The Dockerfile has also been updated to use micromamba. This provides two benefits:
1. Faster environment solving compared to conda
2. Removes dependence on anaconda, which may be helpful due to their updated licensing structure

A semi-related change is removing `save_dir` definitions in `test_integration.py` since they aren't necessary, and they can cause tests to fail if the parent directory is not writable (as is the case with the current Dockerfile).

## Example / Current workflow
Using the existing version of the environment file, pytorch comes from the conda-forge channel and does not have gpu support.

## Bugfix / Desired workflow
Using the updated version of the environment file, pytorch should come from the pytorch channel and include gpu support. Cudatoolkit will also be installed in the environment.

## Questions
I haven't explicitly tested whether GPU support works. It would be great if someone familiar with nvidia-docker could help with that.

## Relevant issues
Fixes #183

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
