### PR TITLE
Multitask Evaluation on Different Magnitude Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Metrics are used to evaluate the success of the model against the test set as th
 * **Multiclass.** cross_entropy (default), accuracy, f1, mcc.
 * **Spectra.** sid (default), wasserstein.
 
+When a multitask model is used, the metric score used for evaluation at each epoch or for choosing the best set of hyperparameters during hyperparameter search is obtained by taking the mean of the metric scores for each task. Some metrics scale with the magnitude of the targets (most regression metrics), so geometric mean instead of arithmetic mean is used in those cases in order to avoid having the mean score dominated by changes in the larger magnitude task.
 ### Cross validation and ensembling
 
 k-fold cross-validation can be run by specifying `--num_folds <k>`. The default is `--num_folds 1`. Each trained model will have different data splits. The reported test score will be the average of the metrics from each fold.

--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -790,9 +790,20 @@ def multitask_mean(
     :axis: The axis along which to take the mean.
     :return: The combined score across the tasks.
     """
-    scale_dependent_metrics = ['rmse', 'mae', 'mse', 'bounded_rmse', 'bounded_mae', 'bounded_mse']
+    scale_dependent_metrics = ["rmse", "mae", "mse", "bounded_rmse", "bounded_mae", "bounded_mse"]
+    nonscale_dependent_metrics = [
+        "auc", "prc-auc", "r2", "accuracy", "cross_entropy",
+        "binary_cross_entropy", "sid", "wasserstein", "f1", "mcc",
+    ]
 
     if metric in scale_dependent_metrics:
         return gmean(scores, axis=axis)
-    else:
+    elif metric in nonscale_dependent_metrics:
         return np.mean(scores, axis=axis)
+    else:
+        raise NotImplementedError(
+            f"The metric used, {metric}, has not been added to the list of\
+                metrics that are scale-dependent or not scale-dependent.\
+                This metric must be added to the appropriate list in the multitask_mean\
+                function in `chemprop/utils.py` in order to be used."
+        )

--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -12,9 +12,11 @@ import collections
 
 import torch
 import torch.nn as nn
+import numpy as np
 from torch.optim import Adam, Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
 from tqdm import tqdm
+from scipy.stats.mstats import gmean
 
 from chemprop.args import PredictArgs, TrainArgs, FingerprintArgs
 from chemprop.data import StandardScaler, MoleculeDataset, preprocess_smiles_columns, get_task_names
@@ -768,3 +770,29 @@ def update_prediction_args(
                 "(with either --features_generator or --features_path "
                 "and using --no_features_scaling if applicable)."
             )
+
+
+def multitask_mean(
+    scores: np.ndarray,
+    metric: str,
+    axis: int = None,
+) -> float:
+    """
+    A function for combining the metric scores across different
+    model tasks into a single score. When the metric being used
+    is one that varies with the magnitude of the task (such as RMSE),
+    a geometric mean is used, otherwise a more typical arithmetic mean
+    is used. This prevents a task with a larger magnitude from dominating
+    over one with a smaller magnitude (e.g., temperature and pressure).
+
+    :param scores: The scores from different tasks for a single metric.
+    :param metric: The metric used to generate the scores.
+    :axis: The axis along which to take the mean.
+    :return: The combined score across the tasks.
+    """
+    scale_dependent_metrics = ['rmse', 'mae', 'mse', 'bounded_rmse', 'bounded_mae', 'bounded_mse']
+
+    if metric in scale_dependent_metrics:
+        return gmean(scores, axis=axis)
+    else:
+        return np.mean(scores, axis=axis)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -270,10 +270,10 @@ class ChempropTests(TestCase):
 
             # Check results
             test_scores_data = pd.read_csv(os.path.join(save_dir, TEST_SCORES_FILE_NAME))
-            test_scores = test_scores_data[f'Mean {metric}']
+            test_scores = np.array(test_scores_data[f'Mean {metric}'])
             self.assertEqual(len(test_scores), 1)
 
-            mean_score = test_scores.mean()
+            mean_score = np.mean(test_scores)
             self.assertAlmostEqual(mean_score, expected_score, delta=DELTA*expected_score)
 
     @parameterized.expand([
@@ -281,21 +281,22 @@ class ChempropTests(TestCase):
                 'chemprop',
                 'chemprop',
                 'auc',
-                0.63495735,
+                0.4908104,
+                ['--class_balance', '--split_sizes', '0.4', '0.3', '0.3']
         ),
         (
                 'chemprop_morgan_features_generator',
                 'chemprop',
                 'auc',
-                0.5827042,
-                ['--features_generator', 'morgan']
+                0.4733686,
+                ['--features_generator', 'morgan', '--class_balance', '--split_sizes', '0.4', '0.3', '0.3']
         ),
         (
                 'chemprop_rdkit_features_path',
                 'chemprop',
                 'auc',
-                0.63613397,
-                ['--features_path', os.path.join(TEST_DATA_DIR, 'classification.npz'), '--no_features_scaling']
+                0.4573833,
+                ['--features_path', os.path.join(TEST_DATA_DIR, 'classification.npz'), '--no_features_scaling', '--class_balance', '--split_sizes', '0.4', '0.3', '0.3']
         ),
         (
                 'chemprop_mcc_metric',
@@ -337,9 +338,8 @@ class ChempropTests(TestCase):
 
             # Check results
             test_scores_data = pd.read_csv(os.path.join(save_dir, TEST_SCORES_FILE_NAME))
-            test_scores = test_scores_data[f'Mean {metric}']
-
-            mean_score = test_scores.mean()
+            test_scores = np.array(test_scores_data[f'Mean {metric}'])
+            mean_score = np.mean(np.array(test_scores))
             self.assertAlmostEqual(mean_score, expected_score, delta=DELTA*expected_score)
 
     @parameterized.expand([
@@ -408,7 +408,7 @@ class ChempropTests(TestCase):
 
             pred, true = pred.drop(columns=['smiles']), true.drop(columns=['smiles'])
             pred, true = pred.to_numpy(), true.to_numpy()
-            mse = float(np.nanmean((pred - true) ** 2))
+            mse = float(np.mean((pred - true) ** 2))
             self.assertAlmostEqual(mse, expected_score, delta=DELTA*expected_score)
     
     def test_predict_individual_ensemble(self):
@@ -440,20 +440,21 @@ class ChempropTests(TestCase):
         (
                 'chemprop',
                 'chemprop',
-                0.07072509
+                0.1804146,
+                ['--class_balance', '--split_sizes', '0.4', '0.3', '0.3'],
         ),
         (
                 'chemprop_morgan_features_generator',
                 'chemprop',
-                0.07685293,
-                ['--features_generator', 'morgan'],
+                0.26773606,
+                ['--features_generator', 'morgan', '--class_balance', '--split_sizes', '0.4', '0.3', '0.3'],
                 ['--features_generator', 'morgan']
         ),
         (
                 'chemprop_rdkit_features_path',
                 'chemprop',
-                0.072059973,
-                ['--features_path', os.path.join(TEST_DATA_DIR, 'classification.npz'), '--no_features_scaling'],
+                0.0778546,
+                ['--features_path', os.path.join(TEST_DATA_DIR, 'classification.npz'), '--no_features_scaling', '--class_balance', '--split_sizes', '0.4', '0.3', '0.3'],
                 ['--features_path', os.path.join(TEST_DATA_DIR, 'classification_test.npz'), '--no_features_scaling']
         )
     ])
@@ -662,10 +663,10 @@ class ChempropTests(TestCase):
 
             # Check results
             test_scores_data = pd.read_csv(os.path.join(save_dir, TEST_SCORES_FILE_NAME))
-            test_scores = test_scores_data[f'Mean {metric}']
+            test_scores = np.array(test_scores_data[f'Mean {metric}'])
             self.assertEqual(len(test_scores), 1)
 
-            mean_score = test_scores.mean()
+            mean_score = np.mean(test_scores)
             self.assertAlmostEqual(mean_score, expected_score, delta=DELTA*expected_score)
 
     @parameterized.expand([
@@ -789,10 +790,10 @@ class ChempropTests(TestCase):
 
             # Check results
             test_scores_data = pd.read_csv(os.path.join(save_dir, TEST_SCORES_FILE_NAME))
-            test_scores = test_scores_data[f'Mean {metric}']
+            test_scores = np.array(test_scores_data[f'Mean {metric}'])
             self.assertEqual(len(test_scores), 1)
 
-            mean_score = test_scores.mean()
+            mean_score = np.mean(test_scores)
             self.assertAlmostEqual(mean_score, expected_score, delta=DELTA*expected_score)
 
     @parameterized.expand([
@@ -822,22 +823,22 @@ class ChempropTests(TestCase):
 
             # Check results
             test_scores_data = pd.read_csv(os.path.join(save_dir, TEST_SCORES_FILE_NAME))
-            test_scores = test_scores_data[f'Mean {metric}']
+            test_scores = np.array(test_scores_data[f'Mean {metric}'])
 
-            mean_score = test_scores.mean()
+            mean_score = np.mean(test_scores)
             self.assertAlmostEqual(mean_score, expected_score, delta=DELTA * expected_score)
 
     @parameterized.expand([
         (
                 'chemprop',
                 'chemprop',
-                3473.79893,
+                2805.4368779,
                 ['--fingerprint_type', 'MPN'],
         ),
         (
                 'chemprop',
                 'chemprop',
-                3504.50003,
+                2689.55376,
                 ['--fingerprint_type', 'last_FFN'],
         )
     ])
@@ -992,10 +993,10 @@ class ChempropTests(TestCase):
 
             # Check results
             test_scores_data = pd.read_csv(os.path.join(save_dir, TEST_SCORES_FILE_NAME))
-            test_scores = test_scores_data[f'Mean {metric}']
+            test_scores = np.array(test_scores_data[f'Mean {metric}'])
             self.assertEqual(len(test_scores), 1)
 
-            mean_score = test_scores.mean()
+            mean_score = np.mean(test_scores)
             self.assertAlmostEqual(mean_score, expected_score, delta=DELTA*expected_score)
 
     @parameterized.expand([(

--- a/tests/test_unit/test_loss_functions.py
+++ b/tests/test_unit/test_loss_functions.py
@@ -134,7 +134,7 @@ def test_bounded_mse(preds, targets, lt_targets, gt_targets, mse):
     "preds,targets,likelihood",
     [(
         torch.tensor([[0, 1]], dtype=float),
-        torch.zeros([1, 1]),
+        torch.zeros([1, 1], dtype=float),
         [[0.3989]],
     )]
 )
@@ -151,14 +151,14 @@ def test_mve(preds, targets, likelihood):
     "alphas,target_labels,lam,expected_loss",
     [
         (
-            torch.tensor([[2, 2]]),
-            torch.ones([1, 1]),
+            torch.tensor([[2, 2]], dtype=float),
+            torch.ones([1, 1], dtype=float),
             0,
             [[0.6]]
         ),
         (
-            torch.tensor([[2, 2]]),
-            torch.ones([1, 1]),
+            torch.tensor([[2, 2]], dtype=float),
+            torch.ones([1, 1], dtype=float),
             0.2,
             [[0.63862943]]
         )
@@ -178,8 +178,8 @@ def test_dirichlet(alphas, target_labels, lam, expected_loss):
     "alphas,target_labels",
     [
         (
-            torch.ones([1, 1]),
-            torch.ones([1, 1]),
+            torch.ones([1, 1], dtype=float),
+            torch.ones([1, 1], dtype=float),
         ),
     ]
 )
@@ -196,14 +196,14 @@ def test_dirichlet_wrong_dimensions(alphas, target_labels):
     "alphas,targets,lam,expected_loss",
     [
         (
-            torch.tensor([[2, 2, 2, 2]]),
-            torch.ones([1, 1]),
+            torch.tensor([[2, 2, 2, 2]], dtype=float),
+            torch.ones([1, 1], dtype=float),
             0,
             [[1.56893861]]
         ),
         (
-            torch.tensor([[2, 2, 2, 2]]),
-            torch.ones([1, 1]),
+            torch.tensor([[2, 2, 2, 2]], dtype=float),
+            torch.ones([1, 1], dtype=float),
             0.2,
             [[2.768938541]]
         )
@@ -223,8 +223,8 @@ def test_evidential(alphas, targets, lam, expected_loss):
     "alphas,targets",
     [
         (
-            torch.ones([2, 2]),
-            torch.ones([2, 2]),
+            torch.ones([2, 2], dtype=float),
+            torch.ones([2, 2], dtype=float),
         ),
     ]
 )


### PR DESCRIPTION
## Description
In multitask models, the metric used for whole model evaluation is an average of the different tasks. This is then used in evaluating the best epoch and for providing the overall test set performance as used in hyperparameter search. The problem is that the metric evaluation is carried out on non-scaled targets, so in regression models the largest magnitude target will dominate for most metrics.

In this PR, I've made the change that when the metric is magnitude-dependent, geometric mean is used instead of arithmetic mean. This bypasses the scale difference by weighing the changes in individual task metrics in a relative sense (10% improvement on task A is worth the same as 10% on task B, no matter the scale).

I've also removed the averaging functions that filter out nan values from the score reporting and the testing functions. If one fold of a model is producing a nan result, it should alert the user to a problem instead of ignoring it.

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
