### PR TITLE
Bug/reaction featurizer

### DIFF
--- a/chemprop/v2/data/datasets.py
+++ b/chemprop/v2/data/datasets.py
@@ -125,7 +125,7 @@ class MoleculeDataset(MolGraphDatasetBase):
     ----------
     data : Iterable[MoleculeDatapoint]
         the data from which to create a dataset
-    featurizer : ReactionFeaturizer
+    featurizer : MoleculeFeaturizer
         the featurizer with which to generate MolGraphs of the molecules
     """
 

--- a/chemprop/v2/featurizers/multihot/atom.py
+++ b/chemprop/v2/featurizers/multihot/atom.py
@@ -119,6 +119,7 @@ class AtomFeaturizer(MultiHotFeaturizer):
         return x
 
     def featurize_num_only(self, a: Atom) -> np.ndarray:
+        """featurize the atom with only the atomic number bit set"""
         x = np.zeros(len(self))
 
         if a is None:

--- a/chemprop/v2/featurizers/reaction.py
+++ b/chemprop/v2/featurizers/reaction.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from enum import auto
-from typing import Optional, Union
+from typing import Iterable, Optional, Sequence, Union
 import warnings
 
 import numpy as np
 from rdkit import Chem
+from rdkit.Chem.rdchem import Bond, Mol
 
 from chemprop.v2.featurizers.molgraph import MolGraph
 from chemprop.v2.featurizers.base import MolGraphFeaturizer
@@ -41,60 +42,6 @@ class ReactionMode(AutoName):
     REAC_DIFF_BALANCE = auto()
     PROD_DIFF = auto()
     PROD_DIFF_BALANCE = auto()
-
-
-def map_reac_to_prod(
-    reactants: Chem.Mol, products: Chem.Mol
-) -> tuple[dict[int, int], list[int], list[int]]:
-    """Map atom indices between corresponding atoms in the reactant and product molecules
-
-    Parameters
-    ----------
-    reactants
-        An RDKit molecule of the reactants
-    products
-        An RDKit molecule of the products
-
-    Returns
-    -------
-    r2p : dict[int, int]
-        A dictionary of corresponding atom indices from reactant atoms to product atoms
-    pdt_idxs : list[int]
-        atom indices of poduct atoms
-    rct_idxs : list[int]
-        atom indices of reactant atoms
-    """
-    pdt_idxs = []
-    prod_map_to_id = {}
-    mapnos_reac = {a.GetAtomMapNum() for a in reactants.GetAtoms()}
-
-    for a in products.GetAtoms():
-        mapno = a.GetAtomMapNum()
-        i = a.GetIdx()
-
-        if mapno > 0:
-            prod_map_to_id[mapno] = i
-            if mapno not in mapnos_reac:
-                pdt_idxs.append(i)
-        else:
-            pdt_idxs.append(i)
-
-    rct_idxs = []
-    r2p = {}
-
-    for a in reactants.GetAtoms():
-        mapno = a.GetAtomMapNum()
-        i = a.GetIdx()
-
-        if mapno > 0:
-            try:
-                r2p[i] = prod_map_to_id[mapno]
-            except KeyError:
-                rct_idxs.append(i)
-        else:
-            rct_idxs.append(i)
-
-    return r2p, pdt_idxs, rct_idxs
 
 
 class ReactionFeaturizer(MolGraphFeaturizer):
@@ -133,14 +80,21 @@ class ReactionFeaturizer(MolGraphFeaturizer):
     ):
         super().__init__(atom_featurizer, bond_featurizer, bond_messages)
 
-        self.mode = ReactionMode.get(mode)
-        self.atom_fdim += len(self.atom_feautrizer) - self.atom_featurizer.max_atomic_num - 1
+        self.mode = mode
+        self.atom_fdim += len(self.atom_featurizer) - self.atom_featurizer.max_atomic_num - 1
         self.bond_fdim *= 2
 
         if self.bond_messages:
             self.bond_fdim += self.atom_fdim
 
-    # TODO(degraff): make this function more readable
+    @property
+    def mode(self) -> ReactionMode:
+        return self.__mode
+    
+    @mode.setter
+    def mode(self, m: Union[str, ReactionMode]):
+        self.__mode = ReactionMode.get(m)
+        
     def featurize(
         self,
         reaction: tuple[Chem.Mol, Chem.Mol],
@@ -164,79 +118,17 @@ class ReactionFeaturizer(MolGraphFeaturizer):
         Returns
         -------
         MolGraph
-            the molecular graph of the input reaction
+            the molecular graph of the reaction
         """
         if atom_features_extra is not None:
