### PR TITLE
more efficient module checkpointing

### DIFF
--- a/chemprop/v2/data/datapoints.py
+++ b/chemprop/v2/data/datapoints.py
@@ -52,7 +52,7 @@ class MoleculeDatapointMixin:
 
     @classmethod
     def from_smi(
-        cls, smi: str, keep_h: bool = False, add_h: bool = False, *args, **kwargs
+        cls, smi: str, *args, keep_h: bool = False, add_h: bool = False, **kwargs
     ) -> MoleculeDatapointMixin:
         mol = make_mol(smi, keep_h, add_h)
 

--- a/chemprop/v2/models/hparams.py
+++ b/chemprop/v2/models/hparams.py
@@ -1,0 +1,40 @@
+from typing import Protocol, Type, TypedDict, TypeVar
+
+
+class HParamsDict(TypedDict):
+    """A dictionary containing a module's class and it's hyperparameters
+    
+    Using this type should essentially allow for initializing a module via:
+    
+    .. :code-block:: python
+        module = hparams.pop('cls')(**hparams)
+
+    """
+    cls: Type
+
+
+class HasHParams(Protocol):
+    """:class:`HasHParams` is a protocol for clases which possess an :attr:`hparams` attribute which is a dictionary containing the object's class and arguments required to initialize it.
+    
+    That is, any object which implements :class:`HasHParams` should be able to be initialized via:
+    
+    .. :code-block:: python
+
+        class Foo(HasHParams):
+            def __init__(self, *args, **kwargs):
+                ...
+        
+        foo1 = Foo(...)
+        foo1_cls = foo1.hparams['cls']
+        foo1_kwargs = {k: v for k, v in foo1.hparams.items() if k != "cls"}
+        foo2 = foo1_cls(**foo1_kwargs)
+        # code to compare foo1 and foo2 goes here and they should be equal
+    """
+    hparams: HParamsDict
+
+
+def from_hparams(hparams: HParamsDict):
+    cls= hparams['cls']
+    kwargs = {k: v for k, v in hparams.items() if k != "cls"}
+
+    return cls(**kwargs)

--- a/chemprop/v2/models/model.py
+++ b/chemprop/v2/models/model.py
@@ -85,6 +85,7 @@ class MPNN(pl.LightningModule):
         self.bn = nn.BatchNorm1d(self.message_passing.output_dim) if batch_norm else nn.Identity()
         self.readout = readout
 
+        # NOTE(degraff): should think about how to handle no supplied metric
         self.metrics = [*metrics, self.criterion] if metrics else [self.criterion]
         w_t = torch.ones(self.n_tasks) if w_t is None else torch.tensor(w_t)
         self.w_t = nn.Parameter(w_t.unsqueeze(0), False)

