### PR TITLE
Add to the description of evidential regularization

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ The loss functions available for training are dependent on the selected dataset 
 * **Multiclass.** cross_entropy (default), mcc (a soft version of Matthews Correlation Coefficient)
 * **Spectra.** sid (default, spectral information divergence), wasserstein (First-order Wasserstein distance a.k.a. earthmover's distance.)
 
-The regression loss functions `mve` and `evidential` function by minimizing the negative log likelihood of a predicted uncertainty distribution. If used during training, the uncertainty predictions from these loss functions can be used for uncertainty prediction during prediction tasks.
+Dropout regularization can be applied regardless of loss function using the argument `--dropout <float>` and providing a dropout fraction between 0 and 1.
+
+The regression loss functions `mve` and `evidential` function by minimizing the negative log likelihood of a predicted uncertainty distribution. If used during training, the uncertainty predictions from these loss functions can be used for uncertainty prediction during prediction tasks. A regularization specific to evidential learning can be applied using the argument `--evidential_regularization <float>`.
 ### Metrics
 
 Metrics are used to evaluate the success of the model against the test set as the final model score and to determine the optimal epoch to save the model at based on the validation set. The primary metric used for both purposes is selected with the argument `--metric <metric>` and additional metrics for test set score only can be added with `--extra_metrics <metric1> <metric2> ...`. Supported metrics are dependent on the dataset type. Unlike loss functions, metrics do not have to be differentiable.

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -417,7 +417,8 @@ class TrainArgs(CommonArgs):
     spectra_target_floor: float = 1e-8
     """Values in targets for dataset type spectra are replaced with this value, intended to be a small positive number used to enforce positive values."""
     evidential_regularization: float = 0
-    """Value used in regularization for evidential loss function. Value used in literature was 1."""
+    """Value used in regularization for evidential loss function. The default value recommended by Soleimany et al.(2021) is 0.2. 
+    Optimal value is dataset-dependent; it is recommended that users test different values to find the best value for their model."""
     overwrite_default_atom_features: bool = False
     """
     Overwrites the default atom descriptors with the new ones instead of concatenating them.


### PR DESCRIPTION
## Description
This PR intends to add some more description to evidential regularization. This option was not previously mentioned in the readme file.

## Relevant issues
Issue #352 asks about the reason for the default value for evidential regularization being 0.0. In doing so, points out that the wrong default value was attributed to the source literature paper, Soleimany et al.(2021). This has been corrected in this PR.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
