### PR TITLE
new split per molecular weight

### DIFF
--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -272,7 +272,7 @@ class TrainArgs(CommonArgs):
     """Path to weights for each molecule in the training data, affecting the relative weight of molecules in the loss function"""
     target_weights: List[float] = None
     """Weights associated with each target, affecting the relative weight of targets in the loss function. Must match the number of target columns."""
-    split_type: Literal['random', 'scaffold_balanced', 'predetermined', 'crossval', 'cv', 'cv-no-test', 'index_predetermined', 'random_with_repeated_smiles'] = 'random'
+    split_type: Literal['random', 'scaffold_balanced', 'predetermined', 'crossval', 'cv', 'cv-no-test', 'index_predetermined', 'random_with_repeated_smiles', 'molecular_weight'] = 'random'
     """Method of splitting the data into train/val/test."""
     split_sizes: List[float] = None
     """Split proportions for train/validation/test sets."""

--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -222,18 +222,13 @@ class MoleculeDatapoint:
         """
         return [[b.GetBondTypeAsDouble() for b in self.mol[i].GetBonds()] for i in range(self.number_of_molecules)]
     @property
-    def molecular_weight(self) -> float:
+    def max_molwt(self) -> float:
         """
         Gets the maximum molecular weight among all the molecules in the :class:`MoleculeDatapoint`.
 
         :return: The maximum molecular weight.
         """
-        max_molecular_weight = 0.0  # Initialize to 0 or any suitable starting value
-        for mol in self.mol:
-            molecular_weight = Chem.rdMolDescriptors.CalcExactMolWt(mol)
-            if molecular_weight > max_molecular_weight:
-                max_molecular_weight = molecular_weight
-        return max_molecular_weight
+        return max(Chem.rdMolDescriptors.CalcExactMolWt(mol) for mol in self.mol)
 
     def set_features(self, features: np.ndarray) -> None:
         """

--- a/chemprop/data/data.py
+++ b/chemprop/data/data.py
@@ -139,7 +139,7 @@ class MoleculeDatapoint:
                         # for H2
                         elif m is not None and m.GetNumHeavyAtoms() == 0:
                             # not all features are equally long, so use methane as dummy molecule to determine length
-                            self.features.extend(np.zeros(len(features_generator(Chem.MolFromSmiles('C')))))                           
+                            self.features.extend(np.zeros(len(features_generator(Chem.MolFromSmiles('C')))))
                     else:
                         if m[0] is not None and m[1] is not None and m[0].GetNumHeavyAtoms() > 0:
                             self.features.extend(features_generator(m[0]))
