### PR TITLE
Added the ability to predict multiple smiles via the web interface

### DIFF
--- a/chemprop/web/app/templates/predict.html
+++ b/chemprop/web/app/templates/predict.html
@@ -42,11 +42,11 @@
 
         <!--SMILES input-->
         <div id="textInputForm">
-            <h5>SMILES (one per line)</h5>
+            <h5>SMILES (one per line or multiple seperated by a comma)</h5>
             <textarea id="textSmilesInput" name="textSmiles" cols="100" rows="10" placeholder="SMILES" required></textarea>
         </div>
         <div id="fileInputForm" style="display:none">
-            <h5>File containing SMILES (one per line)</h5>
+            <h5>File containing SMILES (one per line or multiple seperated by a comma)</h5>
             <input id="fileSmilesInput" type="file" name="data" accept=".csv">
         </div>
         <div id="drawInputForm" style="display:none">

--- a/chemprop/web/app/views.py
+++ b/chemprop/web/app/views.py
@@ -373,7 +373,7 @@ def predict():
     if train_args.number_of_molecules is not None:
         arguments += [
             '--number_of_molecules', str(train_args.number_of_molecules),
-            '--smiles_columns', str(train_args.number_of_molecules),
+            '--smiles_columns', str(train_args.smiles_columns),
         ]
 
     # Parse arguments


### PR DESCRIPTION
## Description
When using the web interface for inference I noticed that I can't make predictions using my model which was trained with ``number_of_molecules > 1``, I noticed that the current API of the code doesn't allow a multi-input smiles option.

## Bugfix / Desired workflow
I moved the initialization of the training args to the beginning of the predict function
that way you can leverage args such as ``number_of_molecules`` when parsing the smiles.
then if the number is larger than one, I parse the smiles using ``\r\n`` which I saw the server received from the web, and then for each list of SMILES, I parse using a comma similar to CSV files.
similar to when uploading a file, it uses the ``get_header`` and ``get_smiles`` methods from the utils file which work with CSVReader.  So when uploading a file I send the extra argument of ``num_of_molecules`` to fix the problem if the file has more than 1 SMILES per column.

## Checklist
- [X] linted with flake8? 
- [ ] (if appropriate) unit tests added?
