### PR TITLE
simplify `MoleculeDatapoint`

### DIFF
--- a/chemprop/sklearn_predict.py
+++ b/chemprop/sklearn_predict.py
@@ -16,39 +16,45 @@ def predict_sklearn(args: SklearnPredictArgs) -> None:
     """
     Loads data and a trained scikit-learn model and uses the model to make predictions on the data.
 
-   :param args: A :class:`~chemprop.args.SklearnPredictArgs` object containing arguments for
-                 loading data, loading a trained scikit-learn model, and making predictions with the model.
+    :param args: A :class:`~chemprop.args.SklearnPredictArgs` object containing arguments for
+        loading data, loading a trained scikit-learn model, and making predictions with the model.
     """
-    print('Loading data')
-    data = get_data(path=args.test_path,
-                    smiles_columns=args.smiles_columns,
-                    target_columns=[],
-                    ignore_columns=[],
-                    store_row=True)
+    print("Loading data")
+    data = get_data(
+        path=args.test_path,
+        smiles_columns=args.smiles_columns,
+        target_columns=[],
+        ignore_columns=[],
+        store_row=True,
+    )
 
-    print('Loading training arguments')
-    with open(args.checkpoint_paths[0], 'rb') as f:
+    print("Loading training arguments")
+    with open(args.checkpoint_paths[0], "rb") as f:
         model = pickle.load(f)
-        train_args: SklearnTrainArgs = SklearnTrainArgs().from_dict(model.train_args, skip_unsettable=True)
+        train_args: SklearnTrainArgs = SklearnTrainArgs().from_dict(
+            model.train_args, skip_unsettable=True
+        )
 
-    print('Computing morgan fingerprints')
-    morgan_fingerprint = get_features_generator('morgan')
-    for datapoint in tqdm(data, total=len(data)):
-        for s in datapoint.smiles:
-            datapoint.extend_features(morgan_fingerprint(mol=s, radius=train_args.radius, num_bits=train_args.num_bits))
+    print("Computing morgan fingerprints")
+    morgan_fingerprint = get_features_generator("morgan")
+    for datum in tqdm(data, total=len(data)):
+        for smi in datum.smiles:
+            features = morgan_fingerprint(smi, train_args.radius, train_args.num_bits)
+            if features is not None:
+                datum.features = np.append(datum.features, features)
 
-    print(f'Predicting with an ensemble of {len(args.checkpoint_paths)} models')
+    print(f"Predicting with an ensemble of {len(args.checkpoint_paths)} models")
     sum_preds = np.zeros((len(data), train_args.num_tasks))
 
     for checkpoint_path in tqdm(args.checkpoint_paths, total=len(args.checkpoint_paths)):
-        with open(checkpoint_path, 'rb') as f:
+        with open(checkpoint_path, "rb") as f:
             model = pickle.load(f)
 
         model_preds = predict(
             model=model,
             model_type=train_args.model_type,
             dataset_type=train_args.dataset_type,
-            features=data.features()
+            features=data.features(),
         )
         sum_preds += np.array(model_preds)
 
@@ -56,22 +62,22 @@ def predict_sklearn(args: SklearnPredictArgs) -> None:
     avg_preds = sum_preds / len(args.checkpoint_paths)
     avg_preds = avg_preds.tolist()
 
-    print(f'Saving predictions to {args.preds_path}')
+    print(f"Saving predictions to {args.preds_path}")
     # assert len(data) == len(avg_preds)    #TODO: address with unit test later
     makedirs(args.preds_path, isfile=True)
 
     # Copy predictions over to data
-    for datapoint, preds in zip(data, avg_preds):
+    for datum, preds in zip(data, avg_preds):
         for pred_name, pred in zip(train_args.task_names, preds):
-            datapoint.row[pred_name] = pred
+            datum.row[pred_name] = pred
 
     # Save
-    with open(args.preds_path, 'w') as f:
+    with open(args.preds_path, "w") as f:
         writer = csv.DictWriter(f, fieldnames=data[0].row.keys())
         writer.writeheader()
 
-        for datapoint in data:
-            writer.writerow(datapoint.row)
+        for datum in data:
+            writer.writerow(datum.row)
 
 
 def sklearn_predict() -> None:


### PR DESCRIPTION
## Description
This PR simplifies the `MoleculeDatapoint` class

## Current design
The `MoleculeDatapoint` class has a number of `set_*` functions that do nothing more than assign the corresponding attribute of the parent object. E.g., `MoleculeDatapoint.set_features(self, features) := self.features = features`. These methods do nothing for the readability, cause bloat in the codebase, and are an anti-pattern in python.

## Refactored design
All `MolceuleDatapoint.set_*` methods have been removed and the calls to these functions in client code have been replaced with the simpler `datum.x = x` pattern.

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