@@ -221,6 +221,19 @@ class MoleculeDatapoint:
         :return: A list of bond types for each molecule.
         """
         return [[b.GetBondTypeAsDouble() for b in self.mol[i].GetBonds()] for i in range(self.number_of_molecules)]
+    @property
+    def molecular_weight(self) -> float:
+        """
+        Gets the maximum molecular weight among all the molecules in the :class:`MoleculeDatapoint`.
+
+        :return: The maximum molecular weight.
+        """
+        max_molecular_weight = 0.0  # Initialize to 0 or any suitable starting value
+        for mol in self.mol:
+            molecular_weight = Chem.rdMolDescriptors.CalcExactMolWt(mol)
+            if molecular_weight > max_molecular_weight:
+                max_molecular_weight = molecular_weight
+        return max_molecular_weight
 
     def set_features(self, features: np.ndarray) -> None:
         """

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -819,7 +819,7 @@ def split_data(data: MoleculeDataset,
 
         return MoleculeDataset(train), MoleculeDataset(val), MoleculeDataset(test)
     elif split_type == 'molecular_weight':
-        train_size, val_size, test_size = sizes[0] * len(data), sizes[1] * len(data), sizes[2] * len(data)
+        train_size, val_size, test_size = [int(size * len(data)) for size in sizes]
 
         sorted_data = sorted(data._data, key=lambda x: x.max_molwt, reverse=False)
         indices = list(range(len(sorted_data)))

--- a/chemprop/data/utils.py
+++ b/chemprop/data/utils.py
@@ -656,46 +656,6 @@ def get_inequality_targets(path: str, target_columns: List[str] = None) -> List[
                 raise ValueError(f'A target value in csv file {path} contains both ">" and "<" symbols. Inequality targets must be on one edge and not express a range.')
 
     return gt_targets, lt_targets
-def weight_split(data: MoleculeDataset,
-                 bias: str,
-                 sizes: Tuple[float, float, float] = (0.8, 0.1, 0.1)) -> Tuple[MoleculeDataset, MoleculeDataset,
-                                                                             MoleculeDataset]:
-    """
-    Splits a MoleculeDataset by molecular weight so that the largest or smallest molecules are in the train set.
-
-    :param data: A MoleculeDataset.
-    :param bias: A string indicating whether to bias the split towards the "big" or "small" molecules.
-    :param sizes: A length-3 tuple with the proportions of data in the train, validation, and test sets.
-    :param seed: Random seed for shuffling.
-    :return: A tuple of MoleculeDataset objects containing the train, validation, and test splits of the data.
-    """
-    if not (len(sizes) == 3 and sum(sizes) == 1):
-        raise ValueError(f"Invalid train/val/test splits! got: {sizes}")
-
-    train_size, val_size, test_size = sizes[0] * len(data), sizes[1] * len(data), sizes[2] * len(data)
-
-    # Sort by molecular weight
-    if bias == 'big':
-        sorted_data = sorted(data._data, key=lambda x: x.molecular_weight, reverse=True)
-    elif bias == 'small':
-        sorted_data = sorted(data._data, key=lambda x: x.molecular_weight, reverse=False)
-    else:
-        raise ValueError("Wrong bias, choose small or big")
-
-    indices = list(range(len(sorted_data)))
-
-    train_end_idx = int(train_size)
-    val_end_idx = int(train_size + val_size)
-    train_indices = indices[:train_end_idx]
-    val_indices = indices[train_end_idx:val_end_idx]
-    test_indices = indices[val_end_idx:]
-
-    # Create MoleculeDataset for each split
-    train = MoleculeDataset([sorted_data[i] for i in train_indices])
-    val = MoleculeDataset([sorted_data[i] for i in val_indices])
-    test = MoleculeDataset([sorted_data[i] for i in test_indices])
-
-    return train, val, test
 
 def split_data(data: MoleculeDataset,
                split_type: str = 'random',
@@ -859,7 +819,22 @@ def split_data(data: MoleculeDataset,
 
         return MoleculeDataset(train), MoleculeDataset(val), MoleculeDataset(test)
     elif split_type == 'molecular_weight':
-        train, val, test = weight_split(data, bias='small', sizes=sizes)
+        train_size, val_size, test_size = sizes[0] * len(data), sizes[1] * len(data), sizes[2] * len(data)
+
+        sorted_data = sorted(data._data, key=lambda x: x.max_molwt, reverse=False)
+        indices = list(range(len(sorted_data)))
+
+        train_end_idx = int(train_size)
+        val_end_idx = int(train_size + val_size)
+        train_indices = indices[:train_end_idx]
+        val_indices = indices[train_end_idx:val_end_idx]
+        test_indices = indices[val_end_idx:]
+
+        # Create MoleculeDataset for each split
+        train = MoleculeDataset([sorted_data[i] for i in train_indices])
+        val = MoleculeDataset([sorted_data[i] for i in val_indices])
+        test = MoleculeDataset([sorted_data[i] for i in test_indices])
+
         return train, val, test
     else:
         raise ValueError(f'split_type "{split_type}" not supported.')

--- a/tests/test_unit/test_data_utils.py
+++ b/tests/test_unit/test_data_utils.py
@@ -9,24 +9,26 @@ import numpy as np
 from chemprop.data import get_header, preprocess_smiles_columns, get_task_names, get_mixed_task_names, \
     get_data_weights, get_smiles, filter_invalid_smiles, MoleculeDataset, MoleculeDatapoint, get_data, split_data
 
+
 class TestGetHeader(TestCase):
     """
     Tests of the get_header function.
     """
+
     def setUp(self):
         self.temp_dir = TemporaryDirectory()
-        with open(os.path.join(self.temp_dir.name,'dummy_data.csv'),'w') as f:
+        with open(os.path.join(self.temp_dir.name, 'dummy_data.csv'), 'w') as f:
             data = 'column0,column1\nCC,10\nCCC,15'
             f.write(data)
-        
+
     def test_correct_file(self):
         """ Test correct input """
-        header = get_header(os.path.join(self.temp_dir.name,'dummy_data.csv'))
-        self.assertEqual(header,['column0','column1'])
+        header = get_header(os.path.join(self.temp_dir.name, 'dummy_data.csv'))
+        self.assertEqual(header, ['column0', 'column1'])
 
     def test_bad_path(self):
         """Test bad provided path """
-        bad_path=os.path.join(self.temp_dir.name,'bad_path.csv')
+        bad_path = os.path.join(self.temp_dir.name, 'bad_path.csv')
         with self.assertRaises(FileNotFoundError):
             get_header(bad_path)
 
@@ -36,16 +38,17 @@ class TestGetHeader(TestCase):
 
 @patch(
     "chemprop.data.utils.get_header",
-    lambda *args : [f'column{i}' for i in range(5)]
+    lambda *args: [f'column{i}' for i in range(5)]
 )
 @patch(
     "os.path.isfile",
-    lambda *args : True
+    lambda *args: True
 )
 class TestPreprocessSmiles(TestCase):
     """
     Tests of the preprocess_smiles_columns function
     """
+
     def test_basecase_1mol(self):
         """Test base case input with 1 molecule"""
         smiles_columns = preprocess_smiles_columns(
@@ -62,7 +65,7 @@ class TestPreprocessSmiles(TestCase):
             smiles_columns=None,
             number_of_molecules=2,
         )
-        self.assertEqual(smiles_columns, ['column0','column1'])
+        self.assertEqual(smiles_columns, ['column0', 'column1'])
 
     def test_specified_smiles(self):
         """Test specified smiles column"""
@@ -77,10 +80,10 @@ class TestPreprocessSmiles(TestCase):
         """Test specified smiles columns provided in a different order"""
         smiles_columns = preprocess_smiles_columns(
             path='dummy_path.txt',
-            smiles_columns=['column3','column2'],
+            smiles_columns=['column3', 'column2'],
             number_of_molecules=2,
         )
-        self.assertEqual(smiles_columns, ['column3','column2'])
+        self.assertEqual(smiles_columns, ['column3', 'column2'])
 
     def test_input_not_list(self):
         """Test case where smiles_columns provided are not a list"""
@@ -105,23 +108,24 @@ class TestPreprocessSmiles(TestCase):
         with self.assertRaises(ValueError):
             smiles_columns = preprocess_smiles_columns(
                 path='dummy_path.txt',
-                smiles_columns=['column3','not_in_file'],
+                smiles_columns=['column3', 'not_in_file'],
                 number_of_molecules=2,
             )
 
 
 @patch(
     "chemprop.data.utils.get_header",
-    lambda *args : [f'column{i}' for i in range(5)]
+    lambda *args: [f'column{i}' for i in range(5)]
 )
 @patch(
     "chemprop.data.utils.preprocess_smiles_columns",
-    lambda *args, **kwargs : ['column0','column1'] # default smiles columns if unspecified
+    lambda *args, **kwargs: ['column0', 'column1']  # default smiles columns if unspecified
 )
 class TestGetTaskNames(TestCase):
     """
     Tests of the get_task_names function.
     """
+
     def test_default_no_arguments(self):
         """Testing default behavior no arguments"""
         task_names = get_task_names(
@@ -130,7 +134,7 @@ class TestGetTaskNames(TestCase):
             target_columns=None,
             ignore_columns=None,
         )
-        self.assertEqual(task_names, ['column2','column3','column4'])
+        self.assertEqual(task_names, ['column2', 'column3', 'column4'])
 
     def test_specified_smiles_columns(self):
         """Test behavior with smiles column specified"""
@@ -140,7 +144,7 @@ class TestGetTaskNames(TestCase):
             target_columns=None,
             ignore_columns=None,
         )
-        self.assertEqual(task_names, ['column1','column2','column3','column4'])
+        self.assertEqual(task_names, ['column1', 'column2', 'column3', 'column4'])
 
     def test_specified_target_columns(self):
         """Test behavior with target columns specified"""
@@ -158,7 +162,7 @@ class TestGetTaskNames(TestCase):
             path='dummy_path.txt',
             smiles_columns=None,
             target_columns=None,
-            ignore_columns=['column2','column3'],
+            ignore_columns=['column2', 'column3'],
         )
         self.assertEqual(task_names, ['column4'])
 
@@ -167,6 +171,7 @@ class TestGetMixedTaskNames(TestCase):
     """
     Tests of the get_mixed_task_names function.
     """
+
     def setUp(self):
         self.data_path = 'tests/data/atomic_bond_regression.csv'
 
@@ -179,7 +184,9 @@ class TestGetMixedTaskNames(TestCase):
             ignore_columns=None,
             add_h=True,
         )
-        self.assertEqual(atom_target_names, ['hirshfeld_charges', 'hirshfeld_charges_plus1', 'hirshfeld_charges_minus1', 'hirshfeld_spin_density_plus1', 'hirshfeld_spin_density_minus1', 'hirshfeld_charges_fukui_neu', 'hirshfeld_charges_fukui_elec', 'NMR'])
+        self.assertEqual(atom_target_names, ['hirshfeld_charges', 'hirshfeld_charges_plus1', 'hirshfeld_charges_minus1',
+                                             'hirshfeld_spin_density_plus1', 'hirshfeld_spin_density_minus1',
+                                             'hirshfeld_charges_fukui_neu', 'hirshfeld_charges_fukui_elec', 'NMR'])
         self.assertEqual(bond_target_names, ['bond_length_matrix', 'bond_index_matrix'])
         self.assertEqual(molecule_target_names, ['homo', 'lumo'])
 
@@ -202,10 +209,13 @@ class TestGetMixedTaskNames(TestCase):
             path=self.data_path,
             smiles_columns=None,
             target_columns=None,
-            ignore_columns=['hirshfeld_charges','bond_length_matrix'],
+            ignore_columns=['hirshfeld_charges', 'bond_length_matrix'],
             add_h=True,
         )
