### PR TITLE
Fix minor bugs in v2

### DIFF
--- a/chemprop/v2/data/dataloader.py
+++ b/chemprop/v2/data/dataloader.py
@@ -87,7 +87,6 @@ class MolGraphDataLoader(DataLoader):
             multiprocessing_context=multiprocessing_context,
             batch_sampler=batch_sampler,
             drop_last=drop_last,
-            sampler=sampler
         )
 
     @property

--- a/chemprop/v2/data/dataloader.py
+++ b/chemprop/v2/data/dataloader.py
@@ -11,7 +11,9 @@ from chemprop.v2.data.datasets import Datum, MolGraphDatasetBase
 from chemprop.v2.data.samplers import ClassBalanceSampler, SeededSampler
 from chemprop.v2.featurizers.molgraph import BatchMolGraph
 
-TrainingBatch = tuple[BatchMolGraph, Tensor, Tensor, Tensor, Optional[Tensor], Optional[Tensor]]
+TrainingBatch = tuple[
+    BatchMolGraph, Tensor, Tensor, Tensor, Optional[Tensor], Optional[Tensor]
+]
 
 
 def collate_batch(batch: Iterable[Datum]) -> TrainingBatch:
@@ -19,7 +21,9 @@ def collate_batch(batch: Iterable[Datum]) -> TrainingBatch:
 
     return (
         BatchMolGraph(mgs),
-        None if atom_descriptors[0] is None else torch.from_numpy(np.array(atom_descriptors, "f4")),
+        None
+        if atom_descriptors[0] is None
+        else torch.from_numpy(np.array(atom_descriptors, "f4")),
         None if features[0] is None else torch.from_numpy(np.array(features, "f4")),
         torch.from_numpy(np.array(ys, "f4")),
         torch.from_numpy(np.array(weights, "f4")).unsqueeze(1),
@@ -57,6 +61,10 @@ class MolGraphDataLoader(DataLoader):
         class_balance: bool = False,
         seed: Optional[int] = None,
         shuffle: bool = True,
+        multiprocessing_context=None,
+        batch_sampler=None,
+        drop_last=None,
+        sampler=None
     ):
         self.dset = dataset
         self.class_balance = class_balance
@@ -76,6 +84,10 @@ class MolGraphDataLoader(DataLoader):
             self.sampler,
             num_workers=num_workers,
             collate_fn=collate_batch,
+            multiprocessing_context=multiprocessing_context,
+            batch_sampler=batch_sampler,
+            drop_last=drop_last,
+            sampler=sampler
         )
 
     @property

--- a/chemprop/v2/models/__init__.py
+++ b/chemprop/v2/models/__init__.py
@@ -9,6 +9,7 @@ from .modules import (
 from .models import (
     MPNN,
     ClassificationMPNN,
+    BinaryClassificationMPNN,
     DirichletClassificationMPNN,
     MulticlassMPNN,
     DirichletMulticlassMPNN,

--- a/chemprop/v2/models/models/__init__.py
+++ b/chemprop/v2/models/models/__init__.py
@@ -1,5 +1,5 @@
 from .base import MPNN
-from .classification import ClassificationMPNN, DirichletClassificationMPNN
+from .classification import ClassificationMPNN, DirichletClassificationMPNN, BinaryClassificationMPNN
 from .multiclass import MulticlassMPNN, DirichletMulticlassMPNN
 from .regression import RegressionMPNN, MveRegressionMPNN
 from .spectral import SpectralMPNN

--- a/chemprop/v2/models/models/classification.py
+++ b/chemprop/v2/models/models/classification.py
@@ -5,7 +5,7 @@ from chemprop.v2.models.models.base import MPNN
 
 class ClassificationMPNN(MPNN):
     _DATASET_TYPE = "classification"
-    _DEFAULT_METRIC = "auroc"
+    _DEFAULT_METRIC = "roc"
 
 
 class BinaryClassificationMPNN(ClassificationMPNN):

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ install_requires =
 	scipy
 	pytorch-lightning >= 1.7
 	torch >= 1.11
+	typed-argument-parser
+    tensorboardX
+    hyperopt
 
 [options.package_data]
 chemprop =


### PR DESCRIPTION
## Description
Various minor fixes which are necessary to run v2 of chemprop smoothly

## Bugfix / Desired workflow
1) Include missing packages (see #408)
2) Include import of BinaryClassification module in the __init__.py
3) expose arguments of the super class to child to prevent lightning error while predicting (see #410)

## Relevant issues
Fixes #408
Fixes #410 --> predict fails on trained models as child class does not expose all arguments