--- a/chemprop/v2/models/model.py
+++ b/chemprop/v2/models/model.py
@@ -204,7 +204,7 @@ class MPNN(pl.LightningModule):
         lr_sched = NoamLR(
             opt,
             self.warmup_epochs,
-            self.trainer.max_epochs,# * self.num_lrs,
+            self.trainer.max_epochs,  # * self.num_lrs,
             self.trainer.estimated_stepping_batches // self.trainer.max_epochs,
             self.init_lr,
             self.max_lr,

--- a/chemprop/v2/models/model.py
+++ b/chemprop/v2/models/model.py
@@ -82,11 +82,11 @@ class MPNN(pl.LightningModule):
 
         super().__init__()
         self.save_hyperparameters(ignore=["message_passing", "agg", "readout"])
-        self.hparams |= {
+        self.hparams.update({
             "message_passing": message_passing.hparams,
             "agg": agg.hparams,
             "readout": readout.hparams,
-        }
+        })
 
         self.message_passing = message_passing
         self.agg = agg

--- a/chemprop/v2/models/modules/agg.py
+++ b/chemprop/v2/models/modules/agg.py
@@ -5,18 +5,20 @@ import torch
 from torch import Tensor, nn
 
 from chemprop.v2.utils import ClassRegistry, pretty_shape
+from chemprop.v2.models.hparams import HasHParams
 
 AggregationRegistry = ClassRegistry()
 
 
-class Aggregation(ABC, nn.Module):
-    """An `Aggregation` module aggregates aggregates the graph-level representation into a global
+class Aggregation(ABC, nn.Module, HasHParams):
+    """An :class:`Aggregation` aggregates the node-level representation into a graph-level
     representation"""
 
     def __init__(self, dim: int = 0):
         super().__init__()
 
         self.dim = dim
+        self.hparams = {"dim": dim, "cls": self.__class__}
 
     def forward(self, H: Tensor, sizes: Sequence[int] | None) -> Tensor:
         """Aggregate the graph-level representations of a batch of graphs into their respective
@@ -101,6 +103,7 @@ class NormAggregation(Aggregation):
         super().__init__(*args, **kwargs)
 
         self.norm = norm
+        self.hparams["norm"] = norm
 
     def agg(self, H: Tensor) -> Tensor:
         return H.sum(self.dim) / self.norm

--- a/chemprop/v2/models/modules/message_passing/base.py
+++ b/chemprop/v2/models/modules/message_passing/base.py
@@ -3,6 +3,7 @@ from typing import Protocol
 from torch import nn, Tensor
 
 from chemprop.v2.featurizers.molgraph import BatchMolGraph
+from chemprop.v2.models.hparams import HasHParams
 
 
 class MessagePassingProto(Protocol):
@@ -30,5 +31,5 @@ class MessagePassingProto(Protocol):
         """
 
 
-class MessagePassingBlock(nn.Module, MessagePassingProto):
+class MessagePassingBlock(nn.Module, MessagePassingProto, HasHParams):
     pass

--- a/chemprop/v2/models/modules/message_passing/molecule.py
+++ b/chemprop/v2/models/modules/message_passing/molecule.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 from abc import abstractmethod
 
+from lightning.pytorch.core.mixins import HyperparametersMixin
 import torch
 from torch import Tensor, nn
 
@@ -12,7 +11,7 @@ from chemprop.v2.models.utils import get_activation_function
 from chemprop.v2.models.modules.message_passing.base import MessagePassingBlock
 
 
-class MessagePassingBlockBase(MessagePassingBlock):
+class MessagePassingBlockBase(MessagePassingBlock, HyperparametersMixin):
     """The base message-passing block for atom- and bond-based MPNNs
 
     NOTE: this class is an abstract base class and cannot be instantiated
@@ -59,16 +58,14 @@ class MessagePassingBlockBase(MessagePassingBlock):
         # layers_per_message: int = 1,
     ):
         super().__init__()
-
+        self.save_hyperparameters()
+        self.hparams['cls'] = self.__class__
+        
         self.W_i, self.W_h, self.W_o, self.W_d = self.build(d_v, d_e, d_h, d_vd, bias)
         self.depth = depth
         self.undirected = undirected
         self.dropout = nn.Dropout(dropout)
         self.tau = get_activation_function(activation)
-
-        # self.__output_dim = d_h
-        # if d_vd is not None:
-        #     # self.__output_dim += d_vd
 
     @property
     def output_dim(self) -> int:

--- a/chemprop/v2/models/modules/readout.py
+++ b/chemprop/v2/models/modules/readout.py
@@ -1,12 +1,14 @@
 from typing import Protocol
 
+from lightning.pytorch.core.mixins import HyperparametersMixin
 import torch
 from torch import nn, Tensor
 from torch.nn import functional as F
-from chemprop.v2.conf import DEFAULT_HIDDEN_DIM
 
+from chemprop.v2.conf import DEFAULT_HIDDEN_DIM
 from chemprop.v2.models import loss
 from chemprop.v2.models.modules.ffn import SimpleFFN
+from chemprop.v2.models.hparams import HasHParams
 from chemprop.v2.utils import ClassRegistry
 
 ReadoutRegistry = ClassRegistry()
@@ -31,11 +33,11 @@ class ReadoutProto(Protocol):
         pass
 
 
-class Readout(nn.Module, ReadoutProto):
+class Readout(nn.Module, ReadoutProto, HasHParams):
     pass
 
 
