### PR TITLE
change calibration_features_path from str to List[str]

### DIFF
--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -779,7 +779,7 @@ class PredictArgs(CommonArgs):
     """Regression calibrators can output either a stdev or an inverval. """
     calibration_path: str = None
     """Path to data file to be used for uncertainty calibration."""
-    calibration_features_path: str = None
+    calibration_features_path: List[str] = None
     """Path to features data to be used with the uncertainty calibration dataset."""
     calibration_phase_features_path: str = None
     """ """


### PR DESCRIPTION
## Description
It seems calibration_features_path is expected to be a List[str] when parsed just like features_path is.

## Example / Current workflow
Providing a calibration_features_path when doing prediction results in an error.

```
Traceback (most recent call last):
  File "chemprop_fork/predict.py", line 6, in <module>
    chemprop_predict()
  File "chemprop_fork/chemprop/train/make_predictions.py", line 497, in chemprop_predict
    make_predictions(args=PredictArgs().parse_args())
  File "chemprop_fork/chemprop/utils.py", line 540, in wrap
    result = func(*args, **kwargs)
  File "chemprop_fork/chemprop/train/make_predictions.py", line 404, in make_predictions
    calibration_data = get_data(
  File "chemprop_fork/chemprop/data/utils.py", line 297, in get_data
    features_data.append(load_features(feat_path))  # each is num_data x num_features
  File "chemprop_fork/chemprop/features/utils.py", line 55, in load_features
    raise ValueError(f'Features path extension {extension} not supported.')
ValueError: Features path extension  not supported.
```

## Bugfix / Desired workflow
Changing calibration_features_path to a List[str] fixed this issue for me.

