### PR TITLE
add job to tests action for PyPI package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,38 @@ jobs:
       shell: bash {0}
       run: |
         pytest -v
+
+  pypi:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    # only run if the tests pass
+    needs: build
+    # run only on pushes to master on chemprop
+    if:  ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'chemprop/chemprop'}}
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
+          verbose: true
+      


### PR DESCRIPTION
## Description
Adds a new job the testing GitHub action that will automatically build and upload the Python package (which conda-forge should notice and upload within a day, auto-magically).

## Example / Current workflow
Currently a manual process, which is tedious.

## Bugfix / Desired workflow
This won't run except on pushes to main on this repository.

## Questions
We will also need to generate a repo secret called `PYPI_API_TOKEN` which we can generate from pypi.org using the dev account.

## Checklist
- [] linted with flake8? (no python added)
- [ ] (if appropriate) unit tests added?
