### PR TITLE
Add v2 unit test for loss functions and update loss/metrics

### DIFF
--- a/chemprop/v2/models/loss.py
+++ b/chemprop/v2/models/loss.py
@@ -257,7 +257,8 @@ class BinaryDirichletLoss(LossFunction, DirichletMixin):
         n_tasks = targets.shape[1]
         preds = preds.reshape(len(preds), n_tasks, N_CLASSES)
         y_one_hot = torch.eye(N_CLASSES, device=preds.device)[targets.long()]
-        return super(LossFunction, self).forward(preds, y_one_hot, *args)
+        
+        return DirichletMixin.forward(self, preds, y_one_hot, *args)
 
 
 @LossFunctionRegistry.register("multiclass-dirichlet")
@@ -265,7 +266,7 @@ class MulticlassDirichletLoss(LossFunction, DirichletMixin):
     def forward(self, preds: Tensor, targets: Tensor, mask: Tensor, *args) -> Tensor:
         y_one_hot = torch.eye(preds.shape[2], device=preds.device)[targets.long()]
 
-        return super(LossFunction, self).forward(preds, y_one_hot, mask)
+        return DirichletMixin.forward(self, preds, y_one_hot, mask)
 
 
 @dataclass

--- a/chemprop/v2/models/loss.py
+++ b/chemprop/v2/models/loss.py
@@ -251,22 +251,22 @@ class DirichletMixin:
 
 
 @LossFunctionRegistry.register("binary-dirichlet")
-class BinaryDirichletLoss(LossFunction, DirichletMixin):
+class BinaryDirichletLoss(DirichletMixin, LossFunction):
     def forward(self, preds: Tensor, targets: Tensor, *args) -> Tensor:
         N_CLASSES = 2
         n_tasks = targets.shape[1]
         preds = preds.reshape(len(preds), n_tasks, N_CLASSES)
         y_one_hot = torch.eye(N_CLASSES, device=preds.device)[targets.long()]
-        
-        return DirichletMixin.forward(self, preds, y_one_hot, *args)
+
+        return super().forward(preds, y_one_hot, *args)
 
 
 @LossFunctionRegistry.register("multiclass-dirichlet")
-class MulticlassDirichletLoss(LossFunction, DirichletMixin):
+class MulticlassDirichletLoss(DirichletMixin, LossFunction):
     def forward(self, preds: Tensor, targets: Tensor, mask: Tensor, *args) -> Tensor:
         y_one_hot = torch.eye(preds.shape[2], device=preds.device)[targets.long()]
 
-        return DirichletMixin.forward(self, preds, y_one_hot, mask)
+        return super().forward(preds, y_one_hot, mask)
 
 
 @dataclass

--- a/chemprop/v2/models/loss.py
+++ b/chemprop/v2/models/loss.py
@@ -67,10 +67,10 @@ class MSELoss(LossFunction):
 @LossFunctionRegistry.register("bounded-mse")
 class BoundedMSELoss(MSELoss):
     def forward(
-        self, preds: Tensor, targets: Tensor, *args, lt_mask: Tensor, gt_mask: Tensor
+        self, preds: Tensor, targets: Tensor, mask, w_s, w_t, lt_mask: Tensor, gt_mask: Tensor
     ) -> Tensor:
-        preds[preds < targets & lt_mask] = targets
-        preds[preds > targets & gt_mask] = targets
+        preds = torch.where((preds < targets) & lt_mask, targets, preds)
+        preds = torch.where((preds > targets) & gt_mask, targets, preds)
 
         return super().forward(preds, targets)
 
@@ -194,14 +194,14 @@ class MulticlassMCCLoss(LossFunction, MccMixin):
 
         p = (bin_preds * masked_data_weights).sum(0)
         t = (bin_targets * masked_data_weights).sum(0)
-        c = (bin_preds * bin_targets * masked_data_weights).sum((0, 2))
-        s = (preds * masked_data_weights).sum((0, 2))
+        c = (bin_preds * bin_targets * masked_data_weights).sum()
+        s = (preds * masked_data_weights).sum()
         s2 = s.square()
 
         # the `einsum` calls amount to calculating the batched dot product
-        cov_ytyp = c * s - torch.einsum("ij,ij->i", p, t)
-        cov_ypyp = s2 - torch.einsum("ij,ij->i", p, p)
-        cov_ytyt = s2 - torch.einsum("ij,ij->i", t, t)
+        cov_ytyp = c * s - torch.einsum("ij,ij->i", p, t) .sum()
+        cov_ypyp = s2 - torch.einsum("ij,ij->i", p, p).sum()
+        cov_ytyt = s2 - torch.einsum("ij,ij->i", t, t).sum()
 
         x = cov_ypyp * cov_ytyt
         MCC = torch.tensor(0.0, device=device) if x == 0 else cov_ytyp / x.sqrt()
