### PR TITLE
improve the `AtomFeaturizer`

### DIFF
--- a/chemprop/v2/featurizers/atom.py
+++ b/chemprop/v2/featurizers/atom.py
@@ -35,18 +35,21 @@ class AtomFeaturizer(AtomFeaturizerProto):
     NOTE: the above signature only applies for the default arguments, as the each slice (save for
     the final two) can increase in size depending on the input arguments.
     """
+
     max_atomic_num: InitVar[int] = 100
     degrees: Sequence[int] = field(default_factory=lambda: range(6))
     formal_charges: Sequence[int] = field(default_factory=lambda: [-1, -2, 1, 2, 0])
     chiral_tags: Sequence[int] = field(default_factory=lambda: range(4))
     num_Hs: Sequence[int] = field(default_factory=lambda: range(5))
-    hybridizations: Sequence[HybridizationType] = field(default_factory=lambda: [
-        HybridizationType.SP,
-        HybridizationType.SP2,
-        HybridizationType.SP3,
-        HybridizationType.SP3D,
-        HybridizationType.SP3D2,
-    ])
+    hybridizations: Sequence[HybridizationType] = field(
+        default_factory=lambda: [
+            HybridizationType.SP,
+            HybridizationType.SP2,
+            HybridizationType.SP3,
+            HybridizationType.SP3D,
+            HybridizationType.SP3D2,
+        ]
+    )
 
     def __post_init__(self, max_atomic_num: int = 100):
         self.atomic_nums = {i: i for i in range(max_atomic_num)}
@@ -71,7 +74,7 @@ class AtomFeaturizer(AtomFeaturizerProto):
             1 + len(self.num_Hs),
             1 + len(self.hybridizations),
             1,
-            1
+            1,
         ]
         self.__size = sum(subfeat_sizes)
 

--- a/chemprop/v2/featurizers/atom.py
+++ b/chemprop/v2/featurizers/atom.py
@@ -1,9 +1,8 @@
+from dataclasses import InitVar, dataclass, field
 from typing import Protocol, Sequence
 
 import numpy as np
 from rdkit.Chem.rdchem import Atom, HybridizationType
-
-from chemprop.v2.featurizers.utils import MultiHotFeaturizerMixin
 
 
 class AtomFeaturizerProto(Protocol):
@@ -12,11 +11,12 @@ class AtomFeaturizerProto(Protocol):
     def __len__(self) -> int:
         """the length of an atomic feature vector"""
 
-    def __call__(self, a: Atom) -> np.ndarray:
+    def __call__(self, a: Atom | None) -> np.ndarray:
         """featurize the atom `a`"""
 
 
-class AtomFeaturizer(MultiHotFeaturizerMixin, AtomFeaturizerProto):
+@dataclass(repr=False, eq=False, slots=True)
+class AtomFeaturizer(AtomFeaturizerProto):
     """An `AtomFeaturizer` calculates feature vectors of RDKit atoms.
 
     The featurizations produced by this featurizer have the following (general) signature:
@@ -34,66 +34,28 @@ class AtomFeaturizer(MultiHotFeaturizerMixin, AtomFeaturizerProto):
 
     NOTE: the above signature only applies for the default arguments, as the each slice (save for
     the final two) can increase in size depending on the input arguments.
