### PR TITLE
v2: update CLI defaults for epochs and aggregation

### DIFF
--- a/chemprop/v2/cli/train.py
+++ b/chemprop/v2/cli/train.py
@@ -381,7 +381,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     train_args.add_argument("--max-lr", type=float, default=1e-3, help="Maximum learning rate.")
     train_args.add_argument("--final-lr", type=float, default=1e-4, help="Final learning rate.")
     train_args.add_argument(
-        "--epochs", type=int, default=30, help="the number of epochs to train over"
+        "--epochs", type=int, default=50, help="the number of epochs to train over"
     )
     train_args.add_argument(
         "--grad-clip", type=float, help="Maximum magnitude of gradient during training."

--- a/chemprop/v2/cli/train.py
+++ b/chemprop/v2/cli/train.py
@@ -159,7 +159,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     mp_args.add_argument(
         "--aggregation",
         "--agg",
-        default="mean",
+        default="norm",
         action=RegistryAction(AggregationRegistry),
         help="the aggregation mode to use during graph readout",
     )


### PR DESCRIPTION
## Description
As discussed at length internally, we are taking the major version bump as an opportunity to change several default settings:
* epochs: 30 --> 50
* aggregation: mean --> norm
* batch_size: 50 --> 64 (already done by #485)
* HPO search space (to be implemented later, see #496)

Based on years of experience training chemprop models across many people in the group, we believe that these defaults are more likely to lead to better models in many cases. These can obviously be problem-dependent, though, so they can and should still be varied depending the problem and empirical results.

## Questions
Are there any other places in the code these defaults need to be changed, other than in the CLI?