@@ -257,8 +257,7 @@ class BinaryDirichletLoss(LossFunction, DirichletMixin):
         n_tasks = targets.shape[1]
         preds = preds.reshape(len(preds), n_tasks, N_CLASSES)
         y_one_hot = torch.eye(N_CLASSES, device=preds.device)[targets.long()]
-
-        return super().forward(preds, y_one_hot)
+        return super(LossFunction, self).forward(preds, y_one_hot, *args)
 
 
 @LossFunctionRegistry.register("multiclass-dirichlet")
@@ -266,7 +265,7 @@ class MulticlassDirichletLoss(LossFunction, DirichletMixin):
     def forward(self, preds: Tensor, targets: Tensor, mask: Tensor, *args) -> Tensor:
         y_one_hot = torch.eye(preds.shape[2], device=preds.device)[targets.long()]
 
-        return super().forward(preds, y_one_hot, mask)
+        return super(LossFunction, self).forward(preds, y_one_hot, mask)
 
 
 @dataclass

--- a/chemprop/v2/tests/unit/test_loss_functions.py
+++ b/chemprop/v2/tests/unit/test_loss_functions.py
@@ -24,34 +24,34 @@ from chemprop.v2.models.loss import (
     "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,mse",
     [
         (
-            torch.tensor([[-3, 2], [1, -1]], dtype=float),
-            torch.zeros([2, 2], dtype=float),
+            torch.tensor([[-3, 2], [1, -1]], dtype=torch.float),
+            torch.zeros([2, 2], dtype=torch.float),
             torch.ones([2, 2], dtype=torch.bool),
             torch.ones([2]),
             torch.ones([2]),
             torch.zeros([2, 2], dtype=torch.bool),
             torch.zeros([2, 2], dtype=torch.bool),
-            3.75000
+            torch.tensor(3.75000, dtype=torch.float)
         ),
         (
-            torch.tensor([[-3, 2], [1, -1]], dtype=float),
-            torch.zeros([2, 2], dtype=float),
+            torch.tensor([[-3, 2], [1, -1]], dtype=torch.float),
+            torch.zeros([2, 2], dtype=torch.float),
             torch.ones([2, 2], dtype=torch.bool),
             torch.ones([2]),
             torch.ones([2]),
             torch.zeros([2, 2], dtype=torch.bool),
             torch.ones([2, 2], dtype=torch.bool),
-            2.5000
+            torch.tensor(2.5000, dtype=torch.float)
         ),
         (
-            torch.tensor([[-3, 2], [1, -1]], dtype=float),
-            torch.zeros([2, 2], dtype=float),
+            torch.tensor([[-3, 2], [1, -1]], dtype=torch.float),
+            torch.zeros([2, 2], dtype=torch.float),
             torch.ones([2, 2], dtype=torch.bool),
             torch.ones([2]),
             torch.ones([2]),
             torch.ones([2, 2], dtype=torch.bool),
             torch.zeros([2, 2], dtype=torch.bool),
-            1.25000
+            torch.tensor(1.25000, dtype=torch.float)
         ),
     ]
 )
