### PR TITLE
[Fix]: Fixed issue with scipy on running gunicorn server inside a docker container.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pytorch>=1.4.0
   - rdkit>=2020.03.1.0
   - scikit-learn>=0.22.2.post1
-  - scipy>=1.4.1
+  - scipy>=1.9.0
   - tensorboardX>=2.0
   - torchvision>=0.5.0
   - tqdm>=4.45.0


### PR DESCRIPTION
## Description
`scipy>=1.4.1` is not working on running the gunicorn server inside a docker container and it gives below error

```
(base) mambauser@f8c994d6c08f:/opt/chemprop/chemprop/web$ gunicorn --bind 0.0.0.0:5000 "wsgi:build_app(init_db=True, root_folder='/opt/chemprop/data')"
[2023-07-31 08:08:46 +0000] [24] [INFO] Starting gunicorn 21.2.0
[2023-07-31 08:08:46 +0000] [24] [INFO] Listening at: http://0.0.0.0:5000 (24)
[2023-07-31 08:08:46 +0000] [24] [INFO] Using worker: sync
[2023-07-31 08:08:46 +0000] [25] [INFO] Booting worker with pid: 25
Unable to make new descriptors, descriptor generator requirements not properly installed
Traceback (most recent call last):
  File "/opt/conda/lib/python3.11/site-packages/descriptastorus/DescriptaStore.py", line 42, in <module>
    from .descriptors import MakeGenerator
  File "/opt/conda/lib/python3.11/site-packages/descriptastorus/descriptors/__init__.py", line 3, in <module>
    from .rdNormalizedDescriptors import *
  File "/opt/conda/lib/python3.11/site-packages/descriptastorus/descriptors/rdNormalizedDescriptors.py", line 49, in <module>
    dist = getattr(st, dist)
           ^^^^^^^^^^^^^^^^^
AttributeError: module 'scipy.stats' has no attribute 'gilbrat'
[2023-07-31 08:08:48 +0000] [25] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/opt/conda/lib/python3.11/site-packages/gunicorn/arbiter.py", line 609, in spawn_worker
    worker.init_process()
  File "/opt/conda/lib/python3.11/site-packages/gunicorn/workers/base.py", line 134, in init_process
    self.load_wsgi()
  File "/opt/conda/lib/python3.11/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
    self.wsgi = self.app.wsgi()
                ^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
                    ^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/gunicorn/util.py", line 371, in import_app
    mod = importlib.import_module(module)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/chemprop/chemprop/web/wsgi.py", line 5, in <module>
    from chemprop.web.app import app, db
  File "/opt/chemprop/chemprop/__init__.py", line 1, in <module>
    import chemprop.data
  File "/opt/chemprop/chemprop/data/__init__.py", line 1, in <module>
    from .data import cache_graph, cache_mol, MoleculeDatapoint, MoleculeDataset, MoleculeDataLoader, \
  File "/opt/chemprop/chemprop/data/data.py", line 11, in <module>
    from chemprop.features import get_features_generator
  File "/opt/chemprop/chemprop/features/__init__.py", line 1, in <module>
    from .features_generators import get_available_features_generators, get_features_generator, \
  File "/opt/chemprop/chemprop/features/features_generators.py", line 93, in <module>
    from descriptastorus.descriptors import rdDescriptors, rdNormalizedDescriptors
  File "/opt/conda/lib/python3.11/site-packages/descriptastorus/descriptors/__init__.py", line 3, in <module>
    from .rdNormalizedDescriptors import *
  File "/opt/conda/lib/python3.11/site-packages/descriptastorus/descriptors/rdNormalizedDescriptors.py", line 49, in <module>
    dist = getattr(st, dist)
           ^^^^^^^^^^^^^^^^^
AttributeError: module 'scipy.stats' has no attribute 'gilbrat'
[2023-07-31 08:08:48 +0000] [25] [INFO] Worker exiting (pid: 25)
[2023-07-31 08:08:48 +0000] [24] [ERROR] Worker (pid:25) exited with code 3
[2023-07-31 08:08:48 +0000] [24] [ERROR] Shutting down: Master
[2023-07-31 08:08:48 +0000] [24] [ERROR] Reason: Worker failed to boot.
```

changing `scipy>=1.4.1` to `scipy>=1.9.0` in the file `environment.yml` resolves the issue.

Fix for the issue https://github.com/chemprop/chemprop/issues/435