-        self.assertEqual(atom_target_names, ['hirshfeld_charges_plus1', 'hirshfeld_charges_minus1', 'hirshfeld_spin_density_plus1', 'hirshfeld_spin_density_minus1', 'hirshfeld_charges_fukui_neu', 'hirshfeld_charges_fukui_elec', 'NMR'])
+        self.assertEqual(atom_target_names,
+                         ['hirshfeld_charges_plus1', 'hirshfeld_charges_minus1', 'hirshfeld_spin_density_plus1',
+                          'hirshfeld_spin_density_minus1', 'hirshfeld_charges_fukui_neu',
+                          'hirshfeld_charges_fukui_elec', 'NMR'])
         self.assertEqual(bond_target_names, ['bond_index_matrix'])
         self.assertEqual(molecule_target_names, ['homo', 'lumo'])
 
@@ -214,28 +224,29 @@ class TestGetDataWeights(TestCase):
     """
     Tests for the function get_data_weights.
     """
+
     def setUp(self):
         self.temp_dir = TemporaryDirectory()
 
     def test_base_case(self):
         """Testing already normalized inputs"""
-        path = os.path.join(self.temp_dir.name,'base_case.csv')
+        path = os.path.join(self.temp_dir.name, 'base_case.csv')
         with open(path, 'w') as f:
             f.write('weights\n1.5\n0.5\n1\n1\n1')
         weights = get_data_weights(path)