@@ -61,20 +61,20 @@ def test_BoundedMSE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, mse):
     """
     bmse_loss= BoundedMSELoss()
     loss = bmse_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    assert loss == mse
+    torch.testing.assert_close(loss, mse)
 
 
 @pytest.mark.parametrize(
     "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,likelihood",
     [(
-        torch.tensor([[0, 1]], dtype=float),
+        torch.tensor([[0, 1]], dtype=torch.float),
         torch.zeros([1, 1]),
         torch.ones([1, 2], dtype=torch.bool),
         torch.ones([1]),
         torch.ones([2]),
         torch.zeros([2], dtype=torch.bool),
         torch.zeros([2], dtype=torch.bool),
-        [[0.3989]],
+        torch.tensor(0.39894228, dtype=torch.float),
     )]
 )
 def test_MVE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, likelihood):
@@ -84,7 +84,7 @@ def test_MVE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, likelihood):
     mve_loss = MVELoss()
     nll_calc = mve_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
     likelihood_calc = np.exp(-1 * nll_calc)
-    np.testing.assert_array_almost_equal(likelihood, likelihood_calc, decimal=4)
+    torch.testing.assert_close(likelihood_calc, likelihood)
 
 
 @pytest.mark.parametrize(
@@ -99,7 +99,7 @@ def test_MVE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, likelihood):
             torch.zeros([1], dtype=torch.bool),
             torch.zeros([1], dtype=torch.bool),
             0,
-            [[0.6]]
+            torch.tensor(0.6, dtype=torch.float)
         ),
         (
             torch.tensor([[2, 2]]),
@@ -110,7 +110,7 @@ def test_MVE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, likelihood):
             torch.zeros([1], dtype=torch.bool),
             torch.zeros([1], dtype=torch.bool),
             0.2,
-            [[0.63862943]]
+            torch.tensor(0.63862943, dtype=torch.float)
         )
     ]
 )
@@ -123,7 +123,7 @@ def test_BinaryDirichlet(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v_kl,
     binary_dirichlet_loss = BinaryDirichletLoss(v_kl = v_kl)
     loss = binary_dirichlet_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
     print(loss)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)
 
 
 @pytest.mark.parametrize(
@@ -162,7 +162,7 @@ def test_BinaryDirichlet_wrong_dimensions(preds, targets, mask, w_s, w_t, lt_mas
             torch.zeros([2], dtype=torch.bool),
             torch.zeros([2], dtype=torch.bool),
             0.2,
-            [[1.868991]]
+            torch.tensor(1.868991, dtype=torch.float)
         ),
         (
             torch.tensor([[[0.2, 0.1, 0.3],[0.1, 0.3, 0.1]],[[1.2, 0.5, 1.7],[1.1, 1.4, 0.8]]]),
@@ -173,7 +173,7 @@ def test_BinaryDirichlet_wrong_dimensions(preds, targets, mask, w_s, w_t, lt_mas
             torch.zeros([2], dtype=torch.bool),
             torch.zeros([2], dtype=torch.bool),
             0.0,
-            [[1.102344]]
+            torch.tensor(1.102344, dtype=torch.float)
         )
     ]
 )
@@ -185,7 +185,7 @@ def test_MulticlassDirichlet(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v
     """
     multiclass_dirichlet_loss = MulticlassDirichletLoss(v_kl)
     loss = multiclass_dirichlet_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)
 
 
 @pytest.mark.parametrize(
@@ -200,7 +200,7 @@ def test_MulticlassDirichlet(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v
             torch.zeros([1], dtype=torch.bool),
             torch.zeros([1], dtype=torch.bool),
             0,
-            [[1.56893861]]
+            torch.tensor(1.56893861, dtype=torch.float)
         ),
         (
             torch.tensor([[2, 2, 2, 2]]),
@@ -211,7 +211,7 @@ def test_MulticlassDirichlet(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v
             torch.zeros([1], dtype=torch.bool),
             torch.zeros([1], dtype=torch.bool),
             0.2,
-            [[2.768938541]]
+            torch.tensor(2.768938541, dtype=torch.float)
         )
     ]
 )
@@ -223,7 +223,7 @@ def test_Evidential(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v_kl, expe
     """
     evidential_loss = EvidentialLoss(v_kl=v_kl)
     loss = evidential_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)
 
 
 @pytest.mark.parametrize(
@@ -254,24 +254,24 @@ def test_Evidential_wrong_dimensions(preds, targets, mask, w_s, w_t, lt_mask, gt
     "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,expected_loss",
     [
         (
-            torch.tensor([2, 2], dtype=float),
-            torch.ones([2], dtype=float),
+            torch.tensor([2, 2], dtype=torch.float),
+            torch.ones([2], dtype=torch.float),
             torch.ones([2], dtype=torch.bool),
             torch.ones([1]),
             torch.ones([2]),
             torch.zeros([2], dtype=torch.bool),
             torch.zeros([2], dtype=torch.bool),
-            [[0.126928]]
+            torch.tensor(0.126928, dtype=torch.float)
         ),
         (
-            torch.tensor([0.5, 0.5], dtype=float),
-            torch.ones([2], dtype=float),
+            torch.tensor([0.5, 0.5], dtype=torch.float),
+            torch.ones([2], dtype=torch.float),
             torch.ones([2], dtype=torch.bool),
             torch.ones([1]),
             torch.ones([2]),
             torch.zeros([2], dtype=torch.bool),
             torch.zeros([2], dtype=torch.bool),
-            [[0.474077]]
+            torch.tensor(0.474077, dtype=torch.float)
         )
     ]
 )
@@ -281,7 +281,7 @@ def test_BCE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_loss):
     """
     bce_loss = BCELoss()
     loss = bce_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)
 
 
 @pytest.mark.parametrize(
@@ -295,7 +295,7 @@ def test_BCE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_loss):
             torch.ones([2]),
             torch.ones([2,2], dtype=torch.bool),
             torch.ones([2,2], dtype=torch.bool),
