### PR TITLE
For any multiclass task, `make_predictions` fails if option --individual_ensemble_predictions is on.

### DIFF
--- a/chemprop/uncertainty/uncertainty_estimator.py
+++ b/chemprop/uncertainty/uncertainty_estimator.py
@@ -1,3 +1,4 @@
+import numpy as np
 from typing import Iterator, List
 
 from chemprop.data import MoleculeDataset, StandardScaler
@@ -62,4 +63,4 @@ class UncertaintyEstimator:
         """
         Return separate predictions made by each individual model in an ensemble of models.
         """
-        return self.predictor.get_individual_preds()
+        return np.asarray(self.predictor.get_individual_preds())


### PR DESCRIPTION
## Description
Method `chemprop.train.make_predictions` assumes the ensemble individual predictions be of numpy array type. In case of multiclass tasks with enabled `--individual_ensemble_predictions` flag, it fails with `AttributeError: 'list' object has no attribute 'reshape'`. Please, find the MNWE below.

## Example
```python
from os import devnull

from chemprop.args import PredictArgs
from chemprop.train import load_model, make_predictions

CHECKPOINT_DIR = "/path/to/chemprop/model/dir"
predict_args = PredictArgs().parse_arg([
    "--test_path", devnull,
    "--preds_path", devnull,
    "--checkpoint_dir", CHECKPOINT_DIR,
    "--individual_ensemble_predictions"
])

(_, *rest_objects) = load_model(args=predict_args)
[[pred]] = make_predictions(args=predict_args,
                            smiles=["CCC"],
                            model_objects=(predict_args,) + tuple(rest_objects))
```

## Bugfix
This PR's fix ensures that `individual_predictions` of `chemprop.uncertainty.UncertaintyEstimator` always outputs the numpy array.