-class ReadoutFFNBase(Readout):
+class ReadoutFFNBase(Readout, HyperparametersMixin):
     _default_criterion: loss.LossFunction
 
     def __init__(
@@ -49,7 +51,9 @@ class ReadoutFFNBase(Readout):
         criterion: loss.LossFunction | None = None,
     ):
         super().__init__()
-
+        self.save_hyperparameters()
+        self.hparams['cls'] = self.__class__
+        
         self.ffn = SimpleFFN(
             input_dim, n_tasks * self.n_targets, hidden_dim, n_layers, dropout, activation
         )

--- a/chemprop/v2/models/schedulers.py
+++ b/chemprop/v2/models/schedulers.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from typing import Union
 
 import numpy as np
+from numpy.typing import ArrayLike
 from torch.optim import Optimizer
-from torch.optim.lr_scheduler import _LRScheduler
+from torch.optim.lr_scheduler import LRScheduler
 
 
-class NoamLR(_LRScheduler):
+class NoamLR(LRScheduler):
     """A Noam learning rate scheduler schedules the learning rate with a piecewise linear followed
     by an exponential decay.
 
@@ -22,17 +23,17 @@ class NoamLR(_LRScheduler):
     -----------
     optimizer : Optimizer
         A PyTorch optimizer.
-    warmup_epochs : list[float | int]
+    warmup_epochs : ArrayLike
         The number of epochs during which to linearly increase the learning rate.
-    total_epochs : list[int]
+    total_epochs : ArrayLike
         The total number of epochs.
     steps_per_epoch : int
         The number of steps (batches) per epoch.
-    init_lr : list[float]
+    init_lr : ArrayLike
         The initial learning rate.
-    max_lr : list[float]
+    max_lr : ArrayLike
         The maximum learning rate (achieved after :code:`warmup_epochs`).
-    final_lr : list[float]
+    final_lr : ArrayLike
         The final learning rate (achieved after :code:`total_epochs`).
 
     References
@@ -43,75 +44,76 @@ class NoamLR(_LRScheduler):
     def __init__(
         self,
         optimizer: Optimizer,
-        warmup_epochs: list[Union[float, int]],
-        total_epochs: list[int],
+        warmup_epochs: ArrayLike,
+        total_epochs: ArrayLike,
         steps_per_epoch: int,
-        init_lr: list[float],
-        max_lr: list[float],
-        final_lr: list[float],
+        init_lrs: ArrayLike,
+        max_lrs: ArrayLike,
+        final_lrs: ArrayLike,
     ):
-        lengths = np.array(
-            [
-                len(optimizer.param_groups),
-                len(warmup_epochs),
-                len(total_epochs),
-                len(init_lr),
-                len(max_lr),
-                len(final_lr),
-            ]
-        )
-        if not (np.diff(lengths) == 0).all():
+        self.num_lrs = len(optimizer.param_groups)
+        warmup_epochs = np.atleast_1d(warmup_epochs)
+        init_lrs = np.atleast_1d(init_lrs)
+        max_lrs = np.atleast_1d(max_lrs)
+        self.final_lrs = np.atleast_1d(final_lrs)
+
+        if not (
+            self.num_lrs
+            == len(warmup_epochs)
+            == len(init_lrs)
+            == len(max_lrs)
+            == len(self.final_lrs)
+        ):
             raise ValueError(
-                "Number of param groups must match length of: "
-                "warmup_epochs, total_epochs, steps_per_epoch, init_lr, max_lr, final_lr! "
-                f"got: {lengths[0]} param groups and respective lengths: {lengths[1:].tolist()}, "
+                "Number of param groups must match number of: "
+                "'warmup_epochs', 'init_lr', 'max_lr', 'final_lr'! "
+                f"got: {len(self.optimizer.param_groups)} param groups, "
+                f"{len(init_lrs)} init_lr, "
+                f"{len(max_lrs)} max_lr, "
+                f"{len(self.final_lrs)} final_lr"
             )
 
-        self.num_lrs = len(optimizer.param_groups)
-
-        self.optimizer = optimizer
-        self.warmup_epochs = np.array(warmup_epochs)
-        self.total_epochs = np.array(total_epochs)
-        self.steps_per_epoch = steps_per_epoch
-        self.init_lr = np.array(init_lr)
-        self.max_lr = np.array(max_lr)
-        self.final_lr = np.array(final_lr)
-
         self.current_step = 0
-        self.lr = init_lr
-        self.warmup_steps = (self.warmup_epochs * self.steps_per_epoch).astype(int)
-        self.total_steps = self.total_epochs * self.steps_per_epoch
-        self.linear_increment = (self.max_lr - self.init_lr) / self.warmup_steps
+        self.lrs = init_lrs
 
-        cooldown_steps = self.total_steps - self.warmup_steps
-        self.gamma = (self.final_lr / self.max_lr) ** (1 / cooldown_steps)
+        warmup_steps = (warmup_epochs * steps_per_epoch).astype(int)
+        total_steps = total_epochs * steps_per_epoch
+        cooldown_steps = total_steps - warmup_steps
+
+        deltas = (max_lrs - init_lrs) / warmup_steps
+        gammas = (self.final_lrs / max_lrs) ** (1 / cooldown_steps)
+
+        self.scheds = []
+        for i in range(self.num_lrs):
+            warmup = init_lrs[i] + np.arange(warmup_steps[i]) * deltas[i]
+            cooldown = max_lrs[i] * (gammas[i] ** np.arange(cooldown_steps[i]))
+            self.scheds.append(np.concatenate((warmup, cooldown)))
+        self.scheds = np.array(self.scheds)
 
         super(NoamLR, self).__init__(optimizer)
-
-    def get_lr(self) -> list[float]:
+    
+    def __len__(self) -> int:
+        """the number of steps in the learning rate schedule"""
+        return self.scheds.shape[1]
+    
+    def get_lr(self) -> np.ndarray:
         """Get a list of the current learning rates"""
-        return list(self.lr)
+        return self.lrs
 
-    def step(self, current_step: int = None):
+    def step(self, step: int | None = None):
         """Step the learning rate
 
         Parameters
         ----------
