### PR TITLE
V2: Args for data splitting

### DIFF
--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -66,8 +66,8 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         "--reaction-mode",
         type=uppercase,
         default="REAC_DIFF",
-        choices=RxnMode.keys(),
-        help="""Choices for construction of atom and bond features for reactions
+        choices=list(RxnMode.keys()),
+        help="""Choices for construction of atom and bond features for reactions (case insensitive):
 - 'reac_prod': concatenates the reactants feature with the products feature.
 - 'reac_diff': concatenates the reactants feature with the difference in features between reactants and products.
 - 'prod_diff': concatenates the products feature with the difference in features between reactants and products.


### PR DESCRIPTION
## Description
This PR just connects the splitting args to the code. It also comments out the splitting args that aren't ready yet. 

It also fixes a bug in common.py (`choices=RxnMode.keys(),`). Discussed in #497.'

Note: Support for splitting by molecular weight was added recently to v1, but has not been added to v2.

## Questions
Support for premade data splits could be added to this PR as well as support for saving smiles splits. These seemed more complicated so were left for later. One question is if they should be added to this PR instead.

Another question is if 'crossval' and 'cv' are the same splitting method. In v2 they show up as two options, which confused me because I thought 'cv' stood for 'crossval'. Currently 'crossval' isn't an option from the commandline.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
