### PR TITLE
V2/bugfix example

### DIFF
--- a/chemprop/v2/models/loss.py
+++ b/chemprop/v2/models/loss.py
@@ -17,7 +17,7 @@ class LossFunction(ABC, RegistryMixin):
         pass
 
     def __call__(
-        self, preds: Tensor, targets: Tensor, mask: Tensor, w_d: Tensor = None, w_t: Tensor = None, **kwargs
+        self, preds: Tensor, targets: Tensor, mask: Tensor, w_d: Tensor | float = 1, w_t: Tensor | float = 1, **kwargs
     ):
         """Calculate the *reduced* loss function value given predicted and target values
 
@@ -43,11 +43,7 @@ class LossFunction(ABC, RegistryMixin):
             a scalar containing the fully reduced loss
         """
         L = self.calc(preds, targets, mask=mask, **kwargs)
-        if w_d is not None:
-            L = L * w_d
-        if w_t is not None:
-            L = L * w_t
-        L = L * mask
+        L = L * w_d * w_t * mask
 
         return L.sum() / mask.sum()
 

--- a/chemprop/v2/models/loss.py
+++ b/chemprop/v2/models/loss.py
@@ -17,7 +17,7 @@ class LossFunction(ABC, RegistryMixin):
         pass
 
     def __call__(
-        self, preds: Tensor, targets: Tensor, mask: Tensor, w_d: Tensor, w_t: Tensor, **kwargs
+        self, preds: Tensor, targets: Tensor, mask: Tensor, w_d: Tensor = None, w_t: Tensor = None, **kwargs
     ):
         """Calculate the *reduced* loss function value given predicted and target values
 
@@ -43,7 +43,11 @@ class LossFunction(ABC, RegistryMixin):
             a scalar containing the fully reduced loss
         """
         L = self.calc(preds, targets, mask=mask, **kwargs)
-        L = L * w_d * w_t * mask
+        if w_d is not None:
+            L = L * w_d
+        if w_t is not None:
+            L = L * w_t
+        L = L * mask
 
         return L.sum() / mask.sum()
 

--- a/chemprop/v2/models/models/base.py
+++ b/chemprop/v2/models/models/base.py
@@ -247,7 +247,7 @@ class MPNN(ABC, pl.LightningModule):
         """
         bmg, X_vd, features, *_ = batch
 
-        return (self((bmg, X_vd), X_f=features),)
+        return (self((bmg, X_vd), X_f=features), None)  # TODO: make this a tuple with uncertainty
 
     def configure_optimizers(self):
         opt = optim.Adam(self.parameters(), self.init_lr)

--- a/chemprop/v2/models/models/base.py
+++ b/chemprop/v2/models/models/base.py
@@ -247,7 +247,7 @@ class MPNN(ABC, pl.LightningModule):
         """
         bmg, X_vd, features, *_ = batch
 
-        return (self((bmg, X_vd), X_f=features), None)  # TODO: make this a tuple with uncertainty
+        return (self((bmg, X_vd), X_f=features), None)  # TODO: include uncertainty in this
 
     def configure_optimizers(self):
         opt = optim.Adam(self.parameters(), self.init_lr)

--- a/example.py
+++ b/example.py
@@ -14,7 +14,7 @@ molenc = modules.molecule_block()
 mpnn = models.RegressionMPNN(molenc, 1)
 print(mpnn)
 
-with open("./data/pdbbind_full.csv") as fid:
+with open("tests/data/regression.csv") as fid:
     reader = csv.reader(fid)
     next(reader)
     smis, scores = zip(*[(smi, float(score)) for smi, score in reader])


### PR DESCRIPTION
Fixing a few issues pointed out by an MLPDS member while trying to run the `example.py` script. 

1. File used in example is not in `tests/data`
2. Prediction step within validation doesn't work yet because we haven't implemented uncertainty yet:
```
Exception has occurred: ValueError
not enough values to unpack (expected 2, got 1)
  File "/home/kpg/chemprop/chemprop/v2/models/models/base.py", line 204, in validation_step
    preds, _ = self.predict_step(batch, batch_idx)
  File "/home/kpg/chemprop/example.py", line 47, in <module>
    trainer.fit(mpnn, train_loader, val_loader)
ValueError: not enough values to unpack (expected 2, got 1)
```
3. Loss function call doesn't work if data/target weights aren't provided
```
Exception has occurred: TypeError
LossFunction.__call__() missing 2 required positional arguments: 'w_d' and 'w_t'
  File "/home/kpg/chemprop/chemprop/v2/models/models/base.py", line 193, in training_step
    l = self.criterion(
  File "/home/kpg/chemprop/example.py", line 47, in <module>
    trainer.fit(mpnn, train_loader, val_loader)
TypeError: LossFunction.__call__() missing 2 required positional arguments: 'w_d' and 'w_t'
```
