### PR TITLE
Ignore invalid atom-mapped SMILES

### DIFF
--- a/chemprop/rdkit.py
+++ b/chemprop/rdkit.py
@@ -18,7 +18,7 @@ def make_mol(s: str, keep_h: bool, add_h: bool, keep_atom_map: bool):
     if add_h:
         mol = Chem.AddHs(mol)
 
-    if keep_atom_map:
+    if keep_atom_map and mol is not None:
         atom_map_numbers = tuple(atom.GetAtomMapNum() for atom in mol.GetAtoms())
         for idx, map_num in enumerate(atom_map_numbers):
             if idx + 1 != map_num:


### PR DESCRIPTION
## Description
The new functionality of atom-mapped SMILES in rdkit.py may encounter an issue when the given SMILES is invalid.

## Example / Current workflow
The following is the error message displayed when an invalid SMILES is provided.
```
Traceback (most recent call last):
  File "/home/gridsan/lmaeser/.conda/envs/chemprop/bin/chemprop_predict", line 33, in <module>
    sys.exit(load_entry_point('chemprop', 'console_scripts', 'chemprop_predict')())
  File "/home/gridsan/lmaeser/chemprop/chemprop/train/make_predictions.py", line 506, in chemprop_predict
    make_predictions(args=PredictArgs().parse_args())
  File "/home/gridsan/lmaeser/chemprop/chemprop/utils.py", line 591, in wrap
    result = func(*args, **kwargs)
  File "/home/gridsan/lmaeser/chemprop/chemprop/train/make_predictions.py", line 399, in make_predictions
    full_data, test_data, test_data_loader, full_to_valid_indices = load_data(
  File "/home/gridsan/lmaeser/chemprop/chemprop/train/make_predictions.py", line 80, in load_data
    if all(mol is not None for mol in full_data[full_index].mol):
  File "/home/gridsan/lmaeser/chemprop/chemprop/data/data.py", line 182, in mol
    mol = make_mols(self.smiles, self.is_reaction_list, self.is_explicit_h_list, self.is_adding_hs_list, self.is_keeping_atom_map_list)
  File "/home/gridsan/lmaeser/chemprop/chemprop/data/data.py", line 964, in make_mols
    mol.append(SMILES_TO_MOL[s] if s in SMILES_TO_MOL else make_mol(s, keep_h, add_h, keep_atom_map))
  File "/home/gridsan/lmaeser/chemprop/chemprop/rdkit.py", line 22, in make_mol
    atom_map_numbers = tuple(atom.GetAtomMapNum() for atom in mol.GetAtoms())
AttributeError: 'NoneType' object has no attribute 'GetAtoms'
```

## Bugfix / Desired workflow
An "if" statement has been implemented in rdkit.py to check the validity of the SMILES.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
