### PR TITLE
Avoid OverflowError when setting field size to sys.maxsize

### DIFF
--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict, defaultdict
 import sys
 import csv
+import ctypes
 from logging import Logger
 import pickle
 from random import Random
@@ -19,8 +20,8 @@ from chemprop.args import PredictArgs, TrainArgs
 from chemprop.features import load_features, load_valid_atom_or_bond_features, is_mol
 from chemprop.rdkit import make_mol
 
-# Increase maximum size of field in the csv processing
-csv.field_size_limit(sys.maxsize)
+# Increase maximum size of field in the csv processing for the current architecture
+csv.field_size_limit(int(ctypes.c_ulong(-1).value // 2))
 
 def get_header(path: str) -> List[str]:
     """


### PR DESCRIPTION
## Description
To handle large fields in a .csv file, the field size was adjusted to `sys.maxsize`. The C long variable that holds this value varies in size depending on the operating system (OS) and CPU architecture. For instance, the long type size is typically 64 bits on Nix-like OS and 32 bits on Windows OS.

When setting the new value into `csv.field_size_limit()` function, it is necessary to ensure that it falls within the long boundaries. In some cases, an exception may occur, such as the `OverflowError: Python int too large to convert to C long` error encountered on Windows OS because `sys.maxsize` is typically 64-bit wide.

## Bugfix / Desired workflow
To avoid this problem, the maximum possible limit (LONG_MAX) can be set using the method described in this [link](https://stackoverflow.com/questions/15063936/csv-error-field-larger-than-field-limit-131072/54517228#54517228).

## Relevant issues
#372 

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