-            [[1.34214]]
+            torch.tensor(1.34214, dtype=torch.float)
         ),
         (
             torch.tensor([[[1.2, 1.5, 0.7],[-0.1, 2.3, 1.1]],[[1.2, 1.5, 1.7],[2.1, 1.3, 1.1]]]),
@@ -305,7 +305,7 @@ def test_BCE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_loss):
             torch.ones([2]),
             torch.ones([2,2], dtype=torch.bool),
             torch.ones([2,2], dtype=torch.bool),
-            [[0.899472]]
+            torch.tensor(0.899472, dtype=torch.float)
         )
     ]
 )
@@ -317,7 +317,7 @@ def test_CrossEntropy(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected
     """
     cross_entropy_loss = CrossEntropyLoss()
     loss = cross_entropy_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)
 
 
 @pytest.mark.parametrize(
@@ -331,7 +331,7 @@ def test_CrossEntropy(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected
             torch.ones(4),
             torch.zeros([1,4], dtype=torch.bool),
             torch.zeros([1,4], dtype=torch.bool),
-            [0]
+            torch.tensor(0, dtype=torch.float)
         ),
         (
             torch.tensor([0, 1, 0, 1, 1, 1, 0, 1, 1]),
@@ -341,7 +341,7 @@ def test_CrossEntropy(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected
             torch.ones(9),
             torch.zeros([1,9], dtype=torch.bool),
             torch.zeros([1,9], dtype=torch.bool),
-            [0.683772]
+            torch.tensor(0.683772, dtype=torch.float)
         ),
     ]
 )
@@ -351,7 +351,7 @@ def test_BinaryMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_lo
     """
     binary_mcc_loss = BinaryMCCLoss()
     loss = binary_mcc_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)
 
 
 @pytest.mark.parametrize(
@@ -365,7 +365,7 @@ def test_BinaryMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_lo
             torch.ones([2]),
             torch.zeros([2,2], dtype=torch.bool),
             torch.zeros([2,2], dtype=torch.bool),
-            [0.2697033]
+            torch.tensor(0.2697033, dtype=torch.float)
         ),
         (
             torch.tensor([[[0.16, 0.26, 0.58],[0.22, 0.61, 0.17]],[[0.71, 0.09, 0.20],[0.05, 0.82, 0.13]]]),
@@ -375,7 +375,7 @@ def test_BinaryMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_lo
             torch.ones([2]),
             torch.zeros([2,2], dtype = bool),
             torch.zeros([2,2], dtype = bool),
-            [0.3876276]
+            torch.tensor(0.3876276, dtype=torch.float)
         ),
     ]
 )