-        self.assertEqual(weights,[1.5,0.5,1,1,1])
+        self.assertEqual(weights, [1.5, 0.5, 1, 1, 1])
 
     def test_normalize_weights(self):
         """Testing weights that need to be normalized"""
-        path = os.path.join(self.temp_dir.name,'normalize.csv')
+        path = os.path.join(self.temp_dir.name, 'normalize.csv')
         with open(path, 'w') as f:
             f.write('weights\n3\n1\n2\n2\n2')
         weights = get_data_weights(path)
-        self.assertEqual(weights,[1.5,0.5,1,1,1])
+        self.assertEqual(weights, [1.5, 0.5, 1, 1, 1])
 
     def test_negative_weights(self):
         """Testing behavior when one of the weights is negative"""
-        path = os.path.join(self.temp_dir.name,'negativ.csv')
+        path = os.path.join(self.temp_dir.name, 'negativ.csv')
         with open(path, 'w') as f:
             f.write('weights\n3\n-1\n2\n2\n2')
         with self.assertRaises(ValueError):
@@ -247,19 +258,20 @@ class TestGetDataWeights(TestCase):
 
 @patch(
     "chemprop.data.utils.preprocess_smiles_columns",
-    lambda *args, **kwargs : ['column0','column1'] # default smiles columns if unspecified
+    lambda *args, **kwargs: ['column0', 'column1']  # default smiles columns if unspecified
 )
 class TestGetSmiles(TestCase):
     """
     Test for the get_smiles function.
     """
+
     def setUp(self):
         self.temp_dir = TemporaryDirectory()
