### PR TITLE
Hyperopt Parallel Race Conditions and Manual Trial Load

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Please see [aicures.mit.edu](https://aicures.mit.edu) and the associated [data G
   * [Docker](#docker)
 - [Web Interface](#web-interface)
 - [Within Python](#within-python)
+- [Reproducibility](#reproducibility)
 - [Data](#data)
 - [Training](#training)
   * [Train/Validation/Test Splits](#trainvalidationtest-splits)
@@ -188,12 +189,13 @@ Our code supports several methods of splitting data into train, validation, and 
 
 * **Random.** By default, the data will be split randomly into train, validation, and test sets.
 * **Scaffold.** Alternatively, the data can be split by molecular scaffold so that the same scaffold never appears in more than one split. This can be specified by adding `--split_type scaffold_balanced`.
+* **k-Fold Cross-Validation.** A split type specified with `--split_type cv` intended for use when training with cross-validation. The data are split randomly into k groups of equal size, where k is the number of cross-validation folds specified with `--num_folds <k>`. Each group is used once as the test set and once as the validation set in training the k folds of the model. Alternatively, the option `--split_type cv-no-test` can be used to train without a test splits.
 * **Random With Repeated SMILES.** Some datasets have multiple entries with the same SMILES. To constrain splitting so the repeated SMILES are in the same split, use the argument `--split_type random_with_repeated_smiles`.
 * **Separate val/test.** If you have separate data files you would like to use as the validation or test set, you can specify them with `--separate_val_path <val_path>` and/or `--separate_test_path <test_path>`. If both are provided, then the data specified by `--data_path` is used entirely as the training data. If only one separate path is provided, the `--data_path` data is split between train data and either val or test data, whichever is not provided separately.
 
 When data contains multiple molecules per datapoint, scaffold and repeated SMILES splitting will only constrain splitting based on one of the molecules. The key molecule can be chosen with the argument `--split_key_molecule <int>`, with the default setting using an index of 0 indicating the first molecule.
 
-By default, both random and scaffold split the data into 80% train, 10% validation, and 10% test. This can be changed with `--split_sizes <train_frac> <val_frac> <test_frac>`. The default setting is `--split_sizes 0.8 0.1 0.1`. If a separate validation set or test set is provided, the split defaults to 80%-20%. Splitting involves a random component and can be seeded with `--seed <seed>`. The default setting is `--seed 0`.
+By default, both random and scaffold split the data into 80% train, 10% validation, and 10% test. This can be changed with `--split_sizes <train_frac> <val_frac> <test_frac>`. The default setting is `--split_sizes 0.8 0.1 0.1`. If a separate validation set or test set is provided, the split defaults to 80%-20%. Splitting involves a random component and can be seeded with `--seed <seed>`. The default setting is `--seed 0`. The split size argument is not used with split types `cv` or `cv-no-test`.
 
 ### Loss functions
 
@@ -215,7 +217,7 @@ Metrics are used to evaluate the success of the model against the test set as th
 When a multitask model is used, the metric score used for evaluation at each epoch or for choosing the best set of hyperparameters during hyperparameter search is obtained by taking the mean of the metric scores for each task. Some metrics scale with the magnitude of the targets (most regression metrics), so geometric mean instead of arithmetic mean is used in those cases in order to avoid having the mean score dominated by changes in the larger magnitude task.
 ### Cross validation and ensembling
 
-k-fold cross-validation can be run by specifying `--num_folds <k>`. The default is `--num_folds 1`. Each trained model will have different data splits. The reported test score will be the average of the metrics from each fold.
+Cross-validation can be run by specifying `--num_folds <k>`. The default is `--num_folds 1`. Each trained model will have different train/val/test splits, determined according to the specified split type argument and split sizes argument but using a different random seed to perform the splitting. The reported test score will be the average of the metrics from each fold. To use a strict k-fold cross-validation where each datapoint will appear in fold test sets exactly once, the argument `--split_type cv` must be used.
 
 To train an ensemble, specify the number of models in the ensemble with `--ensemble_size <n>`. The default is `--ensemble_size 1`. Each trained model within the ensemble will share data splits. The reported test score for one ensemble is the metric applied to the averaged prediction across the models. Ensembling and cros-validation can be used at the same time.
 
@@ -444,7 +446,7 @@ Parallel instances of hyperparameter optimization that share a checkpoint direct
 
 ### Random or Directed Search
 
-As part of the hyperopt search algorithm, the first trial configurations for the model will be randomly spread through the search space. The number of randomized trials can be altered with the argument `--startup_random_iters <int>`. By default, the number or random trials will be half the number of total trials. After this number of trial iterations has been carried out, subsequent trials will use the directed search algorithm to select parameter configurations. This startup count considers the total number of trials in the checkpoint directory rather than the number that has been carried out by an individual instance of hyperparamter optimization.
+As part of the hyperopt search algorithm, the first trial configurations for the model will be randomly spread through the search space. The number of randomized trials can be altered with the argument `--startup_random_iters <int>`. By default, the number or random trials will be half the number of total trials. After this number of trial iterations has been carried out, subsequent trials will use the directed search algorithm to select parameter configurations. This startup count considers the total number of trials in the checkpoint directory rather than the number that has been carried out by an individual instance of hyperparamter optimization instance. Both the random and directed search use a unique trial seed in choosing hyperparameters, this can be specified for the first trial in an optimization instance using `--hyperopt_seed <seed>` and will increment up to the next unused seed for trials afterward.
 
 
 ### Manual Trials

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -901,6 +901,8 @@ class HyperoptArgs(TrainArgs):
 
     num_iters: int = 20
     """Number of hyperparameter choices to try."""
+    hyperopt_seed: int = 0
+    """The initial seed used for choosing parameters in hyperopt trials. In each trial, the seed will be increased by one, skipping seeds previously used."""
     config_save_path: str
     """Path to :code:`.json` file where best hyperparameter settings will be written."""
     log_dir: str = None

--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -18,6 +18,11 @@ CACHE_GRAPH = True
 SMILES_TO_GRAPH: Dict[str, MolGraph] = {}
 
 
+# Cache of RDKit molecules
+CACHE_MOL = True
+SMILES_TO_MOL: Dict[str, Union[Chem.Mol, Tuple[Chem.Mol, Chem.Mol]]] = {}
+
+
 def cache_graph() -> bool:
     r"""Returns whether :class:`~chemprop.features.MolGraph`\ s will be cached."""
     return CACHE_GRAPH
@@ -33,11 +38,6 @@ def empty_cache():
     r"""Empties the cache of :class:`~chemprop.features.MolGraph` and RDKit molecules."""
     SMILES_TO_GRAPH.clear()
     SMILES_TO_MOL.clear()
-
-
-# Cache of RDKit molecules
-CACHE_MOL = True
-SMILES_TO_MOL: Dict[str, Union[Chem.Mol, Tuple[Chem.Mol, Chem.Mol]]] = {}
 
 
 def cache_mol() -> bool:

--- a/chemprop/hyperopt_utils.py
+++ b/chemprop/hyperopt_utils.py
@@ -272,6 +272,7 @@ def load_manual_trials(manual_trials_dirs: List[str], param_keys: List[str], hyp
             'std_score': std_score,
             'hyperparams': param_dict,
             'num_params': 0,
+            'seed': - (i + 1),
         }
         misc_dict = {
             'tid': i,
@@ -297,6 +298,7 @@ def load_manual_trials(manual_trials_dirs: List[str], param_keys: List[str], hyp
     trials = Trials()
     trials = merge_trials(trials=trials, new_trials_data=manual_trials_data)
     return trials
+
 
 def save_config(config_path: str, hyperparams_dict: dict, max_lr: float) -> None:
     """

--- a/chemprop/hyperopt_utils.py
+++ b/chemprop/hyperopt_utils.py
@@ -255,15 +255,21 @@ def load_manual_trials(manual_trials_dirs: List[str], param_keys: List[str], hyp
         vals_dict = {}
         for key in param_keys:
             if key == 'init_lr_ratio':
-                param_value = trial_args['init_lr'] / trial_args['max_lr']
+                param_value = val_value = trial_args['init_lr'] / trial_args['max_lr']
             elif key == 'final_lr_ratio':
-                param_value = trial_args['final_lr'] / trial_args['max_lr']
+                param_value = val_value = trial_args['final_lr'] / trial_args['max_lr']
             elif key == 'linked_hidden_size':
-                param_value = trial_args['hidden_size']
-            else:
+                param_value = val_value = trial_args['hidden_size']
+            elif key == 'aggregation':
                 param_value = trial_args[key]
+                val_value = ["mean", "sum", "norm"].index(param_value)
+            elif key == 'activation':
+                param_value = trial_args[key]
+                val_value = ['ReLU', 'LeakyReLU', 'PReLU', 'tanh', 'SELU', 'ELU'].index(param_value)
+            else:
+                param_value = val_value = trial_args[key]
             param_dict[key] = param_value
-            vals_dict[key] = [param_value]
+            vals_dict[key] = [val_value]
         idxs_dict = {key: [i] for key in param_keys}
         results_dict = {
             'loss': loss,

--- a/chemprop/hyperopt_utils.py
+++ b/chemprop/hyperopt_utils.py
@@ -4,6 +4,7 @@ import pickle
 from typing import List, Dict
 import csv
 import json
+import logging
 
 from hyperopt import Trials, hp
 import numpy as np
@@ -119,18 +120,25 @@ def load_trials(dir_path: str, previous_trials: Trials = None) -> Trials:
     return loaded_trials
 
 
-def save_trials(dir_path: str, trials: Trials, hyperopt_seed: int) -> None:
+def save_trials(dir_path: str, trials: Trials, hyperopt_seed: int, logger: logging.Logger = None) -> None:
     """
     Saves hyperopt trial data as a `.pkl` file.
 
     :param dir_path: Path to the directory containing hyperopt checkpoint files.
     :param trials: A trials object containing information on a completed hyperopt iteration.
     """
+    if logger is None:
+        info = print
+    else:
+        info = logger.info
+
     new_fname = f'{hyperopt_seed}.pkl'
     existing_files = os.listdir(dir_path)
     if new_fname in existing_files:
-        raise ValueError(f'When saving trial with unique seed {hyperopt_seed}, found that a trial with this seed already exists.')
-    pickle.dump(trials, open(os.path.join(dir_path, new_fname), 'wb'))
+        info(f'When saving trial with unique seed {hyperopt_seed}, found that a trial with this seed already exists. ' \
+            'This trial was not saved.')
+    else:
+        pickle.dump(trials, open(os.path.join(dir_path, new_fname), 'wb'))
 
 
 def get_hyperopt_seed(seed: int, dir_path: str) -> int:

--- a/chemprop/hyperopt_utils.py
+++ b/chemprop/hyperopt_utils.py
@@ -132,6 +132,7 @@ def save_trials(
     Saves hyperopt trial data as a `.pkl` file.
 
     :param dir_path: Path to the directory containing hyperopt checkpoint files.
+    :param hyperopt_seed: The initial seed used for choosing parameters in hyperopt trials.
     :param trials: A trials object containing information on a completed hyperopt iteration.
     """
     if logger is None:

--- a/chemprop/hyperparameter_optimization.py
+++ b/chemprop/hyperparameter_optimization.py
@@ -150,7 +150,7 @@ def hyperopt(args: HyperoptArgs) -> None:
 
         # Create a trials object with only the last instance by merging the last data with an empty trials object
         last_trial = merge_trials(Trials(), [trials.trials[-1]])
-        save_trials(args.hyperopt_checkpoint_dir, last_trial, hyperopt_seed)
+        save_trials(args.hyperopt_checkpoint_dir, last_trial, hyperopt_seed, logger)
 
     # Report best result
     all_trials = load_trials(dir_path=args.hyperopt_checkpoint_dir, previous_trials=manual_trials)

--- a/chemprop/hyperparameter_optimization.py
+++ b/chemprop/hyperparameter_optimization.py
@@ -145,7 +145,7 @@ def hyperopt(args: HyperoptArgs) -> None:
 
         # Set a unique random seed for each trial. Pass it into objective function for logging purposes.
         hyperopt_seed = get_hyperopt_seed(
-            seed=args.seed, dir_path=args.hyperopt_checkpoint_dir
+            seed=args.hyperopt_seed, dir_path=args.hyperopt_checkpoint_dir
         )
         fmin_objective = partial(objective, seed=hyperopt_seed)
         os.environ["HYPEROPT_FMIN_SEED"] = str(


### PR DESCRIPTION
## Description
This PR addresses two problems in hyperparameter optimization.

One centers around a race condition where parallel instances read and write simultaneously to the file containing the list of previously used hyperopt seeds. Sometimes instances will coincide in their read/write timing and assign themselves the same seed and duplicate a trial. Currently, if an instance goes to save a trial and discovers that it already exists, it will raise an error because of the discovered conflict. This race condition is difficult to lock out in a way that will be effective for all operating systems. This PR doesn't solve the problem, but does reduce the severity of the discovery. Now, upon discovering that the saved trial already exists, an instance will note it in the log and continue on without raising an error.

The other issue is around the handling of choice hyperparameters (like "aggregation" being a choice of ["sum", "norm", "mean"]). When a previous job is loaded as a manual trial to seed the start of a hyperparameters job, it was raising an error for the choice hyperparameters. This conversion of loaded arguments to trials objects has now been changed so their values will be stored as the index in the options list, rather than the string value of the choice.

## Questions
Is there a robust way to remove this race condition that would work with any OS?

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