@@ -385,7 +385,7 @@ def test_MulticlassMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expecte
     """
     multiclass_mcc_loss = MulticlassMCCLoss()
     loss = multiclass_mcc_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)
 
 
 @pytest.mark.parametrize(
@@ -400,7 +400,7 @@ def test_MulticlassMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expecte
             torch.ones([2], dtype=torch.bool),
             torch.ones([2], dtype=torch.bool),
             None,
-            [[0.031319]]
+            torch.tensor(0.031319, dtype=torch.float)
         ),
         (
             torch.tensor([[0.6, 0.4], [0.2, 0.8]]),
@@ -411,7 +411,7 @@ def test_MulticlassMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expecte
             torch.ones([2], dtype=torch.bool),
             torch.ones([2], dtype=torch.bool),
             None,
-            [[0.295655]]
+            torch.tensor(0.295655, dtype=torch.float)
         ),
         (
             torch.tensor([[0.6, 0.4], [0.2, 0.8]]),
@@ -422,7 +422,7 @@ def test_MulticlassMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expecte
             torch.ones([2], dtype=torch.bool),
             torch.ones([2], dtype=torch.bool),
             0.5,
-            [[0.033673]]
+            torch.tensor(0.033673, dtype=torch.float)
         ),
     ]
 )
@@ -433,7 +433,7 @@ def test_SID(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, threshold, expect
     """
     sid_loss = SIDLoss(threshold)
     loss = sid_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)
 
 
 @pytest.mark.parametrize(
@@ -448,7 +448,7 @@ def test_SID(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, threshold, expect
             torch.zeros([2,4], dtype=torch.bool),
             torch.zeros([2,4], dtype=torch.bool),
             None,
-            [[0.1125]]
+            torch.tensor(0.1125, dtype=torch.float)
         ),
         (
             torch.tensor([[0.1, 0.3, 0.5, 0.7],[0.2, 0.4, 0.6, 0.8]]),
@@ -459,7 +459,7 @@ def test_SID(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, threshold, expect
             torch.zeros([2,4], dtype=torch.bool),
             torch.zeros([2,4], dtype=torch.bool),
             None,
-           [[0.515625]]
+           torch.tensor(0.515625, dtype=torch.float)
         ),
         (
             torch.tensor([[0.1, 0.3, 0.5, 0.7],[0.2, 0.4, 0.6, 0.8]]),
@@ -470,7 +470,7 @@ def test_SID(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, threshold, expect
             torch.zeros([2,4], dtype=torch.bool),
             torch.zeros([2,4], dtype=torch.bool),
             0.3,
-            [[0.501984]]
+            torch.tensor(0.501984, dtype=torch.float)
         ),
     ]
 )
@@ -481,4 +481,4 @@ def test_Wasserstein(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, threshold
     """
     wasserstein_loss = WassersteinLoss(threshold)
     loss = wasserstein_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    np.testing.assert_array_almost_equal(loss, expected_loss)
+    torch.testing.assert_close(loss, expected_loss)

--- a/chemprop/v2/tests/unit/test_loss_functions.py
+++ b/chemprop/v2/tests/unit/test_loss_functions.py
@@ -122,7 +122,6 @@ def test_BinaryDirichlet(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v_kl,
     """
     binary_dirichlet_loss = BinaryDirichletLoss(v_kl = v_kl)
     loss = binary_dirichlet_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
-    print(loss)
     torch.testing.assert_close(loss, expected_loss)
 
 

--- a/chemprop/v2/tests/unit/test_loss_functions.py
+++ b/chemprop/v2/tests/unit/test_loss_functions.py
@@ -1,0 +1,484 @@
+"""Chemprop unit tests for chemprop/v2/models/loss.py"""
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+import pytest
+
+from chemprop.v2.models.loss import (
+    BoundedMSELoss,
+    MVELoss,
+    BinaryDirichletLoss,
+    MulticlassDirichletLoss,
+    EvidentialLoss,
+    BCELoss,
+    CrossEntropyLoss,
+    BinaryMCCLoss,
+    MulticlassMCCLoss,
+    SIDLoss,
+    WassersteinLoss
+)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,mse",
+    [
+        (
+            torch.tensor([[-3, 2], [1, -1]], dtype=float),
+            torch.zeros([2, 2], dtype=float),
+            torch.ones([2, 2], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([2]),
+            torch.zeros([2, 2], dtype=torch.bool),
+            torch.zeros([2, 2], dtype=torch.bool),
+            3.75000
+        ),
+        (
+            torch.tensor([[-3, 2], [1, -1]], dtype=float),
+            torch.zeros([2, 2], dtype=float),
+            torch.ones([2, 2], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([2]),
+            torch.zeros([2, 2], dtype=torch.bool),
+            torch.ones([2, 2], dtype=torch.bool),
+            2.5000
+        ),
+        (
+            torch.tensor([[-3, 2], [1, -1]], dtype=float),
+            torch.zeros([2, 2], dtype=float),
+            torch.ones([2, 2], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([2]),
+            torch.ones([2, 2], dtype=torch.bool),
+            torch.zeros([2, 2], dtype=torch.bool),
+            1.25000
+        ),
+    ]
+)
+def test_BoundedMSE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, mse):
+    """
+    Testing the bounded_mse loss function
+    """
+    bmse_loss= BoundedMSELoss()
+    loss = bmse_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    assert loss == mse
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,likelihood",
+    [(
+        torch.tensor([[0, 1]], dtype=float),
+        torch.zeros([1, 1]),
+        torch.ones([1, 2], dtype=torch.bool),
+        torch.ones([1]),
+        torch.ones([2]),
+        torch.zeros([2], dtype=torch.bool),
+        torch.zeros([2], dtype=torch.bool),
+        [[0.3989]],
+    )]
+)
+def test_MVE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, likelihood):
+    """
+    Tests the normal_mve loss function
+    """
+    mve_loss = MVELoss()
+    nll_calc = mve_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    likelihood_calc = np.exp(-1 * nll_calc)
+    np.testing.assert_array_almost_equal(likelihood, likelihood_calc, decimal=4)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,v_kl,expected_loss",
+    [
+        (
+            torch.tensor([[2, 2]]),
+            torch.ones([1, 1]),
+            torch.ones([1, 2], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([1]),
+            torch.zeros([1], dtype=torch.bool),
+            torch.zeros([1], dtype=torch.bool),
+            0,
+            [[0.6]]
+        ),
+        (
+            torch.tensor([[2, 2]]),
+            torch.ones([1, 1]),
+            torch.ones([1, 2], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([1]),
+            torch.zeros([1], dtype=torch.bool),
+            torch.zeros([1], dtype=torch.bool),
+            0.2,
+            [[0.63862943]]
+        )
+    ]
+)
+def test_BinaryDirichlet(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v_kl, expected_loss):
+    """
+    Test on the dirichlet loss function for classification.
+    Note these values were not hand derived, just testing for
+    dimensional consistency.
+    """
+    binary_dirichlet_loss = BinaryDirichletLoss(v_kl = v_kl)
+    loss = binary_dirichlet_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    print(loss)
+    np.testing.assert_array_almost_equal(loss, expected_loss)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,",
+    [
+        (
+            torch.ones([1, 1]),
+            torch.ones([1, 1]),
+            torch.ones([1, 2], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([1]),
+            torch.zeros([1], dtype=torch.bool),
+            torch.zeros([1], dtype=torch.bool),
+        ),
+    ]
+)
+def test_BinaryDirichlet_wrong_dimensions(preds, targets, mask, w_s, w_t, lt_mask, gt_mask):
+    """
+    Test on the dirichlet loss function for classification
+    for dimension errors.
+    """
+    with pytest.raises(RuntimeError):
+        binary_dirichlet_loss = BinaryDirichletLoss()
+        binary_dirichlet_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,v_kl,expected_loss",
+    [
+        (
+            torch.tensor([[[0.2, 0.1, 0.3],[0.1, 0.3, 0.1]],[[1.2, 0.5, 1.7],[1.1, 1.4, 0.8]]]),
+            torch.tensor([[0, 0],[1,1]]),
+            torch.ones([2,2], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([2]),
+            torch.zeros([2], dtype=torch.bool),
+            torch.zeros([2], dtype=torch.bool),
+            0.2,
+            [[1.868991]]
+        ),
+        (
+            torch.tensor([[[0.2, 0.1, 0.3],[0.1, 0.3, 0.1]],[[1.2, 0.5, 1.7],[1.1, 1.4, 0.8]]]),
+            torch.tensor([[0, 0],[1,1]]),
+            torch.ones([2,2], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([2]),
+            torch.zeros([2], dtype=torch.bool),
+            torch.zeros([2], dtype=torch.bool),
+            0.0,
+            [[1.102344]]
+        )
+    ]
+)
+def test_MulticlassDirichlet(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v_kl, expected_loss):
+    """
+    Test on the dirichlet loss function for classification.
+    Note these values were not hand derived, just testing for
+    dimensional consistency.
+    """
+    multiclass_dirichlet_loss = MulticlassDirichletLoss(v_kl)
+    loss = multiclass_dirichlet_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    np.testing.assert_array_almost_equal(loss, expected_loss)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,v_kl,expected_loss",
+    [
+        (
+            torch.tensor([[2, 2, 2, 2]]),
+            torch.ones([1, 1]),
+            torch.ones([1, 1], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([1]),
+            torch.zeros([1], dtype=torch.bool),
+            torch.zeros([1], dtype=torch.bool),
+            0,
+            [[1.56893861]]
+        ),
+        (
+            torch.tensor([[2, 2, 2, 2]]),
+            torch.ones([1, 1]),
+            torch.ones([1, 1], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([1]),
+            torch.zeros([1], dtype=torch.bool),
+            torch.zeros([1], dtype=torch.bool),
+            0.2,
+            [[2.768938541]]
+        )
+    ]
+)
+def test_Evidential(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, v_kl, expected_loss):
+    """
+    Test on the evidential loss function for classification.
+    Note these values were not hand derived, just testing for
+    dimensional consistency.
+    """
+    evidential_loss = EvidentialLoss(v_kl=v_kl)
+    loss = evidential_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    np.testing.assert_array_almost_equal(loss, expected_loss)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask",
+    [
+        (
+            torch.ones([2, 2]),
+            torch.ones([2, 2]),
+            torch.ones([1, 1], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([1]),
+            torch.zeros([1], dtype=torch.bool),
+            torch.zeros([1], dtype=torch.bool),
+        ),
+    ]
+)
+def test_Evidential_wrong_dimensions(preds, targets, mask, w_s, w_t, lt_mask, gt_mask):
+    """
+    Test on the Evidential loss function for classification
+    for dimension errors.
+    """
+    evidential_loss = EvidentialLoss()
+    with pytest.raises(ValueError):
+        loss = evidential_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,expected_loss",
+    [
+        (
+            torch.tensor([2, 2], dtype=float),
+            torch.ones([2], dtype=float),
+            torch.ones([2], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([2]),
+            torch.zeros([2], dtype=torch.bool),
+            torch.zeros([2], dtype=torch.bool),
+            [[0.126928]]
+        ),
+        (
+            torch.tensor([0.5, 0.5], dtype=float),
+            torch.ones([2], dtype=float),
+            torch.ones([2], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([2]),
+            torch.zeros([2], dtype=torch.bool),
+            torch.zeros([2], dtype=torch.bool),
+            [[0.474077]]
+        )
+    ]
+)
+def test_BCE(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_loss):
+    """
+    Test on the BCE loss function for classification.
+    """
+    bce_loss = BCELoss()
+    loss = bce_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    np.testing.assert_array_almost_equal(loss, expected_loss)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,expected_loss",
+    [
+        (
+            torch.tensor([[[1.2, 0.5, 0.7],[-0.1, 0.3, 0.1]],[[1.2, 0.5, 0.7],[1.1, 1.3, 1.1]]]),
+            torch.tensor([[1, 0],[1,2]]),
+            torch.ones([2,2], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([2]),
+            torch.ones([2,2], dtype=torch.bool),
+            torch.ones([2,2], dtype=torch.bool),
+            [[1.34214]]
+        ),
+        (
+            torch.tensor([[[1.2, 1.5, 0.7],[-0.1, 2.3, 1.1]],[[1.2, 1.5, 1.7],[2.1, 1.3, 1.1]]]),
+            torch.tensor([[1, 1],[2,2]], dtype  = torch.float64),
+            torch.ones([2,2], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([2]),
+            torch.ones([2,2], dtype=torch.bool),
+            torch.ones([2,2], dtype=torch.bool),
+            [[0.899472]]
+        )
+    ]
+)
+def test_CrossEntropy(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_loss):
+    """
+    Test on the CE loss function for classification.
+    Note these values were not hand derived, just testing for
+    dimensional consistency.
+    """
+    cross_entropy_loss = CrossEntropyLoss()
+    loss = cross_entropy_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    np.testing.assert_array_almost_equal(loss, expected_loss)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,expected_loss",
+    [
+        (
+            torch.tensor([0, 1, 1, 0]),
+            torch.tensor([0, 1, 1, 0]),
+            torch.ones([4], dtype=torch.bool),
+            torch.ones(1),
+            torch.ones(4),
+            torch.zeros([1,4], dtype=torch.bool),
+            torch.zeros([1,4], dtype=torch.bool),
+            [0]
+        ),
+        (
+            torch.tensor([0, 1, 0, 1, 1, 1, 0, 1, 1]),
+            torch.tensor([0, 1, 1, 0, 1, 1, 0, 0, 1]),
+            torch.ones([9], dtype=torch.bool),
+            torch.ones(1),
+            torch.ones(9),
+            torch.zeros([1,9], dtype=torch.bool),
+            torch.zeros([1,9], dtype=torch.bool),
+            [0.683772]
+        ),
+    ]
+)
+def test_BinaryMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_loss):
+    """
+    Test on the BinaryMCC loss function for classification. Values have been checked using TorchMetrics. 
+    """
+    binary_mcc_loss = BinaryMCCLoss()
+    loss = binary_mcc_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    np.testing.assert_array_almost_equal(loss, expected_loss)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,expected_loss",
+    [
+        (
+            torch.tensor([[[0.16, 0.26, 0.58],[0.22, 0.61, 0.17]],[[0.71, 0.09, 0.20],[0.05, 0.82, 0.13]]]),
+            torch.tensor([[2, 1,] , [0, 0]]),
+            torch.ones([2,2], dtype=torch.bool),
+            torch.ones([1,2]),
+            torch.ones([2]),
+            torch.zeros([2,2], dtype=torch.bool),
+            torch.zeros([2,2], dtype=torch.bool),
+            [0.2697033]
+        ),
+        (
+            torch.tensor([[[0.16, 0.26, 0.58],[0.22, 0.61, 0.17]],[[0.71, 0.09, 0.20],[0.05, 0.82, 0.13]]]),
+            torch.tensor([[2, 1,] , [0, 0]]),
+            torch.tensor([[1,1],[0,1]], dtype=torch.bool),
+            torch.ones([1,2]),
+            torch.ones([2]),
+            torch.zeros([2,2], dtype = bool),
+            torch.zeros([2,2], dtype = bool),
+            [0.3876276]
+        ),
+    ]
+)
+def test_MulticlassMCC(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, expected_loss):
+    """
+    Test on the MulticlassMCC loss function for classification.
+    """
+    multiclass_mcc_loss = MulticlassMCCLoss()
+    loss = multiclass_mcc_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    np.testing.assert_array_almost_equal(loss, expected_loss)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,threshold,expected_loss",
+    [
+        (
+            torch.tensor([[0.8, 0.2], [0.3, 0.7]]),
+            torch.tensor([[0.9, 0.1], [0.4, 0.6]]),
+            torch.ones([2,2], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([2]),
+            torch.ones([2], dtype=torch.bool),
+            torch.ones([2], dtype=torch.bool),
+            None,
+            [[0.031319]]
+        ),
+        (
+            torch.tensor([[0.6, 0.4], [0.2, 0.8]]),
+            torch.tensor([[0.7, 0.3], [0.3, 0.7]]),
+            torch.tensor([[1, 1], [1, 0]], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([2]),
+            torch.ones([2], dtype=torch.bool),
+            torch.ones([2], dtype=torch.bool),
+            None,
+            [[0.295655]]
+        ),
+        (
+            torch.tensor([[0.6, 0.4], [0.2, 0.8]]),
+            torch.tensor([[0.7, 0.3], [0.3, 0.7]]),
+            torch.tensor([[1, 1], [1, 1]], dtype=torch.bool),
+            torch.ones([1]),
+            torch.ones([2]),
+            torch.ones([2], dtype=torch.bool),
+            torch.ones([2], dtype=torch.bool),
+            0.5,
+            [[0.033673]]
+        ),
+    ]
+)
+def test_SID(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, threshold, expected_loss):
+    """
+    Test on the SID loss function. These values were not handchecked,
+    just checking function returns values with/without mask and threshold.
+    """
+    sid_loss = SIDLoss(threshold)
+    loss = sid_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    np.testing.assert_array_almost_equal(loss, expected_loss)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,w_s,w_t,lt_mask,gt_mask,threshold,expected_loss",
+    [
+        (
+            torch.tensor([[0.1, 0.3, 0.5, 0.7], [0.2, 0.4, 0.6, 0.8]]),
+            torch.tensor([[0.1, 0.2, 0.3, 0.4],[0.5, 0.6, 0.7, 0.8]]),
+            torch.tensor([[1, 1, 1, 1],[1, 0, 1, 0]], dtype=torch.bool),
+            torch.ones([2,1]),
+            torch.ones([1,4]),
+            torch.zeros([2,4], dtype=torch.bool),
+            torch.zeros([2,4], dtype=torch.bool),
+            None,
+            [[0.1125]]
+        ),
+        (
+            torch.tensor([[0.1, 0.3, 0.5, 0.7],[0.2, 0.4, 0.6, 0.8]]),
+            torch.tensor([[0.1, 0.2, 0.3, 0.4],[0.5, 0.6, 0.7, 0.8]]),
+            torch.ones([2,4], dtype=torch.bool),
+            torch.ones([2,1]),
+            torch.ones([1,4]),
+            torch.zeros([2,4], dtype=torch.bool),
+            torch.zeros([2,4], dtype=torch.bool),
+            None,
+           [[0.515625]]
+        ),
+        (
+            torch.tensor([[0.1, 0.3, 0.5, 0.7],[0.2, 0.4, 0.6, 0.8]]),
+            torch.tensor([[0.1, 0.2, 0.3, 0.4],[0.5, 0.6, 0.7, 0.8]]),
+            torch.ones([2,4], dtype=torch.bool),
+            torch.ones([2,1]),
+            torch.ones([1,4]),
+            torch.zeros([2,4], dtype=torch.bool),
+            torch.zeros([2,4], dtype=torch.bool),
+            0.3,
+            [[0.501984]]
+        ),
+    ]
+)
+def test_Wasserstein(preds, targets, mask, w_s, w_t, lt_mask, gt_mask, threshold, expected_loss):
+    """
+    Test on the Wasserstein loss function. These values were not handchecked,
+    just checking function returns values with/without mask and threshold.
+    """
+    wasserstein_loss = WassersteinLoss(threshold)
+    loss = wasserstein_loss(preds, targets, mask, w_s, w_t, lt_mask, gt_mask)
+    np.testing.assert_array_almost_equal(loss, expected_loss)


### PR DESCRIPTION
## Description
This PR adds a unit test for the loss functions defined in `loss.py`. The tests are not exhaustive, but include a test for each loss function available and check for basic functionality such as expected dimensions, reduction, and simple parameters. Some loss function definitions in `loss.py` are modified to address some issues. These are: 
1) BoundedMSELoss is modified to have the lt and gt masks applied to the targets in addition to preds. 
2) MulticlassMCCLoss is modified to have summations such that the end vector is a scalar. This should match the implementation in v1. 
3) BinaryDirichletLoss and MulticlassDirichletLoss have had their forward call modified to pass to DirichletMixin as the loss was previously returning a NoneType.  

`metrics.py` has also been updated to have metrics inherit from loss functions where possible. Specifically SID and Wasserstein metrics now inherit from the corresponding loss functions. The MCCmetric has been replaced with BinaryMCC and MulticlassMCC metrics to reflect the updated loss functions in loss.py as well. BoundedMixin has been updated to apply the lt and gt masks applied to targets as well, matching the change for BoundedMSELoss in `loss.py`

## Questions
1) The changes made to MulticlassMCCLoss and the DirichletLoss functions work, but are they in line with what was intended for the v2 framework?

