### PR TITLE
Fixing skipped lines in csv writing when using a windows computer

### DIFF
--- a/chemprop/sklearn_predict.py
+++ b/chemprop/sklearn_predict.py
@@ -67,7 +67,7 @@ def predict_sklearn(args: SklearnPredictArgs) -> None:
             datapoint.row[pred_name] = pred
 
     # Save
-    with open(args.preds_path, 'w') as f:
+    with open(args.preds_path, 'w', newline="") as f:
         writer = csv.DictWriter(f, fieldnames=data[0].row.keys())
         writer.writeheader()
 

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -311,7 +311,7 @@ def predict_and_save(
             print(f"Saving uncertainty evaluations to {args.evaluation_scores_path}")
             if args.dataset_type == "multiclass":
                 task_names = original_task_names
-            with open(args.evaluation_scores_path, "w") as f:
+            with open(args.evaluation_scores_path, "w", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow(["evaluation_method"] + task_names)
                 for i, evaluation_method in enumerate(args.evaluation_methods):

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -300,7 +300,7 @@ def predict_and_save(
                         datapoint.row[pred_name + f"_model_{idx}"] = pred
 
         # Save
-        with open(args.preds_path, 'w') as f:
+        with open(args.preds_path, 'w', newline="") as f:
             writer = csv.DictWriter(f, fieldnames=full_data[0].row.keys())
             writer.writeheader()
 

--- a/chemprop/train/molecule_fingerprint.py
+++ b/chemprop/train/molecule_fingerprint.py
@@ -170,7 +170,7 @@ def molecule_fingerprint(args: FingerprintArgs,
             datapoint.row[fingerprint_columns[i]] = preds[i]
 
     # Write predictions
-    with open(args.preds_path, 'w') as f:
+    with open(args.preds_path, 'w', newline="") as f:
         writer = csv.DictWriter(f, fieldnames=args.smiles_columns+fingerprint_columns,extrasaction='ignore')
         writer.writeheader()
         for datapoint in full_data:

--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -675,7 +675,7 @@ def save_smiles_splits(
         if dataset is None:
             continue
 
-        with open(os.path.join(save_dir, f"{name}_smiles.csv"), "w") as f:
+        with open(os.path.join(save_dir, f"{name}_smiles.csv"), "w", newline="") as f:
             writer = csv.writer(f)
             if smiles_columns[0] == "":
                 writer.writerow(["smiles"])
@@ -684,7 +684,7 @@ def save_smiles_splits(
             for smiles in dataset.smiles():
                 writer.writerow(smiles)
 
-        with open(os.path.join(save_dir, f"{name}_full.csv"), "w") as f:
+        with open(os.path.join(save_dir, f"{name}_full.csv"), "w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(smiles_columns + task_names)
             dataset_targets = dataset.targets()
@@ -695,7 +695,7 @@ def save_smiles_splits(
         if features_path is not None:
             dataset_features = dataset.features()
             if extension_sets == {'.csv'}:
-                with open(os.path.join(save_dir, f"{name}_features.csv"), "w") as f:
+                with open(os.path.join(save_dir, f"{name}_features.csv"), "w", newline="") as f:
                     writer = csv.writer(f)
                     writer.writerow(features_header)
                     writer.writerows(dataset_features)
@@ -704,7 +704,7 @@ def save_smiles_splits(
 
         if constraints_path is not None:
             dataset_constraints = [d.raw_constraints for d in dataset._data]
-            with open(os.path.join(save_dir, f"{name}_constraints.csv"), "w") as f:
+            with open(os.path.join(save_dir, f"{name}_constraints.csv"), "w", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow(constraints_header)
                 writer.writerows(dataset_constraints)
@@ -729,7 +729,7 @@ def save_smiles_splits(
         if name == "train":
             data_weights = dataset.data_weights()
             if any([w != 1 for w in data_weights]):
-                with open(os.path.join(save_dir, f"{name}_weights.csv"), "w") as f:
+                with open(os.path.join(save_dir, f"{name}_weights.csv"), "w", newline="") as f:
                     writer = csv.writer(f)
                     writer.writerow(["data weights"])
                     for weight in data_weights:

--- a/scripts/find_similar_mols.py
+++ b/scripts/find_similar_mols.py
@@ -197,7 +197,7 @@ def save_similar_mols(test_path: str,
     # Save results
     makedirs(save_path, isfile=True)
 
-    with open(save_path, 'w') as f:
+    with open(save_path, 'w', newline="") as f:
         writer = csv.DictWriter(f, fieldnames=similar_mols[0].keys())
         writer.writeheader()
         for row in similar_mols:


### PR DESCRIPTION
## Description
The written csv files created by Chemprop include skipped lines when Chemprop is run on a Windows computer. This PR introduces a fix to avoid those skipped lines on Windows with no impact on Linux or Mac systems. The most common places this comes up are in the `test_scores.csv` output from training, the splits files generated in training when `--save_smiles_splits` is selected, and the predictions csv file generated during predictions jobs.

## Example / Current workflow
By adding `newline=""` into the with open block before csv writing, Windows systems will no longer write extraneous newlines in their csv files.
```
with open(args.evaluation_scores_path, "w", newline="") as f:
```

## Questions
This should not affect Linux or Mac systems as the handling of newlines is carried out by the csv writer in each case.

This is not the only windows-specific issue with Chemprop. It seems that users need to use `--num_workers 0` when making predictions using chemprop on a windows machine. I believe it would be a good practice to set the default to zero when a windows user is running a job and leave it as 8 for other users. This change could be bundled together with this PR or entered as a separate PR.

## Checklist
- [x ] linted with flake8?
- [ ] (if appropriate) unit tests added?
