### PR TITLE
V2 atom, bond, and molgraph featurizers unit tests

### DIFF
--- a/chemprop/v2/data/datasets.py
+++ b/chemprop/v2/data/datasets.py
@@ -13,7 +13,7 @@ from chemprop.v2.featurizers import (
     MoleculeMolGraphFeaturizerProto,
     MoleculeMolGraphFeaturizer,
     RxnMolGraphFeaturizerProto,
-    RxnMolGraphFeaturizer,
+    CGRFeaturizer,
 )
 
 
@@ -276,7 +276,7 @@ class ReactionDataset(Dataset, _MolGraphDatasetMixin):
 
     data: list[ReactionDatapoint]
     """the dataset from which to load"""
-    featurizer: RxnMolGraphFeaturizerProto = field(default_factory=RxnMolGraphFeaturizer)
+    featurizer: RxnMolGraphFeaturizerProto = field(default_factory=CGRFeaturizer)
     """the featurizer with which to generate MolGraphs of the input"""
 
     def __getitem__(self, idx: int) -> Datum:

--- a/chemprop/v2/featurizers/__init__.py
+++ b/chemprop/v2/featurizers/__init__.py
@@ -3,4 +3,4 @@ from .atom import AtomFeaturizer
 from .bond import BondFeaturizer
 from .molgraph import MolGraph, BatchMolGraph
 from .molecule import MoleculeMolGraphFeaturizer
-from .reaction import RxnMolGraphFeaturizer, RxnMode
+from .reaction import CGRFeaturizer, RxnMode

--- a/chemprop/v2/featurizers/reaction.py
+++ b/chemprop/v2/featurizers/reaction.py
@@ -37,7 +37,7 @@ class RxnMode(AutoName):
 
 
 @dataclass
