### PR TITLE
Bugfix for multitarget mve_weighting calibration

### DIFF
--- a/chemprop/uncertainty/uncertainty_calibrator.py
+++ b/chemprop/uncertainty/uncertainty_calibrator.py
@@ -519,11 +519,9 @@ class MVEWeightingCalibrator(UncertaintyCalibrator):
         uncal_preds = np.array(
             self.calibration_predictor.get_uncal_preds()
         )  # shape(data, tasks)
-        print(self.calibration_predictor.get_individual_vars())
         individual_vars = np.array(
             self.calibration_predictor.get_individual_vars()
         )  # shape(models, data, tasks)
-        print(individual_vars)
         targets = np.array(self.calibration_data.targets())
         errors = uncal_preds - targets
 


### PR DESCRIPTION
## Description
Previously, the mve_weighting calibration method that can be used on ensembles of mve or evidential trained models did not work for multitask models. The optimization step took in shape(num_models) fitting parameters and returned shape(num_tasks) loss values. These were used with `fmin` which is incompatible with multiple returned values.

To fix this, I summed the output losses together so that it was a single output value. Because these losses were negative log likelihood values, summing them together is the equivalent of treating them like joint distributions, and is a sensible way to aggregate the values.

Placing as a PR for atom-bond-targets because including a version of mve_weighting that worked with atom targets was awaiting this bug fix. And will subsequently be rolled into master all together shortly.