-            warnings.warn("Extra atom features are currently not supported for reactions")
+            warnings.warn("'atom_features_extra' is currently unsupported for reactions")
         if bond_features_extra is not None:
-            warnings.warn("Extra bond features are currently not supported for reactions")
+            warnings.warn("'bond_features_extra' is currently unsupported for reactions")
 
         rct, pdt = reaction
-        ri2pi, pids, rids = map_reac_to_prod(rct, pdt)
+        ri2pj, pids, rids = self.map_reac_to_prod(rct, pdt)
 
-        A = np.array([self.atom_featurizer(a) for a in rct.GetAtoms()])
-        D = np.array([self.atom_featurizer(pdt.GetAtomWithIdx(i)) for i in pids])
-        D = D.reshape(-1, self.atom_fdim)  # NOTE(degraff): this line might be bugged
-
-        if self.mode in [ReactionMode.REAC_DIFF, ReactionMode.PROD_DIFF, ReactionMode.REAC_PROD]:
-            # Reactant: regular atom features for each atom in the reactants, as well as zero
-            # features for atoms that are only in the products (indices in pio)
-            B = np.array(
-                [self.atom_featurizer.featurize_num_only(pdt.GetAtomWithIdx(i)) for i in pids]
-            )
-            B = B.reshape(-1, self.atom_fdim)
-
-            # Product: regular atom features for each atom that is in both reactants and products
-            # (not in rio), other atom features zero,
-            # regular features for atoms that are only in the products (indices in pio)
-            C = np.array(
-                [
-                    self.atom_featurizer(pdt.GetAtomWithIdx(ri2pi[a.GetIdx()]))
-                    if a.GetIdx() not in rids
-                    else self.atom_featurizer.featurize_num_only(a)
-                    for a in rct.GetAtoms()
-                ]
-            )
-        else:  # balance
-            # Reactant: regular atom features for each atom in the reactants, copy features from
-            #   product side for atoms that are only in the products (:= indices in pio)
-            B = np.array([self.atom_featurizer(pdt.GetAtomWithIdx(i)) for i in pids])
-            B = B.reshape(-1, self.atom_fdim)
-
-            # Product: (1) regular atom features for each atom that is in both reactants and
-            #   products (:= indices not in rids), copy features from reactant side for other
-            #   atoms, (2) regular features for atoms that are only in the products (:= indices in
-            #   pio)
-            C = np.array(
-                [
-                    self.atom_featurizer(pdt.GetAtomWithIdx(ri2pi[a.GetIdx()]))
-                    if a.GetIdx() not in rids
-                    else self.atom_featurizer(a)
-                    for a in rct.GetAtoms()
-                ]
-            )
-
-        X_v_r = np.concatenate((A, B))
-        X_v_p = np.concatenate((C, D))
-
-        m = min(len(X_v_r), len(X_v_p))
-
-        if self.mode in [
-            ReactionMode.REAC_DIFF,
-            ReactionMode.REAC_DIFF_BALANCE,
-            ReactionMode.PROD_DIFF,
-            ReactionMode.PROD_DIFF_BALANCE,
-        ]:
-            X_v_d = X_v_p[:m] - X_v_r[:m]
-
-        if self.mode in [ReactionMode.REAC_PROD, ReactionMode.REAC_PROD_BALANCE]:
-            X_v = np.hstack((X_v_r[:m], X_v_p[:m, self.atom_featurizer.max_atomic_num + 1 :]))
-        elif self.mode in [ReactionMode.REAC_DIFF, ReactionMode.REAC_DIFF_BALANCE]:
-            X_v = np.hstack((X_v_r[:m], X_v_d[:m, self.atom_featurizer.max_atomic_num + 1 :]))
-        elif self.mode in [ReactionMode.PROD_DIFF, ReactionMode.PROD_DIFF_BALANCE]:
-            X_v = np.hstack((X_v_p[:m], X_v_d[:m, self.atom_featurizer.max_atomic_num + 1 :]))
-        else:
-            raise RuntimeError(f"fell through! reaction mode: {self.mode}.")
+        X_v = self._calc_node_feature_matrix(rct, pdt, ri2pj, pids, rids)
 
         n_atoms = len(X_v)
         n_atoms_r = rct.GetNumAtoms()