-class RxnMolGraphFeaturizer(MolGraphFeaturizerMixin, RxnMolGraphFeaturizerProto):
+class CondensedGraphOfReactionFeaturizer(MolGraphFeaturizerMixin, RxnMolGraphFeaturizerProto):
     """A :class:`ReactionMolGraphFeaturizer` featurizes reactions using the condensed reaction graph method utilized in [1]_
 
     **NOTE**: This class *does not* accept a :class:`AtomFeaturizerProto` instance. This is because
@@ -315,3 +315,5 @@ class RxnMolGraphFeaturizer(MolGraphFeaturizerMixin, RxnMolGraphFeaturizerProto)
                 rct_idxs.append(ri)
 
         return ri2pj, pdt_idxs, rct_idxs
+
+CGRFeaturizer = CondensedGraphOfReactionFeaturizer

--- a/chemprop/v2/tests/unit/featurizers/test_atom.py
+++ b/chemprop/v2/tests/unit/featurizers/test_atom.py
@@ -85,7 +85,7 @@ def test_len(featurizer, expected_len):
 
 
 def test_num_subfeatures():
-    assert AtomFeaturizer().num_subfeatures == 8
+    assert len(AtomFeaturizer()._subfeats) == 6
 
 
 def test_none(featurizer):
@@ -101,16 +101,16 @@ def test_atomic_num_bit(atom, x, max_atomic_num):
         assert x[n - 1] == 1
 
 
-def test_aromatic_bit(featurizer, x, aromatic):
-    i = featurizer.subfeatures["aromatic"].start
+def test_aromatic_bit(x, aromatic):
+    i = -2
     if aromatic:
         assert x[i] == 1
     else:
         assert x[i] == 0
 
 
-def test_mass_bit(featurizer, x, mass_bit):
-    assert x[featurizer.subfeatures["mass"].start] == pytest.approx(mass_bit)
+def test_mass_bit(x, mass_bit):
+    assert x[-1] == pytest.approx(mass_bit)
 
 
 @pytest.mark.parametrize(

--- a/chemprop/v2/tests/unit/featurizers/test_atom.py
+++ b/chemprop/v2/tests/unit/featurizers/test_atom.py
@@ -83,11 +83,6 @@ def x(featurizer, atom):
 def test_len(featurizer, expected_len):
     assert len(featurizer) == expected_len
 
-
-def test_num_subfeatures():
-    assert len(AtomFeaturizer()._subfeats) == 6
-
-
 def test_none(featurizer):
     np.testing.assert_array_equal(featurizer(None), np.zeros(len(featurizer)))
 

--- a/chemprop/v2/tests/unit/featurizers/test_bond.py
+++ b/chemprop/v2/tests/unit/featurizers/test_bond.py
@@ -42,7 +42,7 @@ def bt_bit(bond, bond_types, featurizer):
     if i == -1:
         return i
 
-    return featurizer.one_hot_index(bt, featurizer.bond_types)[0] + 1 
+    return featurizer.one_hot_index(bt, featurizer.bond_types)[0] + 1
 
 
 @pytest.fixture
@@ -65,8 +65,8 @@ def test_bt_bit(x, bt_bit):
     assert x[bt_bit] == 1
 
 
-def test_conj_bit(featurizer, bond, bond_types, x):
-    conj_bit = featurizer.one_hot_index(bond_types, featurizer.bond_types)[1] 
+def test_conj_bit(featurizer, bond, x):
+    conj_bit = 1 + len(featurizer.bond_types)
     assert x[conj_bit] == int(bond.GetIsConjugated())
 
 

--- a/chemprop/v2/tests/unit/featurizers/test_bond.py
+++ b/chemprop/v2/tests/unit/featurizers/test_bond.py
@@ -42,7 +42,7 @@ def bt_bit(bond, bond_types, featurizer):
     if i == -1:
         return i
 
-    return range(len(featurizer))[featurizer.subfeatures["bond_type"].start + i]
+    return featurizer.one_hot_index(bt, featurizer.bond_types)[0] + 1 
 
 
 @pytest.fixture
@@ -65,9 +65,8 @@ def test_bt_bit(x, bt_bit):
     assert x[bt_bit] == 1
 
 
-def test_conj_bit(featurizer, x, bond):
-    conj_bit = featurizer.subfeatures["conjugated"].start
-
+def test_conj_bit(featurizer, bond, bond_types, x):
+    conj_bit = featurizer.one_hot_index(bond_types, featurizer.bond_types)[1] 
     assert x[conj_bit] == int(bond.GetIsConjugated())
 
 

--- a/chemprop/v2/tests/unit/featurizers/test_molgraph.py
+++ b/chemprop/v2/tests/unit/featurizers/test_molgraph.py
@@ -72,10 +72,10 @@ def test_atom_fdim(extra):
 
 
 def test_bond_fdim(atom_messages, extra):
-    mf = MoleculeMolGraphFeaturizer(extra_bond_fdim=extra, bond_messages=atom_messages)
+    mf = MoleculeMolGraphFeaturizer(extra_bond_fdim=extra, bond_messages= not atom_messages)
 
     if atom_messages:
-        assert mf.bond_fdim == len(mf.bond_featurizer) + extra
+        assert mf.bond_fdim == len(mf.bond_featurizer) + extra 
     else:
         assert mf.bond_fdim == len(mf.bond_featurizer) + extra + mf.atom_fdim
 
@@ -136,28 +136,28 @@ def test_invalid_bond_extra_shape(mol_featurizer, mol):
 
 
 def test_atom_extra_shape(mol, extra, atom_features_extra):
-    mf = MoleculeMolGraphFeaturizer(None, None, extra)
+    mf = MoleculeMolGraphFeaturizer(extra_atom_fdim=extra)
     mg = mf(mol, atom_features_extra=atom_features_extra)
 
     assert mg.V.shape == (mol.GetNumAtoms(), mf.atom_fdim)
 
 
 def test_atom_extra_values(mol, extra, atom_features_extra):
-    mf = MoleculeMolGraphFeaturizer(None, None, extra)
+    mf = MoleculeMolGraphFeaturizer(extra_atom_fdim=extra)
     mg = mf(mol, atom_features_extra=atom_features_extra)
 
     np.testing.assert_array_equal(mg.V[:, len(mf.atom_featurizer):], atom_features_extra)
 
 
 def test_bond_extra(mol, extra, bond_features_extra):
-    mf = MoleculeMolGraphFeaturizer(None, None, 0, extra)
+    mf = MoleculeMolGraphFeaturizer(extra_bond_fdim=extra)
     mg = mf(mol, bond_features_extra=bond_features_extra)
 
     assert mg.E.shape == (2 * mol.GetNumBonds(), mf.bond_fdim)
 
 
 def test_atom_bond_extra(mol, extra, atom_features_extra, bond_features_extra):
-    mf = MoleculeMolGraphFeaturizer(None, None, extra, extra, False)
+    mf = MoleculeMolGraphFeaturizer(extra_atom_fdim=extra, extra_bond_fdim=extra, bond_messages = True)
     mg = mf(mol, atom_features_extra, bond_features_extra)
 
     assert mg.E.shape == (

--- a/chemprop/v2/tests/unit/featurizers/test_molgraph.py
+++ b/chemprop/v2/tests/unit/featurizers/test_molgraph.py
@@ -63,7 +63,7 @@ def mg(mol, mol_featurizer):
 def test_abc():
     with pytest.raises(TypeError):
         MolGraphFeaturizerProto()
-    
+
 
 def test_atom_fdim(extra):
     mf = MoleculeMolGraphFeaturizer(extra_atom_fdim=extra)
@@ -72,10 +72,10 @@ def test_atom_fdim(extra):
 
 
 def test_bond_fdim(atom_messages, extra):
-    mf = MoleculeMolGraphFeaturizer(extra_bond_fdim=extra, bond_messages= not atom_messages)
+    mf = MoleculeMolGraphFeaturizer(extra_bond_fdim=extra, bond_messages=not atom_messages)
 
     if atom_messages:
-        assert mf.bond_fdim == len(mf.bond_featurizer) + extra 
+        assert mf.bond_fdim == len(mf.bond_featurizer) + extra
     else:
         assert mf.bond_fdim == len(mf.bond_featurizer) + extra + mf.atom_fdim
 
@@ -102,7 +102,7 @@ def test_X_e_shape(mol, mol_featurizer: MoleculeMolGraphFeaturizer, mg: MolGraph
 def test_x2y_len(mol: Chem.Mol, mg: MolGraph):
     n_a = mol.GetNumAtoms()
     n_b = mol.GetNumBonds()
-    
+
     assert len(mg.a2b) == n_a
     assert len(mg.b2a) == 2 * n_b
     assert len(mg.b2revb) == 2 * n_b
@@ -157,7 +157,7 @@ def test_bond_extra(mol, extra, bond_features_extra):
 
 
 def test_atom_bond_extra(mol, extra, atom_features_extra, bond_features_extra):
-    mf = MoleculeMolGraphFeaturizer(extra_atom_fdim=extra, extra_bond_fdim=extra, bond_messages = True)
+    mf = MoleculeMolGraphFeaturizer(extra_atom_fdim=extra, extra_bond_fdim=extra, bond_messages=True)
     mg = mf(mol, atom_features_extra, bond_features_extra)
 
     assert mg.E.shape == (


### PR DESCRIPTION
## Description
The tests for the atom, bond, and molgraph featurizers have been updated to pass in v2. RxnMolGraphFeaturizer has been renamed to CGRFeaturizer. A placeholder test_cgr.py has been added to the featurizers unit test folder. 

1. In test_atom.py, number of subfeatures has been changed to match new featurization, and the indices in the atom featurers vector have been modified to ensure checking of aromaticity and atomic mass. 
2. In test_bond.py, the one_hot_index function is used to check that the bond type and conjugation properties are set in the right index in the bond feature vector. 
3. In test_molgraph.py, a missing not was added to ensure that the bond_message argument is being set correctly during the unit test. The passing of additional atom and bond features for the unit test has also been rectified.   