-        self.smiles_path = os.path.join(self.temp_dir.name,'smiles.csv')
-        with open(self.smiles_path,'w') as f:
+        self.smiles_path = os.path.join(self.temp_dir.name, 'smiles.csv')
+        with open(self.smiles_path, 'w') as f:
             f.write('column0,column1\nC,CC\nCC,CN\nO,CO')
-        self.no_header_path = os.path.join(self.temp_dir.name,'no_header.csv')
-        with open(self.no_header_path,'w') as f:
+        self.no_header_path = os.path.join(self.temp_dir.name, 'no_header.csv')
+        with open(self.no_header_path, 'w') as f:
             f.write('C,CC\nCC,CN\nO,CO')
 
     def test_default_inputs(self):
@@ -267,7 +279,7 @@ class TestGetSmiles(TestCase):
         smiles = get_smiles(
             path=self.smiles_path
         )
-        self.assertEqual(smiles,[['C', 'CC'], ['CC', 'CN'], ['O', 'CO']])
+        self.assertEqual(smiles, [['C', 'CC'], ['CC', 'CN'], ['O', 'CO']])
 
     def test_specified_column_inputs(self):
         """Testing with a specified smiles column argument."""
@@ -275,15 +287,15 @@ class TestGetSmiles(TestCase):
             path=self.smiles_path,
             smiles_columns=['column1']
         )
-        self.assertEqual(smiles,[['CC'], ['CN'], ['CO']])
+        self.assertEqual(smiles, [['CC'], ['CN'], ['CO']])
 
     def test_specified_columns_changed_order(self):
         """Testing with no optional arguments."""
         smiles = get_smiles(
             path=self.smiles_path,
-            smiles_columns=['column1','column0']
+            smiles_columns=['column1', 'column0']
         )
-        self.assertEqual(smiles,[['CC', 'C'], ['CN', 'CC'], ['CO', 'O']])
+        self.assertEqual(smiles, [['CC', 'C'], ['CN', 'CC'], ['CO', 'O']])
 
     def test_noheader_1mol(self):
         """Testing with no header"""
@@ -291,7 +303,7 @@ class TestGetSmiles(TestCase):
             path=self.no_header_path,
             header=False
         )
-        self.assertEqual(smiles,[['C'], ['CC'], ['O']])
+        self.assertEqual(smiles, [['C'], ['CC'], ['O']])
 
     def test_noheader_2mol(self):
         """Testing with no header and 2 molecules."""
@@ -300,7 +312,7 @@ class TestGetSmiles(TestCase):
             number_of_molecules=2,
             header=False
         )
-        self.assertEqual(smiles,[['C', 'CC'], ['CC', 'CN'], ['O', 'CO']])
+        self.assertEqual(smiles, [['C', 'CC'], ['CC', 'CN'], ['O', 'CO']])
 
     def test_flatten(self):
         """Testing with flattened output"""
@@ -308,7 +320,7 @@ class TestGetSmiles(TestCase):
             path=self.smiles_path,
             flatten=True,
         )
-        self.assertEqual(smiles,['C', 'CC', 'CC', 'CN', 'O', 'CO'])
+        self.assertEqual(smiles, ['C', 'CC', 'CC', 'CN', 'O', 'CO'])
 
     def tearDown(self):
         self.temp_dir.cleanup()
@@ -318,51 +330,53 @@ class TestFilterInvalidSmiles(TestCase):
     """
     Tests for the filter_invalid_smiles function.
     """
+
     def test_filter_good_smiles(self):
         """Test pass through for all good smiles"""
-        smiles_list = [['C'],['CC'],['CN'],['O']]
+        smiles_list = [['C'], ['CC'], ['CN'], ['O']]
         dataset = MoleculeDataset([MoleculeDatapoint(s) for s in smiles_list])
         filtered_dataset = filter_invalid_smiles(dataset)
-        self.assertEqual(filtered_dataset.smiles(),[['C'],['CC'],['CN'],['O']])
+        self.assertEqual(filtered_dataset.smiles(), [['C'], ['CC'], ['CN'], ['O']])
 
     def test_filter_empty_smiles(self):
         """Test filter out empty smiles"""
-        smiles_list = [['C'],['CC'],[''],['O']]
+        smiles_list = [['C'], ['CC'], [''], ['O']]
         dataset = MoleculeDataset([MoleculeDatapoint(s) for s in smiles_list])
         filtered_dataset = filter_invalid_smiles(dataset)
