### PR TITLE
Simplified install with PyPI `rdkit` and git install in `setup.py`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,25 +30,25 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Set temp directories on Windows
-      shell: bash -l {0}
+      shell: bash {0}
       if: matrix.os == 'windows-latest'
       run: |
         echo "TMPDIR=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
         echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
         echo "TMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
     - name: Install dependencies
-      shell: bash -l {0}
+      shell: bash {0}
       run: |
         python -m pip install flake8 pytest parameterized
         python -m pip install -e .
     - name: Lint with flake8
-      shell: bash -l {0}
+      shell: bash {0}
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      shell: bash -l {0}
+      shell: bash {0}
       run: |
         pytest -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,9 +28,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         mamba-version: "*"
-        environment-file: environment.yml
-        channels: conda-forge, defaults
-        activate-environment: chemprop
 
     - name: Set temp directories on Windows
       shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,19 +16,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]  # TODO: fix windows permissions issues and add windows-latest
-        python-version: [3.7, 3.8]
+        python-version: ['3.7', '3.8']
         exclude:
         # excludes node 8 on macOS
           - os: macos-latest
-            python-version: 3.8
+            python-version: '3.8'
 
     steps:
     - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
-
+        architecture: x64
     - name: Set temp directories on Windows
       shell: bash -l {0}
       if: matrix.os == 'windows-latest'
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        mamba install flake8 pytest parameterized
+        python -m pip install flake8 pytest parameterized
         python -m pip install -e .
     - name: Lint with flake8
       shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ Then proceed to either option below to complete the installation. Note that on m
 
 1. `conda create -n chemprop python=3.8`
 2. `conda activate chemprop`
-3. `conda install -c conda-forge rdkit`
-4. `pip install git+https://github.com/bp-kelley/descriptastorus`
-5. `pip install chemprop`
+3. `pip install chemprop`
 
 ### Option 2: Installing from source
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,64 @@
 [metadata]
-description-file = README.md
-version = 1.5.2
+name = chemprop
+author = Kyle Swanson, Kevin Yang, Wengong Jin, Lior Hirschfeld, Allison Tam
+author_email = chemprop@mit.edu
+license = MIT
+description = Molecular Property Prediction with Message Passing Neural Networks
+keywords =
+    chemistry
+    machine learning
+    property prediction
+    message passing neural network
+    graph neural network
+url = https://github.com/chemprop/chemprop
+download_url = https://github.com/chemprop/chemprop/v_1.5.2.tar.gz
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+project_urls =
+    Documentation = https://chemprop.readthedocs.io/en/latest/
+    Source = https://github.com/chemprop/chemprop
+    PyPi = https://pypi.org/project/chemprop/
+    Demo = http://chemprop.csail.mit.edu/
+
+[options]
+packages = find:
+install_requires =
+    flask>=1.1.2
+    hyperopt>=0.2.3
+    matplotlib>=3.1.3
+    numpy>=1.18.1
+    pandas>=1.0.3
+    pandas-flavor>=0.2.0
+    scikit-learn>=0.22.2.post1
+    scipy>=1.5.2
+    sphinx>=3.1.2
+    tensorboardX>=2.0
+    torch>=1.5.2
+    tqdm>=4.45.0
+    typed-argument-parser>=1.6.1
+    rdkit>=2020.03.1.0
+    descriptastorus
+python_requires = >=3.7
+
+[options.entry_points]
+console_scripts =
+    chemprop_train=chemprop.train:chemprop_train
+    chemprop_predict=chemprop.train:chemprop_predict
+    chemprop_fingerprint=chemprop.train:chemprop_fingerprint
+    chemprop_hyperopt=chemprop.hyperparameter_optimization:chemprop_hyperopt
+    chemprop_interpret=chemprop.interpret:chemprop_interpret
+    chemprop_web=chemprop.web.run:chemprop_web
+    sklearn_train=chemprop.sklearn_train:sklearn_train
+    sklearn_predict=chemprop.sklearn_predict:sklearn_predict
+
+[options.extras_require]
+test = pytest>=6.2.2; parameterized>=0.8.1
+
+[options.package_data]
+chemprop = py.typed

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'tqdm>=4.45.0',
         'typed-argument-parser>=1.6.1',
         'rdkit>=2020.03.1.0',
-        'descriptastorus @ git+https://github.com/bp-kelley/descriptastorus'
+        'descriptastorus'
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ setup(
         'tensorboardX>=2.0',
         'torch>=1.5.2',
         'tqdm>=4.45.0',
-        'typed-argument-parser>=1.6.1'
+        'typed-argument-parser>=1.6.1',
+        'rdkit>=2020.03.1.0',
+        'descriptastorus @ git+https://github.com/bp-kelley/descriptastorus'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Description
The current install instructions require the user to separately install RDKit from the appropriate conda channel, and then install `descriptastorus` with `pip` separately before then installing `chemprop`. Now that [RDKit is on PyPI](https://pypi.org/project/rdkit-pypi/), the entire install can be consolidated into just `pip install chemprop` by adding the two dependencies to the `install_requires`.
Creating a fresh environment and running `pip install chemprop; pytest -v` passes all unit tests on my end.

## Bugfix / Desired workflow
This was all that added to `setup.py`:
```
        'rdkit>=2020.03.1.0',
        'descriptastorus @ git+https://github.com/bp-kelley/descriptastorus'
```

## Questions
 - README might need to be updated more than what I changed

## Checklist
- [x] linted with flake8?
~- [ ] (if appropriate) unit tests added?~
