### PR TITLE
Fixed "validation auc = nan"

### DIFF
--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -16,7 +16,6 @@ import numpy as np
 from torch.optim import Adam, Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
 from tqdm import tqdm
-from scipy.stats.mstats import gmean
 
 from chemprop.args import PredictArgs, TrainArgs, FingerprintArgs
 from chemprop.data import StandardScaler, AtomBondScaler, MoleculeDataset, preprocess_smiles_columns, get_task_names
@@ -838,6 +837,11 @@ def update_prediction_args(
             )
 
 
+def gmean(array, axis=None):
+    """Geometric mean ignoring nans"""
+    return np.exp(np.nanmean(np.log(array), axis=axis))
+
+
 def multitask_mean(
     scores: np.ndarray,
     metric: str,
@@ -865,7 +869,7 @@ def multitask_mean(
     if metric in scale_dependent_metrics:
         return gmean(scores, axis=axis)
     elif metric in nonscale_dependent_metrics:
-        return np.mean(scores, axis=axis)
+        return np.nanmean(scores, axis=axis)
     else:
         raise NotImplementedError(
             f"The metric used, {metric}, has not been added to the list of\

--- a/tests/test_multitask_mean.py
+++ b/tests/test_multitask_mean.py
@@ -1,0 +1,17 @@
+import unittest
+import numpy as np
+from chemprop.utils import multitask_mean
+
+
+class TestMean(unittest.TestCase):
+    def _test_multitask_mean(self, metric_name: str):
+        scores = np.random.random(5)
+        scores[4] = np.nan
+        metric = multitask_mean(scores, metric_name)
+        self.assertTrue(np.isfinite(metric).all())
+
+    def test_classification_multitask_mean(self):
+        self._test_multitask_mean('auc')
+
+    def test_regression_multitask_mean(self):
+        self._test_multitask_mean('mae')


### PR DESCRIPTION
## Description
Commit 04094406e473a16f9b4a89d8df759f0f9498d182 introduced the `multitask_mean` function which replaced `np.nanmean`. However, the `multitask_mean` function cannot handle nans which is crucial for sparse data where a label might not be represented for a certain task. If we have only zeros or only nans in a few tasks, we should not receive nan for the average score across all the tasks. Here, I just added capability to handle nan for the `multitask_mean` function and simple test for it.

## Example / Current workflow
Unit tests introduced in this PR fails because average score is nan for an array of scores containing only 1 nan value.

## Bugfix / Desired workflow
I replaced `np.mean` with `np.nanmean` and `gmean` with `np.exp(np.nanmean(np.log(x)))`. The test is passed.

## Checklist
- `multitask_mean` can handle nan
- unit tests added