-        self.assertEqual(filtered_dataset.smiles(),[['C'],['CC'],['O']])
+        self.assertEqual(filtered_dataset.smiles(), [['C'], ['CC'], ['O']])
 
     def test_no_heavy_smiles(self):
         """Test filter out smiles with no heavy atoms"""
-        smiles_list = [['C'],['CC'],['[HH]'],['O']]
+        smiles_list = [['C'], ['CC'], ['[HH]'], ['O']]
         dataset = MoleculeDataset([MoleculeDatapoint(s) for s in smiles_list])
         filtered_dataset = filter_invalid_smiles(dataset)
-        self.assertEqual(filtered_dataset.smiles(),[['C'],['CC'],['O']])
+        self.assertEqual(filtered_dataset.smiles(), [['C'], ['CC'], ['O']])
 
     def test_invalid_smiles(self):
         """Test filter out smiles with an invalid smiles"""
-        smiles_list = [['C'],['CC'],['cccXc'],['O']]
+        smiles_list = [['C'], ['CC'], ['cccXc'], ['O']]
         dataset = MoleculeDataset([MoleculeDatapoint(s) for s in smiles_list])
         filtered_dataset = filter_invalid_smiles(dataset)
-        self.assertEqual(filtered_dataset.smiles(),[['C'],['CC'],['O']])
+        self.assertEqual(filtered_dataset.smiles(), [['C'], ['CC'], ['O']])
 
 
 @patch(
     "chemprop.data.utils.get_data_weights",
-    lambda *args, **kwargs : np.array([1,1.5,0.5])
+    lambda *args, **kwargs: np.array([1, 1.5, 0.5])
 )
 @patch(
     "chemprop.data.utils.preprocess_smiles_columns",
-    lambda *args, **kwargs : ['column0','column1'] # default smiles columns if unspecified
+    lambda *args, **kwargs: ['column0', 'column1']  # default smiles columns if unspecified
 )
 class TestGetData(TestCase):
     """
     Tests for the get_data function. Note, not including testing for args input because that may be removed.
     """
+
     def setUp(self):
         self.temp_dir = TemporaryDirectory()
-        self.data_path = os.path.join(self.temp_dir.name,'data.csv')
-        with open(self.data_path,'w') as f:
+        self.data_path = os.path.join(self.temp_dir.name, 'data.csv')
+        with open(self.data_path, 'w') as f:
             f.write('column0,column1,column2,column3\nC,CC,0,1\nCC,CN,2,3\nO,CO,4,5')
 
     def test_return_dataset(self):
@@ -370,25 +384,25 @@ class TestGetData(TestCase):
         data = get_data(
             path=self.data_path
         )
-        self.assertIsInstance(data,MoleculeDataset)
+        self.assertIsInstance(data, MoleculeDataset)
 
     def test_smiles(self):
         """Testing the base case smiles"""
         data = get_data(
             path=self.data_path
         )
-        self.assertEqual(data.smiles(),[['C','CC'],['CC','CN'],['O','CO']])
+        self.assertEqual(data.smiles(), [['C', 'CC'], ['CC', 'CN'], ['O', 'CO']])
 
     def test_targets(self):
         """Testing the base case targets"""
         data = get_data(
             path=self.data_path
         )
-        self.assertEqual(data.targets(),[[0,1],[2,3],[4,5]])
+        self.assertEqual(data.targets(), [[0, 1], [2, 3], [4, 5]])
 
     @patch(
         "chemprop.data.utils.load_features",
-        lambda *args, **kwargs : np.array([[0,1],[2,3],[4,5]])
+        lambda *args, **kwargs: np.array([[0, 1], [2, 3], [4, 5]])
     )
     def test_features(self):
         """Testing the features return"""
@@ -397,11 +411,11 @@ class TestGetData(TestCase):
             features_path=['dummy_path.csv'],
         )
         print(data.features())
-        self.assertTrue(np.array_equal(data.features(),[[0,1],[2,3],[4,5]]))
+        self.assertTrue(np.array_equal(data.features(), [[0, 1], [2, 3], [4, 5]]))
 
     @patch(
         "chemprop.data.utils.load_features",
-        lambda *args, **kwargs : np.array([[0,1],[2,3],[4,5]])
+        lambda *args, **kwargs: np.array([[0, 1], [2, 3], [4, 5]])
     )
     def test_2features(self):
         """Testing the features return for two features paths"""
