### PR TITLE
Correct a bug in ENCE uncertainty evaluation

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1047,7 +1047,7 @@ class ChempropTests(TestCase):
         [],
     ),
     (
-        20.50925,
+        0.7223842,
         'dropout',
         'zscaling',
         'ence',
@@ -1071,7 +1071,7 @@ class ChempropTests(TestCase):
         [],
     ),
     (
-        39.07013967,
+        0.480757667,
         'ensemble',
         'zelikman_interval',
         'ence',
@@ -1095,7 +1095,7 @@ class ChempropTests(TestCase):
         [],
     ),
     (
-        757883.0509,
+        99.40899,
         'ensemble',
         None,
         'ence',


### PR DESCRIPTION
## Description
The equation for uncertainty evaluator ENCE is defined in an equation in Scalia et al.(2020). However, the equation implemented for ENCE in Chemprop neglects a square root operation on the variance, making it incorrect and not dimensionally consistent.

This PR corrects the bug and updates the testing values associated.

## Relevant issues
#356 Correctly identifies the bug in equation implementation and identifies what is needed for its correction.

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