-
-    Parameters
-    ----------
-    max_atomic_num : int, default=100
-        the maximum atomic number categorized, by
-    degrees : Sequence[int] | None, default=[0, 1, 2, 3, 4, 5]
-        the categories for the atomic degree
-    formal_charges : Sequence[int] | None, default=[-1, -2, 1, 2, 0]
-        the categories for formal charge of an atom
-    chiral_tags : Sequence[int] | None, default=[0, 1, 2, 3]
-        the categories for the chirality of an atom
-    num_Hs : Sequence[int] | None, default=[0, 1, 2, 3, 4]
-        the categories for the number of hydrogens attached to an atom
-    hybridizations : Sequence[HybridizationType] | None, default=[SP, SP2, SP3, SP3D, SP3D2]
-        the categories for the hybridization of an atom
     """
+    max_atomic_num: InitVar[int] = 100
+    degrees: Sequence[int] = field(default_factory=lambda: range(6))
+    formal_charges: Sequence[int] = field(default_factory=lambda: [-1, -2, 1, 2, 0])
+    chiral_tags: Sequence[int] = field(default_factory=lambda: range(4))
+    num_Hs: Sequence[int] = field(default_factory=lambda: range(5))
+    hybridizations: Sequence[HybridizationType] = field(default_factory=lambda: [
+        HybridizationType.SP,
+        HybridizationType.SP2,
+        HybridizationType.SP3,
+        HybridizationType.SP3D,
+        HybridizationType.SP3D2,
+    ])
 
-    def __init__(
-        self,
-        max_atomic_num: int = 100,
-        degrees: Sequence[int] | None = None,
-        formal_charges: Sequence[int] | None = None,
-        chiral_tags: Sequence[int] | None = None,
-        num_Hs: Sequence[int] | None = None,
-        hybridizations: Sequence[HybridizationType] | None = None,
-    ):
-        self.max_atomic_num = max_atomic_num
-        self.atomic_nums = range(max_atomic_num)
-        self.degrees = degrees or range(6)
-        self.formal_charges = formal_charges or [-1, -2, 1, 2, 0]
-        self.chiral_tags = chiral_tags or range(4)
-        self.num_Hs = num_Hs or range(5)
-        self.hybridizations = hybridizations or [
-            HybridizationType.SP,
-            HybridizationType.SP2,
-            HybridizationType.SP3,
-            HybridizationType.SP3D,
-            HybridizationType.SP3D2,
-        ]
-
-    def __len__(self) -> int:
-        return (
-            len(self.atomic_nums)
-            + 1
-            + len(self.degrees)
-            + 1
-            + len(self.formal_charges)
-            + 1
-            + len(self.chiral_tags)
-            + 1
-            + len(self.num_Hs)
-            + 1
-            + len(self.hybridizations)
-            + 1
-            + 2
-        )
-
-    @property
-    def choicess(self) -> list[Sequence]:
-        return [
+    def __post_init__(self, max_atomic_num: int = 100):
+        self.atomic_nums = {i: i for i in range(max_atomic_num)}
+        self.degrees = {i: i for i in self.degrees}
+        self.formal_charges = {j: i for i, j in enumerate(self.formal_charges)}
+        self.chiral_tags = {i: i for i in self.chiral_tags}
+        self.num_Hs = {i: i for i in self.num_Hs}
+        self.hybridizations = {ht: i for i, ht in enumerate(self.hybridizations)}
+        self._subfeats: list[dict] = [
             self.atomic_nums,
             self.degrees,
             self.formal_charges,
@@ -101,44 +63,40 @@ class AtomFeaturizer(MultiHotFeaturizerMixin, AtomFeaturizerProto):
             self.num_Hs,
             self.hybridizations,
         ]
+        subfeat_sizes = [
+            1 + len(self.atomic_nums),
+            1 + len(self.degrees),
+            1 + len(self.formal_charges),
+            1 + len(self.chiral_tags),
+            1 + len(self.num_Hs),
+            1 + len(self.hybridizations),
+            1,
+            1
+        ]
+        self.__size = sum(subfeat_sizes)
 
-    @property
-    def subfeatures(self) -> list[str, slice]:
-        names = (
-            "atomic_num",
-            "degree",
-            "formal_charge",
-            "chiral_tag",
-            "num_Hs",
-            "hybridization",
-            "aromatic",
-            "mass",
-        )
-        sizes = [len(choices) + 1 for choices in self.choicess] + [1, 1]
-        offsets = np.cumsum([0] + sizes)
-        slices = [slice(i, j) for i, j in zip(offsets, offsets[1:])]
+    def __len__(self) -> int:
+        return self.__size
 
-        return dict(zip(names, slices))
-
-    def __call__(self, a: Atom) -> np.ndarray:
-        x = np.zeros(len(self))
+    def __call__(self, a: Atom | None) -> np.ndarray:
+        x = np.zeros(self.__size)
 
         if a is None:
             return x
 
-        bits_sizes = [
-            self.one_hot_index((a.GetAtomicNum() - 1), self.atomic_nums),
-            self.one_hot_index(a.GetTotalDegree(), self.degrees),
-            self.one_hot_index(a.GetFormalCharge(), self.formal_charges),
-            self.one_hot_index(int(a.GetChiralTag()), self.chiral_tags),
-            self.one_hot_index(int(a.GetTotalNumHs()), self.num_Hs),
-            self.one_hot_index(int(a.GetHybridization()), self.hybridizations),
+        feats = [
+            a.GetAtomicNum() - 1,
+            a.GetTotalDegree(),
+            a.GetFormalCharge(),
+            int(a.GetChiralTag()),
+            int(a.GetTotalNumHs()),
+            a.GetHybridization(),
         ]
-
         i = 0
-        for j, size in bits_sizes:
+        for feat, choices in zip(feats, self._subfeats):
+            j = choices.get(feat, len(choices))
             x[i + j] = 1
-            i += size
+            i += len(choices) + 1
         x[i] = int(a.GetIsAromatic())
         x[i + 1] = 0.01 * a.GetMass()
 
@@ -151,7 +109,7 @@ class AtomFeaturizer(MultiHotFeaturizerMixin, AtomFeaturizerProto):
         if a is None:
             return x
 
-        bit, _ = self.one_hot_index((a.GetAtomicNum() - 1), self.atomic_nums)
-        x[bit] = 1
+        i = self.atomic_nums.get(a.GetAtomicNum() - 1, len(self.atomic_nums))
+        x[i] = 1
 
         return x

--- a/chemprop/v2/featurizers/bond.py
+++ b/chemprop/v2/featurizers/bond.py
@@ -58,15 +58,6 @@ class BondFeaturizer(BondFeaturizerProto, MultiHotFeaturizerMixin):
     def __len__(self):
         return 1 + len(self.bond_types) + 2 + (len(self.stereo) + 1)
 
-    @property
-    def subfeatures(self) -> list[tuple[str, slice]]:
-        names = ("null", "bond_type", "conjugated", "ring", "stereo")
-        subfeature_sizes = [1, len(self.bond_types), 1, 1, (len(self.stereo) + 1)]
-        offsets = np.cumsum([0] + subfeature_sizes[:-1])
-        slices = [slice(i, j) for i, j in zip(offsets, offsets[1:])]
-
-        return list(zip(names, slices))
-
     def __call__(self, b: Bond) -> np.ndarray:
         x = np.zeros(len(self), int)
 


### PR DESCRIPTION
## Description
This PR reworks the internals of the `AtomFeaturizer` to make it faster

## Current model
Currently, the `AtomFeaturizer` class relies on a number of internal `Sequence`s which describe the possible choices for each subfeature in an overall atomic feature vector. During atom featurization, an atom would have some descriptors calculated and the index of the descriptor would be retrieved from the list of respective subfeature choices. I.e.,

```python
atomic_nums = range(100)
a: Chem.Atom
n = a.GetAtomicNum() - 1
i = atomic_nums.index(n) if n in atomic_nums else len(atomic_nums)
```

However, retrieving the index of an item in a sequence is O(N), so atom featurization can end up being fairly "slow"

## Proposed model
Given that the main work for atom featurization is essentially index retrieval, the internals of the `AtomFeaturizer` have been reworked from a series of `Sequence`s containing the possible choices to `dict`s (more broadly, `Mapping`s) that map from a choice to its respective index for the given subfeature. I.e.,

```python
atomic_nums = range(100)
atomic_nums_map = {j, i for i, j in enumerate(atomic_nums)}
a: Chem.Atom
n = a.GetAtomicNum() - 1
i = atomic_nums_map.get(n, atomic_nums_map))
```

## Impact
From a client-facing perspective, there is no change. `AtomFeaturizer`s are still created in the same exact way. In terms of atom featurization, the new code is approximately 20% faster:
```python
>>> smi = "O=S(=O)(c1ccc(N)cc1)N(CC(C)C)C[C@@H](O)[C@@H](NC(=O)O[C@H]2CO[C@H]3OCC[C@@H]23)Cc4ccccc4"
>>> mol = Chem.MolFromSmiles(smi)
>>> i = 5
>>> %timeit af_using_sequences(atoms[i])
5.63 µs ± 21.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
>>> %timeit af_using_maps(atoms[i])
4.41 µs ± 13 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

As a sanity check, the new featurizer produces equivalent results to the old:
```python
>>> all((af_using_sequences(a) == af_using_maps(a)).all() for a in mol.GetAtoms())
True
```

In terms of overall `MolGraph` featurization, the new `AtomFeaturizer` leads to an approximate 5% speedup:

```python
>>> %timeit mgf_with_old_af(mol)
829 µs ± 1.15 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
>>> %timeit mgf_with_new_af(mol)
783 µs ± 1.62 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