@@ -410,7 +424,7 @@ class TestGetData(TestCase):
             features_path=['dummy_path.csv', 'also_dummy_path.csv'],
         )
         print(data.features())
-        self.assertTrue(np.array_equal(data.features(),[[0,1,0,1],[2,3,2,3],[4,5,4,5]]))
+        self.assertTrue(np.array_equal(data.features(), [[0, 1, 0, 1], [2, 3, 2, 3], [4, 5, 4, 5]]))
 
     def test_dataweights(self):
         """Testing the handling of data weights"""
@@ -418,11 +432,11 @@ class TestGetData(TestCase):
             path=self.data_path,
             data_weights_path='dummy_path.csv'
         )
-        self.assertEqual(data.data_weights(),[1,1.5,0.5])
+        self.assertEqual(data.data_weights(), [1, 1.5, 0.5])
 
     @patch(
         "chemprop.data.utils.load_features",
-        lambda *args, **kwargs : np.array([[0,1],[1,0],[1,0]])
+        lambda *args, **kwargs: np.array([[0, 1], [1, 0], [1, 0]])
     )
     def test_phase_features(self):
         """Testing the handling of phase features"""
@@ -430,11 +444,11 @@ class TestGetData(TestCase):
             path=self.data_path,
             phase_features_path='dummy_path.csv'
         )
-        self.assertTrue(np.array_equal(data.phase_features(),[[0,1],[1,0],[1,0]]))
+        self.assertTrue(np.array_equal(data.phase_features(), [[0, 1], [1, 0], [1, 0]]))
 
     @patch(
         "chemprop.data.utils.load_features",
-        lambda *args, **kwargs : np.array([[0,1],[1,0],[1,0]])
+        lambda *args, **kwargs: np.array([[0, 1], [1, 0], [1, 0]])
     )
     def test_features_and_phase_features(self):
         """Testing the handling of phase features"""
@@ -443,11 +457,11 @@ class TestGetData(TestCase):
             features_path=['dummy_path.csv'],
             phase_features_path='dummy_path.csv'
         )
-        self.assertTrue(np.array_equal(data.features(),[[0,1,0,1],[1,0,1,0],[1,0,1,0]]))
+        self.assertTrue(np.array_equal(data.features(), [[0, 1, 0, 1], [1, 0, 1, 0], [1, 0, 1, 0]]))
 
     @patch(
         "chemprop.data.utils.load_features",
-        lambda *args, **kwargs : np.array([[0,2],[1,0],[1,0]])
+        lambda *args, **kwargs: np.array([[0, 2], [1, 0], [1, 0]])
     )
     def test_features_and_phase_features(self):
         """Testing the handling of phase features"""
@@ -466,23 +480,25 @@ class TestSplitData(TestCase):
     """
     Testing of the split_data function.
     """
+
     # Testing currently covers random and random_with_repeated_smiles
     def setUp(self):
-        smiles_list = [['C','CC'],['CC','CCC'],['CCC','CN'],['CN','CCN'],['CCN','CCCN'],['CCCN','CCCCN'],['CCCCN','CO'],['CO','CCO'],['CO','CCCO'],['CN','CCC']]
+        smiles_list = [['C', 'CC'], ['CC', 'CCC'], ['CCC', 'CN'], ['CN', 'CCN'], ['CCN', 'CCCN'], ['CCCN', 'CCCCN'],
+                       ['CCCCN', 'CO'], ['CO', 'CCO'], ['CO', 'CCCO'], ['CN', 'CCC']]
         self.dataset = MoleculeDataset([MoleculeDatapoint(s) for s in smiles_list])
 
     def test_splits_sum1(self):
         with self.assertRaises(ValueError):
             train, val, test = split_data(
                 data=self.dataset,
-                sizes=(0.4,0.8,0.2)
+                sizes=(0.4, 0.8, 0.2)
             )
 
     def test_three_splits_provided(self):
         with self.assertRaises(ValueError):
             train, val, test = split_data(
                 data=self.dataset,
-                sizes=(0.8,0.2)
+                sizes=(0.8, 0.2)
             )
 
     def test_random_split(self):
@@ -490,7 +506,9 @@ class TestSplitData(TestCase):
         train, val, test = split_data(
             data=self.dataset
         )
