### PR TITLE
Remove deprecated numpy float types

### DIFF
--- a/chemprop/data/scaffold.py
+++ b/chemprop/data/scaffold.py
@@ -156,7 +156,7 @@ def log_scaffold_stats(data: MoleculeDataset,
     index_sets = sorted(index_sets, key=lambda idx_set: len(idx_set), reverse=True)
     for scaffold_num, index_set in enumerate(index_sets[:num_scaffolds]):
         data_set = [data[i] for i in index_set]
-        targets = np.array([d.targets for d in data_set], dtype=np.float)
+        targets = np.array([d.targets for d in data_set], dtype=float)
 
         with warnings.catch_warnings():  # Likely warning of empty slice of target has no values besides NaN
             warnings.simplefilter('ignore', category=RuntimeWarning)

--- a/scripts/examine_split_balance.py
+++ b/scripts/examine_split_balance.py
@@ -21,7 +21,7 @@ class Args(Tap):
 
 
 def compute_ratios(data: MoleculeDataset) -> np.ndarray:
-    ratios = np.nanmean(np.array(data.targets(), dtype=np.float), axis=0)
+    ratios = np.nanmean(np.array(data.targets(), dtype=float), axis=0)
     ratios = np.minimum(ratios, 1 - ratios)
 
     return ratios


### PR DESCRIPTION
## Description
Numpy has deprecated the `np.float` data type as an unnecessary duplicate of the base python `float` type. As of numpy version 1.24, this data type is no longer supported and will cause errors during running or testing. This appears to be the cause of the error in testing currently on the main branch; testing on the last PR showed passing because it was tested with an older version of numpy.

This PR replaces `np.float` with `float` in the two instances in Chemprop where it was used.