### PR TITLE
Add changes for features and atom descriptors CLI arguments

### DIFF
--- a/chemprop/v2/cli/common.py
+++ b/chemprop/v2/cli/common.py
@@ -123,7 +123,7 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
     featurization_args.add_argument(
         "--features-path",
         type=list[str],  # TODO: why is this a list[str] instead of str?
-        help="Path(s) to features to use in FNN (instead of features_generator).",
+        help="Path(s) to features to use in FFN (instead of features_generator).",
     )
     featurization_args.add_argument(
         "--phase-features-path",

--- a/chemprop/v2/cli/predict.py
+++ b/chemprop/v2/cli/predict.py
@@ -209,6 +209,15 @@ def main(args):
     #     cal_data = None
 
     test_dset = make_dataset(test_data, bond_messages, args.rxn_mode)
+    if args.no_features_scaling is False:
+        p_features_scaler = args.checkpoint_path.parents[1] / "features_scaler.pkl"
+        features_scaler = torch.load(p_features_scaler)
+        test_dset.normalize_inputs("X_f", features_scaler)
+
+    if args.no_atom_descriptor_scaling is False:
+        p_atom_descs_scaler = args.checkpoint_path.parents[1] / "atom_descs_scaler.pkl"
+        atom_descs_scaler = torch.load(p_atom_descs_scaler)
+        test_dset.normalize_inputs("V_d", atom_descs_scaler)
 
     test_loader = data.MolGraphDataLoader(test_dset, args.batch_size, args.n_cpu, shuffle=False)
     # TODO: add uncertainty and calibration

--- a/chemprop/v2/data/datasets.py
+++ b/chemprop/v2/data/datasets.py
@@ -242,13 +242,13 @@ class MoleculeDataset(Dataset, _MolGraphDatasetMixin):
 
         match key:
             case "X_f":
-                X = self.X_f
+                X = None if np.all(self.X_f == None) else self.X_f
             case "V_f":
-                X = None if self.V_fs is None else np.concatenate(self.V_fs, axis=0)
+                X = None if np.all(self.V_fs == None) else np.concatenate(self.V_fs, axis=0)
             case "E_f":
-                X = None if self.E_fs is None else np.concatenate(self.E_fs, axis=0)
+                X = None if np.all(self.E_fs == None) else np.concatenate(self.E_fs, axis=0)
             case "V_d":
-                X = None if self.V_ds is None else np.concatenate(self.V_ds, axis=0)
+                X = None if np.all(self.V_ds == None) else np.concatenate(self.V_ds, axis=0)
             case None:
                 return [self.normalize_inputs(k, scaler) for k in VALID_KEYS - {None}]
             case _:


### PR DESCRIPTION
This commit makes some changes to help control the scaling of additional molecular features and atom_descriptors that may be concatenated to the representation after message passing. datasets.py have had normalize_inputs edited to check if the arrays of features are None. train.py is modified to apply the scaling to train, val, and test datasets and save the scalers. predict.py is modified to use the saved scaler to scale inputs during inference. The `--features-generators` and `--features-path` arguments are also being tested for implementation here but should work directly. 

## Questions
1. How to best save the scalers in train.py so that they can then be used in inference in predict.py.
2. Do we want to scale the default atoms and bonds features? The featurization already makes sure that they are in an  appropriate range, so it may not be necessary. 
3. Support for additional bond descriptors to be concatenated after message passing?

## Relevant issues
The assignment of additional features in 'make_datapoints' from `utils_.py` has not been updated here as this is being addressed in PR #493 .
