### PR TITLE
Molecule fingerprinting with invalid SMILES in list

### DIFF
--- a/chemprop/train/molecule_fingerprint.py
+++ b/chemprop/train/molecule_fingerprint.py
@@ -13,13 +13,16 @@ from chemprop.features import set_reaction, set_explicit_h, set_adding_hs, reset
 from chemprop.models import MoleculeModel
 
 @timeit()
-def molecule_fingerprint(args: FingerprintArgs, smiles: List[List[str]] = None) -> List[List[Optional[float]]]:
+def molecule_fingerprint(args: FingerprintArgs,
+                         smiles: List[List[str]] = None,
+                         return_invalid_smiles: bool = True) -> List[List[Optional[float]]]:
     """
     Loads data and a trained model and uses the model to encode fingerprint vectors for the data.
 
     :param args: A :class:`~chemprop.args.PredictArgs` object containing arguments for
                  loading data and a model and making predictions.
     :param smiles: List of list of SMILES to make predictions on.
+    :param return_invalid_smiles: Whether to return predictions of "Invalid SMILES" for invalid SMILES, otherwise will skip them in returned predictions.
     :return: A list of fingerprint vectors (list of floats)
     """
 
@@ -172,7 +175,15 @@ def molecule_fingerprint(args: FingerprintArgs, smiles: List[List[str]] = None) 
         for datapoint in full_data:
             writer.writerow(datapoint.row)
 
-    return all_fingerprints
+    if return_invalid_smiles:
+        full_fingerprints = np.zeros((len(full_data), total_fp_size, len(args.checkpoint_paths)), dtype='object')
+        for full_index in range(len(full_data)):
+            valid_index = full_to_valid_indices.get(full_index, None)
+            preds = all_fingerprints[valid_index] if valid_index is not None else np.full((total_fp_size, len(args.checkpoint_paths)), 'Invalid SMILES')
+            full_fingerprints[full_index] = preds
+        return full_fingerprints
+    else:
+        return all_fingerprints
 
 def model_fingerprint(model: MoleculeModel,
             data_loader: MoleculeDataLoader,


### PR DESCRIPTION
## Description
During the fingerprinting of molecules, invalid  SMILES will be ignored so there is no way to map the results back to the original SMILES list. This issue has been well described in #350.

## Bugfix / Desired workflow
Similarly to #235, a `return_invalid_smiles ` option is added to `molecule_fingerprint()`.

This `return_invalid_smiles` option indicates whether to include predictions for invalid datapoints, with the value "Invalid SMILES" in the function return. This makes it consistent with the saved value behavior. This option has been set default to True. The previous behavior before the option would have been False.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
