### PR TITLE
move packaging over

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,5 @@ cython_debug/
 *.sqlite3
 *.yaml
 *.tfevents.*
+*.ckpt
 chemprop/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,59 @@
 requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "chemprop"
+description = "Molecular Property Prediction with Message Passing Neural Networks"
+version = "1.5.1"
+authors = [
+    {name = "David Graff"},
+    {name = "Kevin Greenman"},
+    {name = "Oschar Wu"},
+    {name = "Kyle Swanson"},
+    {name = "Kevin Yang"},
+    {name = "Wengong Jin"},
+    {name = "Lior Hirschfeld"},
+    {name = "Allison Tam"}
+    
+]
+readme = "README.md"
+license = {text = "MIT"}
+classifiers = [
+	"Programming Language :: Python :: 3",
+	"Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"
+]
+keywords = [
+    "chemistry",
+    "machine learning",
+    "property prediction",
+    "message passing neural network",
+    "graph neural networtk"
+]
+requires-python = ">=3.11"
+dependencies = [
+    "lightning >= 2.0",
+    "numpy",
+    "pandas",
+    "rdkit",
+    "scikit-learn",
+    "scipy",
+    "torch >= 2.0",
+]
+
+[project.optional-dependencies]
+dev = ["black", "bumpversion", "flake8", "pytest", "pytest-cov"]
+docs = ["sphinx >= 1.5"]
+test = ["parameterized > 0.8", "pytest >= 6.2", "pytest-cov"]
+web = ["flask >= 1.1"]
+
+[project.urls]
+documentation = "https://chemprop.readthedocs.io/en/latest/"
+source = "https://github.com/chemprop/chemprop"
+PyPi = "https://pypi.org/project/chemprop/"
+demo = "http://chemprop.csail.mit.edu/"
+
 [tool.setuptools_scm]
 write_to = "chemprop/_version.py"
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import  setup
-
-setup()


### PR DESCRIPTION
## Description
This PR will be update both the package versions and the packaging system:

- `python >= 3.9` -> `python >= 3.11`
- `torch-1.X` -> `torch-2.X`
- `pytorch_lightning-1.X` -> `lightning-2.X`
- moving the packaging system from `setup.cfg` + `pyproject.toml` to solely `pyproject.toml`

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?