-        self.assertEqual(train.smiles(),[['CO', 'CCO'], ['CO', 'CCCO'], ['CC', 'CCC'], ['CCCN', 'CCCCN'], ['CN', 'CCN'], ['CCN', 'CCCN'], ['CCC', 'CN'], ['C', 'CC']])
+        self.assertEqual(train.smiles(),
+                         [['CO', 'CCO'], ['CO', 'CCCO'], ['CC', 'CCC'], ['CCCN', 'CCCCN'], ['CN', 'CCN'],
+                          ['CCN', 'CCCN'], ['CCC', 'CN'], ['C', 'CC']])
 
     def test_seed1(self):
         """Testing the random split with seed 1"""
@@ -498,30 +516,49 @@ class TestSplitData(TestCase):
             data=self.dataset,
             seed=1,
         )
-        self.assertEqual(train.smiles(),[['CCCCN', 'CO'], ['CO', 'CCCO'], ['CN', 'CCC'], ['CO', 'CCO'], ['CCCN', 'CCCCN'], ['CN', 'CCN'], ['C', 'CC'], ['CCN', 'CCCN']])
+        self.assertEqual(train.smiles(),
+                         [['CCCCN', 'CO'], ['CO', 'CCCO'], ['CN', 'CCC'], ['CO', 'CCO'], ['CCCN', 'CCCCN'],
+                          ['CN', 'CCN'], ['C', 'CC'], ['CCN', 'CCCN']])
 
     def test_split_4_4_2(self):
         """Testing the random split with changed sizes"""
         train, val, test = split_data(
             data=self.dataset,
-            sizes=(0.4,0.4,0.2)
+            sizes=(0.4, 0.4, 0.2)
         )
-        self.assertEqual(train.smiles(),[['CO', 'CCO'], ['CO', 'CCCO'], ['CC', 'CCC'], ['CCCN', 'CCCCN']])
+        self.assertEqual(train.smiles(), [['CO', 'CCO'], ['CO', 'CCCO'], ['CC', 'CCC'], ['CCCN', 'CCCCN']])
 
     def test_split_4_0_6(self):
         """Testing the random split with an empty set"""
         train, val, test = split_data(
             data=self.dataset,
-            sizes=(0.4,0,0.6)
+            sizes=(0.4, 0, 0.6)
         )
-        self.assertEqual(val.smiles(),[])
+        self.assertEqual(val.smiles(), [])
 
     def test_repeated_smiles(self):
         """Testing the random split with repeated smiles"""
         train, val, test = split_data(
             data=self.dataset,
-            sizes=(0.4,0.4,0.2),
+            sizes=(0.4, 0.4, 0.2),
             split_type='random_with_repeated_smiles'
         )
-        self.assertEqual(test.smiles(),[['CO', 'CCCO'], ['CO', 'CCO']])
+        self.assertEqual(test.smiles(), [['CO', 'CCCO'], ['CO', 'CCO']])
 
+    def test_molecular_weight_split(self):
+        """Testing the molecular weight-based split."""
+        train, val, test = split_data(
+            data=self.dataset,
+            sizes=(0.8, 0.1, 0.1),
+            split_type='molecular_weight'
+        )
+
+        # sort the subsets by molecular weight
+        sorted_train_mw = [dp.max_molwt for dp in train]
+        sorted_val_mw = [dp.max_molwt for dp in val]
+        sorted_test_mw = [dp.max_molwt for dp in test]
+
+        # Assert that consecutive data are sorted in descending order
+        assert np.all(np.diff(sorted_train_mw) >= 0)
+        assert np.all(np.diff(sorted_val_mw) >= 0)
+        assert np.all(np.diff(sorted_test_mw) >= 0)


### PR DESCRIPTION
## Description
Added another way to split the data based on the molecular weight. By default small molecules go to the train subset and larger to the subset. This provides a more challenging split for the generalization of the moelecules. Several datasets are biased towards small molecules so by using this split the user can assess the generalizability of the model better before applying external datasets.

## Example / Current workflow
Same call:
chemprop_train --data_path data/tox21.csv --dataset_type classification --save_dir tox21_checkpoints --split_type scaffold_balanced --save_smiles_splits  

## Bugfix / Desired workflow
The output files prove the correctness of the split.
[test_smiles.csv](https://github.com/chemprop/chemprop/files/12619953/test_smiles.csv)
[val_smiles.csv](https://github.com/chemprop/chemprop/files/12619954/val_smiles.csv)
[train_smiles.csv](https://github.com/chemprop/chemprop/files/12619955/train_smiles.csv)



## Questions
Is a unittest needed. Only the random split has.

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