@@ -249,62 +141,11 @@ class ReactionFeaturizer(MolGraphFeaturizer):
 
         for a1 in range(n_atoms):
             for a2 in range(a1 + 1, n_atoms):
-                if a1 >= n_atoms_r and a2 >= n_atoms_r:
-                    # Both atoms only in product
-                    b_prod = pdt.GetBondBetweenAtoms(pids[a1 - n_atoms_r], pids[a2 - n_atoms_r])
-
-                    if self.mode in [
-                        ReactionMode.REAC_PROD_BALANCE,
-                        ReactionMode.REAC_DIFF_BALANCE,
-                        ReactionMode.PROD_DIFF_BALANCE,
-                    ]:
-                        b_reac = b_prod
-                    else:
-                        b_reac = None
-                elif a1 < n_atoms_r and a2 >= n_atoms_r:
-                    # One atom only in product
-                    b_reac = None
-
-                    if a1 in ri2pi.keys():
-                        b_prod = pdt.GetBondBetweenAtoms(ri2pi[a1], pids[a2 - n_atoms_r])
-                    else:
-                        # Atom atom only in reactant, the other only in product
-                        b_prod = None
-                else:
-                    b_reac = rct.GetBondBetweenAtoms(a1, a2)
-
-                    if a1 in ri2pi.keys() and a2 in ri2pi.keys():
-                        # Both atoms in both reactant and product
-                        b_prod = pdt.GetBondBetweenAtoms(ri2pi[a1], ri2pi[a2])
-                    else:
-                        if self.mode in [
-                            ReactionMode.REAC_PROD_BALANCE,
-                            ReactionMode.REAC_DIFF_BALANCE,
-                            ReactionMode.PROD_DIFF_BALANCE,
-                        ]:
-                            b_prod = None if a1 in ri2pi.keys() or a2 in ri2pi.keys() else b_reac
-                        else:
-                            # One or both atoms only in reactant
-                            b_prod = None
-
+                b_reac, b_prod = self._get_bonds(rct, pdt, ri2pj, pids, n_atoms_r, a1, a2)
                 if b_reac is None and b_prod is None:
                     continue
 
-                x_e_r = self.bond_featurizer(b_reac)
-                x_e_p = self.bond_featurizer(b_prod)
-
-                if self.mode in [ReactionMode.REAC_PROD, ReactionMode.REAC_PROD_BALANCE]:
-                    x_e = np.hstack((x_e_r, x_e_p))
-                else:
-                    x_e_d = x_e_p - x_e_r
-
-                    if self.mode in [ReactionMode.REAC_DIFF, ReactionMode.REAC_DIFF_BALANCE]:
-                        x_e_r = self.bond_featurizer(b_reac)
-                        x_e = np.hstack((x_e_r, x_e_d))
-                    else:
-                        x_e_p = self.bond_featurizer(b_prod)
-                        x_e = np.hstack((x_e_p, x_e_d))
-
+                x_e = self._calc_edge_feature(b_reac, b_prod)
                 if self.bond_messages:
                     X_e.append(np.hstack((X_v[a1], x_e)))
                     X_e.append(np.hstack((X_v[a2], x_e)))
@@ -319,11 +160,189 @@ class ReactionFeaturizer(MolGraphFeaturizer):
                 b2a.extend([a1, a2])
                 b2revb.extend([b21, b12])
                 n_bonds += 2
-                # b2a.append(a1)
-                # b2a.append(a2)
-                # b2revb.append(b12)
-                # b2revb.append(b21)
 
         X_e = np.array(X_e)
 
         return MolGraph(n_atoms, n_bonds, X_v, X_e, a2b, b2a, b2revb, None, None)
