### PR TITLE
Rearrange ence evaluation

### DIFF
--- a/chemprop/uncertainty/uncertainty_evaluator.py
+++ b/chemprop/uncertainty/uncertainty_evaluator.py
@@ -40,11 +40,14 @@ class UncertaintyEvaluator(ABC):
             raise NotImplementedError(
                 "No uncertainty evaluators implemented for spectra dataset type."
             )
-        if self.uncertainty_method in ['ensemble', 'dropout'] and self.dataset_type in ['classification', 'multiclass']:
+        if self.uncertainty_method in ["ensemble", "dropout"] and self.dataset_type in [
+            "classification",
+            "multiclass",
+        ]:
             raise NotImplementedError(
-                'Though ensemble and dropout uncertainty methods are available for classification \
+                "Though ensemble and dropout uncertainty methods are available for classification \
                     multiclass dataset types, their outputs are not confidences and are not \
-                    compatible with any implemented evaluation methods for classification.'
+                    compatible with any implemented evaluation methods for classification."
             )
 
     @abstractmethod
@@ -158,7 +161,8 @@ class NLLClassEvaluator(UncertaintyEvaluator):
             task_mask = mask[:, i]
             task_unc = uncertainties[task_mask, i]
             task_targets = targets[task_mask, i]
-            task_likelihood = task_unc * task_targets + (1 - task_unc) * (1 - task_targets)
+            task_likelihood = task_unc * task_targets \
+                + (1 - task_unc) * (1 - task_targets)
             task_nll = -1 * np.log(task_likelihood)
             nll.append(task_nll.mean())
         return nll
@@ -252,7 +256,7 @@ class CalibrationAreaEvaluator(UncertaintyEvaluator):
                     bin_unc = task_unc / original_scaling[j] * bin_scaling[i][j]
                     bin_fraction = np.mean(bin_unc >= task_error)
                     fractions[j, i] = bin_fraction
-            
+
             # return calibration settings to original state
             self.calibrator.regression_calibrator_metric = original_metric
             self.calibrator.scaling = original_scaling
@@ -310,7 +314,10 @@ class ExpectedNormalizedErrorEvaluator(UncertaintyEvaluator):
         if self.calibrator is not None:
             original_metric = self.calibrator.regression_calibrator_metric
             original_scaling = self.calibrator.scaling
-            if self.calibration_method != "tscaling" and self.calibrator.regression_calibrator_metric == "interval":
+            if (
+                self.calibration_method != "tscaling"
+                and self.calibrator.regression_calibrator_metric == "interval"
+            ):
                 self.calibrator.regression_calibrator_metric = "stdev"
                 self.calibrator.calibrate()
                 stdev_scaling = self.calibrator.scaling
@@ -423,12 +430,7 @@ def build_uncertainty_evaluator(
         "f1",
         "mcc",
     ]
-    multiclass_metrics = [
-        "cross_entropy",
-        "accuracy",
-        "f1",
-        "mcc"
-    ]
+    multiclass_metrics = ["cross_entropy", "accuracy", "f1", "mcc"]
     if dataset_type == "classification" and evaluation_method in classification_metrics:
         evaluator_class = MetricEvaluator
     elif dataset_type == "multiclass" and evaluation_method in multiclass_metrics:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1046,14 +1046,14 @@ class ChempropTests(TestCase):
         ['--loss_function', 'evidential'],
         [],
     ),
-    # (
-    #     8.843267,
-    #     'dropout',
-    #     None,
-    #     'nll',
-    #     ['--num_folds', '1'],
-    #     [],
-    # ),
+    (
+        20.50925,
+        'dropout',
+        'zscaling',
+        'ence',
+        ['--num_folds', '1'],
+        [],
+    ),
     (
         -1.9783182,
         'ensemble',


### PR DESCRIPTION
## Description
The `ence` uncertainty evaluation method contained a bug where an unassigned variable was called unnecessarily. It triggered when a calibration method was used with a stdev metric. Have corrected this and added a unit test covering this combination. Also noticed that the variable assignment wasn't set up right for the calibration method `tscaling` in combination with `ence` and corrected this as well.

## Example / Current workflow
Bug present when used with `--calibration_method {any} --regression_calibration_metric stdev --uncertainty_evaluation_methods ence`.

## Relevant issues
Addresses #301

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
