### PR TITLE
Allow for Running With Empty Test Set and Fix `cv-no-test`

### DIFF
--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -658,8 +658,10 @@ class TrainArgs(CommonArgs):
             if self.separate_val_path is None and self.separate_test_path is None: # separate data paths are not provided
                 if len(self.split_sizes) != 3:
                     raise ValueError(f'Three values should be provided for train/val/test split sizes. Instead received {len(self.split_sizes)} value(s).')
-                if 0. in self.split_sizes:
-                    raise ValueError(f'Provided split sizes must be nonzero if no separate data files are provided. Received split sizes of {self.split_sizes}.')
+                if self.split_sizes[0] == 0.:
+                    raise ValueError(f'Provided split size for train split must be nonzero. Received split size {self.split_sizes[0]}')
+                if self.split_sizes[1] == 0.:
+                    raise ValueError(f'Provided split size for validation split must be nonzero. Received split size {self.split_sizes[1]}')
 
             elif self.separate_val_path is not None and self.separate_test_path is None: # separate val path only
                 if len(self.split_sizes) == 2: # allow input of just 2 values

--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -398,7 +398,9 @@ class MoleculeDataset(Dataset):
 
     def gt_targets(self) -> List[np.ndarray]:
         """
-
+        Returns indications of whether the targets associated with each molecule are greater-than inequalities.
+        
+        :return: A list of lists of booleans indicating whether the targets in those positions are greater-than inequality targets.
         """
         if not hasattr(self._data[0], 'gt_targets'):
             return None