+
+    def _calc_node_feature_matrix(
+        self, rct: Mol, pdt: Mol, ri2pj: dict[int, int], pids: Iterable[int], rids: Iterable[int]
+    ) -> np.ndarray:
+        """Calculate the global node feature matrix for the reaction"""
+        X_v_r1 = np.array([self.atom_featurizer(a) for a in rct.GetAtoms()])
+        X_v_p2 = np.array([self.atom_featurizer(pdt.GetAtomWithIdx(i)) for i in pids])
+        X_v_p2 = X_v_p2.reshape(-1, X_v_r1.shape[1])
+
+        if self.mode in [ReactionMode.REAC_DIFF, ReactionMode.PROD_DIFF, ReactionMode.REAC_PROD]:
+            # Reactant:
+            # (1) regular features for each atom in the reactants
+            # (2) zero features for each atom that only in the products
+            X_v_r2 = [self.atom_featurizer.featurize_num_only(pdt.GetAtomWithIdx(i)) for i in pids]
+            X_v_r2 = np.array(X_v_r2).reshape(-1, X_v_r1.shape[1])
+
+            # Product:
+            # (1) either (a) product-side features for each atom in both
+            #         or (b) zero features for each atom only in the reatants
+            # (2) regular features for each atom only in the products
+            X_v_p1 = np.array(
+                [
+                    self.atom_featurizer(pdt.GetAtomWithIdx(ri2pj[a.GetIdx()]))
+                    if a.GetIdx() not in rids
+                    else self.atom_featurizer.featurize_num_only(a)
+                    for a in rct.GetAtoms()
+                ]
+            )
+        else:
+            # Reactant:
+            # (1) regular features for each atom in the reactants
+            # (2) regular features for each atom only in the products
+            X_v_r2 = [self.atom_featurizer(pdt.GetAtomWithIdx(i)) for i in pids]
+            X_v_r2 = np.array(X_v_r2).reshape(-1, X_v_r1.shape[1])
+
+            # Product:
+            # (1) either (a) product-side features for each atom in both
+            #         or (b) reactant-side features for each atom only in the reatants
+            # (2) regular features for each atom only in the products
+            X_v_p1 = np.array(
+                [
+                    self.atom_featurizer(pdt.GetAtomWithIdx(ri2pj[a.GetIdx()]))
+                    if a.GetIdx() not in rids
+                    else self.atom_featurizer(a)
+                    for a in rct.GetAtoms()
+                ]
+            )
+
+        X_v_r = np.concatenate((X_v_r1, X_v_r2))
+        X_v_p = np.concatenate((X_v_p1, X_v_p2))
+
+        m = min(len(X_v_r), len(X_v_p))
+
+        if self.mode in [ReactionMode.REAC_PROD, ReactionMode.REAC_PROD_BALANCE]:
+            X_v = np.hstack((X_v_r[:m], X_v_p[:m, self.atom_featurizer.max_atomic_num + 1 :]))
+        else:
+            X_v_d = X_v_p[:m] - X_v_r[:m]
+            if self.mode in [ReactionMode.REAC_DIFF, ReactionMode.REAC_DIFF_BALANCE]:
+                X_v = np.hstack((X_v_r[:m], X_v_d[:m, self.atom_featurizer.max_atomic_num + 1 :]))
+            else:
+                X_v = np.hstack((X_v_p[:m], X_v_d[:m, self.atom_featurizer.max_atomic_num + 1 :]))
+
+        return X_v
+
+    def _get_bonds(
+        self,
+        rct: Bond,
+        pdt: Bond,
+        ri2pj: dict[int, int],
+        pids: Sequence[int],
+        n_atoms_r: int,
+        a1: int,
+        a2: int,
+    ) -> tuple[Bond, Bond]:
+        """get the reactant- and product-side bonds, respectively, betweeen atoms `a1` and `a2`"""
+        if a1 >= n_atoms_r and a2 >= n_atoms_r:
+            b_prod = pdt.GetBondBetweenAtoms(pids[a1 - n_atoms_r], pids[a2 - n_atoms_r])
+
+            if self.mode in [
+                ReactionMode.REAC_PROD_BALANCE,
+                ReactionMode.REAC_DIFF_BALANCE,
+                ReactionMode.PROD_DIFF_BALANCE,
+            ]:
+                b_reac = b_prod
+            else:
+                b_reac = None
+        elif a1 < n_atoms_r and a2 >= n_atoms_r:  # One atom only in product
+            b_reac = None
+
+            if a1 in ri2pj:
+                b_prod = pdt.GetBondBetweenAtoms(ri2pj[a1], pids[a2 - n_atoms_r])
+            else:  # Atom atom only in reactant, the other only in product
+                b_prod = None
+        else:
+            b_reac = rct.GetBondBetweenAtoms(a1, a2)
+
+            if a1 in ri2pj and a2 in ri2pj:  # Both atoms in both reactant and product
+                b_prod = pdt.GetBondBetweenAtoms(ri2pj[a1], ri2pj[a2])
+            else:   # One or both atoms only in reactant
+                if self.mode in [
+                    ReactionMode.REAC_PROD_BALANCE,
+                    ReactionMode.REAC_DIFF_BALANCE,
+                    ReactionMode.PROD_DIFF_BALANCE,
+                ]:
+                    b_prod = None if (a1 in ri2pj or a2 in ri2pj) else b_reac
+                else:
+                    b_prod = None
+
+        return b_reac, b_prod
+
+    def _calc_edge_feature(self, b_reac: Bond, b_prod: Bond):
+        """Calculate the global features of the two bonds"""
+        x_e_r = self.bond_featurizer(b_reac)
+        x_e_p = self.bond_featurizer(b_prod)
+
+        if self.mode in [ReactionMode.REAC_PROD, ReactionMode.REAC_PROD_BALANCE]:
+            x_e = np.hstack((x_e_r, x_e_p))
+        else:
+            x_e_d = x_e_p - x_e_r
+
+            if self.mode in [ReactionMode.REAC_DIFF, ReactionMode.REAC_DIFF_BALANCE]:
+                x_e_r = self.bond_featurizer(b_reac)
+                x_e = np.hstack((x_e_r, x_e_d))
+            else:
+                x_e_p = self.bond_featurizer(b_prod)
+                x_e = np.hstack((x_e_p, x_e_d))
+
+        return x_e
+
+    @staticmethod
+    def map_reac_to_prod(
+        reactants: Chem.Mol, products: Chem.Mol
+    ) -> tuple[dict[int, int], list[int], list[int]]:
+        """Map atom indices between corresponding atoms in the reactant and product molecules
+
+        Parameters
+        ----------
+        reactants : Chem.Mol
+            An RDKit molecule of the reactants
+        products : Chem.Mol
+            An RDKit molecule of the products
+
+        Returns
+        -------
+        ri2pi : dict[int, int]
+            A dictionary of corresponding atom indices from reactant atoms to product atoms
+        pdt_idxs : list[int]
+            atom indices of poduct atoms
+        rct_idxs : list[int]
+            atom indices of reactant atoms
+        """
+        pdt_idxs = []
+        mapno2pj = {}
+        mapnos_reac = {a.GetAtomMapNum() for a in reactants.GetAtoms()}
+
+        for a in products.GetAtoms():
+            mapno = a.GetAtomMapNum()
+            pj = a.GetIdx()
+
+            if mapno > 0:
+                mapno2pj[mapno] = pj
+                if mapno not in mapnos_reac:
+                    pdt_idxs.append(pj)
+            else:
+                pdt_idxs.append(pj)
+
+        rct_idxs = []
+        ri2pj = {}
+
+        for a in reactants.GetAtoms():
+            mapno = a.GetAtomMapNum()
+            ri = a.GetIdx()
+
+            if mapno > 0:
+                try:
+                    ri2pj[ri] = mapno2pj[mapno]
+                except KeyError:
+                    rct_idxs.append(ri)
+            else:
+                rct_idxs.append(ri)
+
+        return ri2pj, pdt_idxs, rct_idxs


### PR DESCRIPTION
## Description
This PR fixes the bugged `ReactionFeaturizer`. It was seriously incorrect but now there is parity between the two (based on a few examples of atom-mapped SMILES strings being featurized the same way). This PR also refactors the `featurize()` method be more legible. This includes factoring into several private function, updating inline comments, and renaming variables.

## Current workflow
The current `ReactionFeaturizer` would raise exceptions due to the improper dimensions of both `B` and `C` arrays during node feature matrix construction

## Bugfix
A previous PR quietly fixed a problem with the `atom/bond_fdim` and attributes of the `ReactionFeaturizer` causing the originally written code to break. It was previously passing and featurization was correct but the reported attribute values were incorrect. The new logic fixes the implementation to work with the updated attributes.

## Relevant issues
If appropriate, please tag them here and include a quick summary

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