-        current_step : Optional[int], default=None
-            What step to set the learning rate to. If None, :code:`current_step += 1`.
+        step : int | None, default=None
+            What step to set the learning rate to. If ``None``, use ``self.current_step + 1``.
         """
-        if current_step is not None:
-            self.current_step = current_step
-        else:
-            self.current_step += 1
+        self.current_step = step if step is not None else self.current_step + 1
 
         for i in range(self.num_lrs):
-            if self.current_step <= self.warmup_steps[i]:
-                self.lr[i] = self.init_lr[i] + self.current_step * self.linear_increment[i]
-            elif self.current_step <= self.total_steps[i]:
-                decay_term = self.gamma[i] ** (self.current_step - self.warmup_steps[i])
-                self.lr[i] = self.max_lr[i] * decay_term
+            if self.current_step < len(self):
+                self.lrs[i] = self.scheds[i][self.current_step]
             else:
-                self.lr[i] = self.final_lr[i]
+                self.lrs[i] = self.final_lrs[i]
 
-            self.optimizer.param_groups[i]["lr"] = self.lr[i]
+            self.optimizer.param_groups[i]["lr"] = self.lrs[i]

--- a/chemprop/v2/models/schedulers.py
+++ b/chemprop/v2/models/schedulers.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 from numpy.typing import ArrayLike
 from torch.optim import Optimizer

--- a/chemprop/v2/models/utils.py
+++ b/chemprop/v2/models/utils.py
@@ -1,4 +1,5 @@
 from enum import auto
+
 from torch import nn
 
 from chemprop.v2.utils.utils import AutoName

--- a/example.py
+++ b/example.py
@@ -1,11 +1,9 @@
 import csv
 import sys
-import pdb
 
 from lightning import pytorch as pl
 import numpy as np
 from sklearn.model_selection import train_test_split
-import torch.jit
 
 from chemprop.v2 import data
 from chemprop.v2 import featurizers

--- a/example.py
+++ b/example.py
@@ -1,9 +1,11 @@
 import csv
 import sys
+import pdb
 
 from lightning import pytorch as pl
 import numpy as np
 from sklearn.model_selection import train_test_split
+import torch.jit
 
 from chemprop.v2 import data
 from chemprop.v2 import featurizers
@@ -23,15 +25,17 @@ print(mpnn)
 with open(sys.argv[1]) as fid:
     reader = csv.reader(fid)
     next(reader)
-    smis, scores = zip(*[(smi, float(score)) for smi, score in reader])
-scores = np.array(scores).reshape(-1, 1)
-all_data = [data.MoleculeDatapoint(smi, target) for smi, target in zip(smis, scores)]
+    smis, ys = zip(*[(smi, float(score)) for smi, score in reader])
+ys = np.array(ys).reshape(-1, 1)
+all_data = [data.MoleculeDatapoint.from_smi(smi, y) for smi, y in zip(smis, ys)]
 
 train_data, val_test_data = train_test_split(all_data, test_size=0.1)
 val_data, test_data = train_test_split(val_test_data, test_size=0.5)
 
 train_dset = data.MoleculeDataset(train_data, featurizer)
 scaler = train_dset.normalize_targets()
+
+pdb.set_trace()
 
 val_dset = data.MoleculeDataset(val_data, featurizer)
 val_dset.normalize_targets(scaler)


### PR DESCRIPTION
## Description
The current object model utilizes composition to enable extensibility for future clients. However, this creates a problem for model checkpointing during training where the checkpoints are twice as large as necessary.

## Current workflow
It is standard for `LightningModule`'s to call `save_hyperparameters()` at the top of their initializers, like so:

```python
class Model(LightningModule):
    def __init__(self, in_feats: int, out_feats: int):
        super().__init__()
        self.save_hyperparameters
        # do stuff to set up the model here
```
This call to `save_hyperparameters()` automatically saves both `in_feats` and `out_feats` to `self.hparams`, enabling seamless checkpoint loading for downstream applications. However, we run into problems when we create a model class which itself accepts other `nn.Module`s:

```python
class Model(LightningModule):
    def __init__(self, modelA: nn.Module, modelB: nn.Module):
        super().__init__()
        self.save_hyperparameters
        # do stuff to set up the model here
```

Again `save_hyperparameters()` *does* save both `modelA` and `modelB` to `self.hparams` and the checkpoints from this model *are* loadable, but Lightning will give a warning along the lines of:

```UserWarning: Attribute 'modelA' is an instance of `nn.Module` and is already saved during checkpointing. It is recommended to ignore them using `self.save_hyperparameters(ignore=['modelA']```

What this means in practice is not only is Lightning saving the `modelA` architecture but it is **also** saving its weights. Given that the weights will simply be overwritten by a later call to `load_state_dict()` during checkpoint loading, these weights are wasted space. Not only is this message annoying, but in the limit of large models, this can lead to unnecessarily large models.

We run into this same warning in the `MPNN` class because the `message_passing`, `agg`, and `readout` arguments are all input `nn.Module`s.

## Proposed solution
This PR introduces a workaround to this solution by making all input modules to the `MPNN` implement the `HasHParams` protocol. This is a lightweight protocol that requires any implementing class have an `hparams: dict` attribute. In turn, this dictionary has both (1) the arguments used to initialize the class and _crucially_ (2) the class `Type` itself. Essentially, a class that implements the `HasHParams` protocol is able to be reinitialized identically using just its `hparams` attribute.

We leverage this new object model to override the `MPNN.load_checkpoint()` behavior to (1) load the raw hyperparameters from the checkpoint file, (2) convert these raw hyperparameters into their corresponding `MessagePassing/Aggregation/Readout` modules, and (3) pass these into `LightningModule.load_checkpoint()` via `**kwargs` to enable both seamless and disk-efficient checkpointing.

## Questions
One open question here is how we can amend to arbitrarily nested modules. The current solution only works for singly nested modules, but I don't think it would be too difficult to extend it, and it's not something that's currently a problem.

## Relevant issues
this [issue](https://github.com/Lightning-AI/lightning/issues/11494#issue-1104690710) has covered this topic before, but the proposed solutions seem too brittle.

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