@@ -407,7 +409,9 @@ class MoleculeDataset(Dataset):
 
     def lt_targets(self) -> List[np.ndarray]:
         """
-
+        Returns indications of whether the targets associated with each molecule are less-than inequalities.
+        
+        :return: A list of lists of booleans indicating whether the targets in those positions are less-than inequality targets.
         """
         if not hasattr(self._data[0], 'lt_targets'):
             return None

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -543,7 +543,7 @@ def split_data(data: MoleculeDataset,
 
         random = Random(0)
 
-        indices = np.repeat(np.arange(num_folds), 1 + len(data) // num_folds)[:len(data)]
+        indices = np.tile(np.arange(num_folds), 1 + len(data) // num_folds)[:len(data)]
         random.shuffle(indices)
         test_index = seed % num_folds
         val_index = (seed + 1) % num_folds

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -515,7 +515,9 @@ def split_data(data: MoleculeDataset,
              validation, and test splits of the data.
     """
     if not (len(sizes) == 3 and np.isclose(sum(sizes), 1)):
-        raise ValueError(f"Invalid train/val/test splits! got: {sizes}")
+        raise ValueError(f"Split sizes do not sum to 1. Received train/val/test splits: {sizes}")
+    if any([size < 0 for size in sizes]):
+        raise ValueError(f"Split sizes must be non-negative. Received train/val/test splits: {sizes}")
 
     random = Random(seed)
 

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -539,7 +539,7 @@ def split_data(data: MoleculeDataset,
 
     elif split_type in {'cv', 'cv-no-test'}:
         if num_folds <= 1 or num_folds > len(data):
-            raise ValueError('Number of folds for cross-validation must be between 2 and len(data), inclusive.')
+            raise ValueError(f'Number of folds for cross-validation must be between 2 and the number of valid datapoints ({len(data)}), inclusive.')
 
         random = Random(0)
 

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -146,6 +146,20 @@ def run_training(args: TrainArgs,
     debug(f'Total size = {len(data):,} | '
           f'train size = {len(train_data):,} | val size = {len(val_data):,} | test size = {len(test_data):,}')
 
+    if len(val_data) == 0:
+        raise ValueError('The validation data split is empty. During normal chemprop training (non-sklearn functions), \
+            a validation set is required to conduct early stopping according to the selected evaluation metric. This \
+            may have occurred because validation data provided with `--separate_val_path` was empty or contained only invalid molecules.')
+
+    if len(test_data) == 0:
+        debug('The test data split is empty. This may be either because splitting with no test set was selected, \
+            such as with `cv-no-test`, or because test data provided with `--separate_test_path` was empty or contained only invalid molecules. \
+            Performance on the test set will not be evaluated and metric scores will return `nan` for each task.')
+        empty_test_set = True
+    else:
+        empty_test_set = False
+
+
     # Initialize scaler and scale training targets by subtracting mean and dividing standard deviation (regression only)
     if args.dataset_type == 'regression':
         debug('Fitting scaler')
@@ -306,13 +320,51 @@ def run_training(args: TrainArgs,
         info(f'Model {model_idx} best validation {args.metric} = {best_score:.6f} on epoch {best_epoch}')
         model = load_checkpoint(os.path.join(save_dir, MODEL_FILE_NAME), device=args.device, logger=logger)
 
-        test_preds = predict(
-            model=model,
-            data_loader=test_data_loader,
-            scaler=scaler
-        )
-        test_scores = evaluate_predictions(
-            preds=test_preds,
+        if empty_test_set:
+            info(f'Model {model_idx} provided with no test set, no metric evaluation will be performed.')
+        else:
+            test_preds = predict(
+                model=model,
+                data_loader=test_data_loader,
+                scaler=scaler
+            )
+            test_scores = evaluate_predictions(
+                preds=test_preds,
+                targets=test_targets,
+                num_tasks=args.num_tasks,
+                metrics=args.metrics,
+                dataset_type=args.dataset_type,
+                gt_targets=test_data.gt_targets(),
+                lt_targets=test_data.lt_targets(),
+                logger=logger
+            )
+
+            if len(test_preds) != 0:
+                sum_test_preds += np.array(test_preds)
+
+            # Average test score
+            for metric, scores in test_scores.items():
+                avg_test_score = np.nanmean(scores)
+                info(f'Model {model_idx} test {metric} = {avg_test_score:.6f}')
+                writer.add_scalar(f'test_{metric}', avg_test_score, 0)
+
+                if args.show_individual_scores and args.dataset_type != 'spectra':
+                    # Individual test scores
+                    for task_name, test_score in zip(args.task_names, scores):
+                        info(f'Model {model_idx} test {task_name} {metric} = {test_score:.6f}')
+                        writer.add_scalar(f'test_{task_name}_{metric}', test_score, n_iter)
+        writer.close()
+
+    # Evaluate ensemble on test set
+    if empty_test_set:
+        ensemble_scores = {
+            metric: [np.nan for task in args.task_names] for metric in args.metrics
+        }
+    else:
+        avg_test_preds = (sum_test_preds / args.ensemble_size).tolist()
+
+        ensemble_scores = evaluate_predictions(
+            preds=avg_test_preds,
             targets=test_targets,
             num_tasks=args.num_tasks,
             metrics=args.metrics,
@@ -321,36 +373,6 @@ def run_training(args: TrainArgs,
             lt_targets=test_data.lt_targets(),
             logger=logger
         )
-
-        if len(test_preds) != 0:
-            sum_test_preds += np.array(test_preds)
-
-        # Average test score
-        for metric, scores in test_scores.items():
-            avg_test_score = np.nanmean(scores)
-            info(f'Model {model_idx} test {metric} = {avg_test_score:.6f}')
-            writer.add_scalar(f'test_{metric}', avg_test_score, 0)
-
-            if args.show_individual_scores and args.dataset_type != 'spectra':
-                # Individual test scores
-                for task_name, test_score in zip(args.task_names, scores):
-                    info(f'Model {model_idx} test {task_name} {metric} = {test_score:.6f}')
-                    writer.add_scalar(f'test_{task_name}_{metric}', test_score, n_iter)
-        writer.close()
-
-    # Evaluate ensemble on test set
-    avg_test_preds = (sum_test_preds / args.ensemble_size).tolist()
-
-    ensemble_scores = evaluate_predictions(
-        preds=avg_test_preds,
-        targets=test_targets,
-        num_tasks=args.num_tasks,
-        metrics=args.metrics,
-        dataset_type=args.dataset_type,
-        gt_targets=test_data.gt_targets(),
-        lt_targets=test_data.lt_targets(),
-        logger=logger
-    )
 
     for metric, scores in ensemble_scores.items():
         # Average ensemble score
@@ -367,7 +389,7 @@ def run_training(args: TrainArgs,
         json.dump(ensemble_scores, f, indent=4, sort_keys=True)
 
     # Optionally save test preds
-    if args.save_preds:
+    if args.save_preds and not empty_test_set:
         test_preds_dataframe = pd.DataFrame(data={'smiles': test_data.smiles()})
 
         for i, task_name in enumerate(args.task_names):


### PR DESCRIPTION
## Description
Previously, chemprop could not be run with an empty test set, except in the narrow situation where it was triggered by splitting according to `cv-no-test`. A recent change created an error in the operation with `cv-no-test`as noted in #260 and #279. This PR makes several changes that affects the `cv` and `cv-no-test` splits and empty test set splits generally.
- creates a logic check for whether a dataset is empty that bypasses evaluation and prediction steps
- removes a requirement that the test set size in provided `--test_set_sizes` be nonzero
- changes the algorithm for `cv` and `cv-no-test` to address a problem where data splits could vary by more than +/- 1 datapoint between folds.

## Example / Current workflow
```
chemprop_train \
--data_path path/to/data.csv \
--dataset_type regression \
--split_type cv-no-test \
--num_folds 7
```

## Questions
When running with an empty test set, there are warnings thrown for taking means of empty slices. Not sure if those should be disabled by changing the `np.nanmean` in cross validation to `np.mean`.
Will make splits generated by `cv` and `cv-no-test` to be composed of different data if run before or after this commit.

## Relevant issues
#260 a PR to correct the broken `cv-no-test`. Got held up with decision about how to treat attributes of empty datasets. This approach does not affect that decision, but does fix the issue.
#279 user wanted to run in a leave-one-out mode using `cv-no-test`, but ran into the error. Also encountered the uneven split size behavior also corrected.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
