### PR TITLE
V2: Improve datasplit function for multicomponent dataset

### DIFF
--- a/chemprop/v2/data/__init__.py
+++ b/chemprop/v2/data/__init__.py
@@ -3,3 +3,4 @@ from .dataloader import MolGraphDataLoader
 from .datapoints import MoleculeDatapoint, ReactionDatapoint
 from .datasets import MoleculeDataset, ReactionDataset, Datum
 from .samplers import ClassBalanceSampler, SeededSampler
+from .splitting import split_monocomponent, split_multicomponent, SplitType

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -55,7 +55,7 @@ def split_data(
 
     Raises
     ------
-    RuntimeError
+    ValueError
         Requested split sizes tuple not of length 3
     ValueError
         Innapropriate number of folds requested

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -240,6 +240,6 @@ def split_multicomponent(
             val = [[datapoints[i] for i in val_idxs] for datapoints in datapointss]
             test = [[datapoints[i] for i in test_idxs] for datapoints in datapointss]
         case _:
-            raise ValueError(f'Split type "{split}" not supported.')
+            raise RuntimeError("Unreachable code reached!")
 
     return train, val, test

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -196,44 +196,50 @@ def _unpack_astartes_result(
 
 
 def split_monocomponent(
-    datapoints: Sequence[MoleculeDatapoint], *args, **kwargs
+    datapoints: Sequence[MoleculeDatapoint], split: SplitType | str = "random", **kwargs
 ) -> tuple[list[MoleculeDatapoint], ...] | tuple[list[list[MoleculeDatapoint]], ...]:
     """Splits monocomponent data into training, validation, and test splits."""
 
     # split the data
-    train_idxs, val_idxs, test_idxs = split_data(datapoints, *args, **kwargs)
+    train_idxs, val_idxs, test_idxs = split_data(datapoints, **kwargs)
 
-    if isinstance(train_idxs[0], list):
-        # convert indices to datapoints for each fold
-        train = [[datapoints[i] for i in fold] for fold in train_idxs]
-        val = [[datapoints[i] for i in fold] for fold in val_idxs]
-        test = [[datapoints[i] for i in fold] for fold in test_idxs]
-    else:
-        # convert indices to datapoints
-        train = [datapoints[i] for i in train_idxs]
-        val = [datapoints[i] for i in val_idxs]
-        test = [datapoints[i] for i in test_idxs]
+    match SplitType.get(split):
+        case SplitType.CV_NO_VAL, SplitType.CV:
+            # convert indices to datapoints for each fold
+            train = [[datapoints[i] for i in fold] for fold in train_idxs]
+            val = [[datapoints[i] for i in fold] for fold in val_idxs]
+            test = [[datapoints[i] for i in fold] for fold in test_idxs]
+        case SplitType.SCAFFOLD_BALANCED, SplitType.RANDOM_WITH_REPEATED_SMILES, SplitType.RANDOM, SplitType.KENNARD_STONE, SplitType.KMEANS:
+            # convert indices to datapoints
+            train = [datapoints[i] for i in train_idxs]
+            val = [datapoints[i] for i in val_idxs]
+            test = [datapoints[i] for i in test_idxs]
+        case _:
+            raise ValueError(f'Split type "{split}" not supported.')
 
     return train, val, test
 
 
 def split_multicomponent(
-    datapointss: Sequence[MulticomponentDatapoint], key_index: int = 0, *args, **kwargs
+    datapointss: Sequence[MulticomponentDatapoint], split: SplitType | str = "random", key_index: int = 0, **kwargs
 ) -> tuple[list[MulticomponentDatapoint], ...] | tuple[list[list[MulticomponentDatapoint]], ...]:
     """Splits multicomponent data into training, validation, and test splits."""
 
     key_datapoints = datapointss[key_index]
-    train_idxs, val_idxs, test_idxs = split_data(key_datapoints, *args, **kwargs)
+    train_idxs, val_idxs, test_idxs = split_data(key_datapoints, **kwargs)
 
-    if isinstance(train_idxs[0], list):
-        # convert indices to datapoints for each fold
-        train = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in train_idxs]
-        val = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in val_idxs]
-        test = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in test_idxs]
-    else:
-        # convert indices to datapoints
-        train = [[datapoints[i] for i in train_idxs] for datapoints in datapointss]
-        val = [[datapoints[i] for i in val_idxs] for datapoints in datapointss]
-        test = [[datapoints[i] for i in test_idxs] for datapoints in datapointss]
+    match SplitType.get(split):
+        case SplitType.CV_NO_VAL, SplitType.CV:
+            # convert indices to datapoints for each fold
+            train = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in train_idxs]
+            val = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in val_idxs]
+            test = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in test_idxs]
+        case SplitType.SCAFFOLD_BALANCED, SplitType.RANDOM_WITH_REPEATED_SMILES, SplitType.RANDOM, SplitType.KENNARD_STONE, SplitType.KMEANS:
+            # convert indices to datapoints
+            train = [[datapoints[i] for i in train_idxs] for datapoints in datapointss]
+            val = [[datapoints[i] for i in val_idxs] for datapoints in datapointss]
+            test = [[datapoints[i] for i in test_idxs] for datapoints in datapointss]
+        case _:
+            raise ValueError(f'Split type "{split}" not supported.')
 
     return train, val, test

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -63,7 +63,9 @@ def split_data(
         Unsupported split method requested
     """
     if (num_splits := len(sizes)) != 3:
-        raise ValueError(f"Specify sizes for train, validation, and test (got {num_splits} values).")
+        raise ValueError(
+            f"Specify sizes for train, validation, and test (got {num_splits} values)."
+        )
     # typically include a validation set
     include_val = True
     split_fun = train_val_test_split

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -161,7 +161,7 @@ def split_data(
             train, val, test = _unpack_astartes_result(result, include_val)
 
         case _:
-            raise ValueError(f'Split type "{split}" not supported.')
+            raise RuntimeError("Unreachable code reached!")
 
     return train, val, test
 
@@ -215,7 +215,7 @@ def split_monocomponent(
             val = [datapoints[i] for i in val_idxs]
             test = [datapoints[i] for i in test_idxs]
         case _:
-            raise ValueError(f'Split type "{split}" not supported.')
+            raise RuntimeError("Unreachable code reached!")
 
     return train, val, test
 

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -87,7 +87,7 @@ def split_data(
     train, val, test = None, None, None
     match SplitType.get(split):
         case SplitType.CV_NO_VAL | SplitType.CV:
-            if (max_folds := len(datapoints)) > num_folds or num_folds <= 1:
+            if (max_folds := len(datapoints)) < num_folds or num_folds <= 1:
                 raise ValueError(
                     f"Number of folds for cross-validation must be between 2 and {max_folds} (length of data) inclusive (got {num_folds})."
                 )

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -32,7 +32,7 @@ def split_data(
     sizes: tuple[float, float, float] = (0.8, 0.1, 0.1),
     seed: int = 0,
     num_folds: int = 1,
-) -> tuple[list[int], ...] | tuple[list[list[int], ...], ...]:
+):
     """Splits data into training, validation, and test splits.
 
     Parameters
@@ -50,7 +50,7 @@ def split_data(
 
     Returns
     -------
-    tuple[list[int], ...] | tuple[list[list[int], ...], ...]
+    tuple[list[int], list[int], list[int]] | tuple[list[list[int], ...], list[list[int], ...], list[list[int], ...]]
         A tuple of list of indices corresponding to the train, validation, and test splits of the data.
         If the split type is "cv" or "cv-no-test", returns a tuple of lists of lists of indices corresponding to the train, validation, and test splits of each fold.
             NOTE: validation may or may not be present
@@ -197,7 +197,7 @@ def _unpack_astartes_result(
 
 def split_monocomponent(
     datapoints: Sequence[MoleculeDatapoint], split: SplitType | str = "random", **kwargs
-) -> tuple[list[MoleculeDatapoint], ...] | tuple[list[list[MoleculeDatapoint]], ...]:
+):
     """Splits monocomponent data into training, validation, and test splits."""
 
     # split the data
@@ -222,7 +222,7 @@ def split_monocomponent(
 
 def split_multicomponent(
     datapointss: Sequence[MulticomponentDatapoint], split: SplitType | str = "random", key_index: int = 0, **kwargs
-) -> tuple[list[MulticomponentDatapoint], ...] | tuple[list[list[MulticomponentDatapoint]], ...]:
+):
     """Splits multicomponent data into training, validation, and test splits."""
 
     key_datapoints = datapointss[key_index]

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -130,24 +130,9 @@ def split_data(
             train_idxs, val_idxs, test_idxs = _unpack_astartes_result(result, include_val)
 
             # convert these to the 'actual' indices from the original list using the dict we made
-            train = [
-                ii
-                for ii in itertools.chain.from_iterable(
-                    smiles_indices[unique_smiles[i]] for i in train_idxs
-                )
-            ]
-            val = [
-                ii
-                for ii in itertools.chain.from_iterable(
-                    smiles_indices[unique_smiles[i]] for i in val_idxs
-                )
-            ]
-            test = [
-                ii
-                for ii in itertools.chain.from_iterable(
-                    smiles_indices[unique_smiles[i]] for i in test_idxs
-                )
-            ]
+            train = list(itertools.chain.from_iterable(smiles_indices[unique_smiles[i]] for i in train_idxs))
+            val = list(itertools.chain.from_iterable(smiles_indices[unique_smiles[i]] for i in val_idxs))
+            test = list(itertools.chain.from_iterable(smiles_indices[unique_smiles[i]] for i in test_idxs))
 
         case SplitType.RANDOM:
             result = split_fun(np.arange(len(datapoints)), sampler="random", **astartes_kwargs)

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -94,7 +94,7 @@ def split_data(
 
             # returns nested lists of indices
             train, val, test = [], [], []
-            for _ in range(len(num_folds)):
+            for _ in range(num_folds):
                 result = split_fun(np.arange(len(datapoints)), sampler="random", **astartes_kwargs)
                 i_train, i_val, i_test = _unpack_astartes_result(result, include_val)
                 train.append(i_train)

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -201,7 +201,7 @@ def split_monocomponent(
     """Splits monocomponent data into training, validation, and test splits."""
 
     # split the data
-    train_idxs, val_idxs, test_idxs = split_data(datapoints, **kwargs)
+    train_idxs, val_idxs, test_idxs = split_data(datapoints, split=split, **kwargs)
 
     match SplitType.get(split):
         case SplitType.CV_NO_VAL | SplitType.CV:
@@ -226,7 +226,7 @@ def split_multicomponent(
     """Splits multicomponent data into training, validation, and test splits."""
 
     key_datapoints = datapointss[key_index]
-    train_idxs, val_idxs, test_idxs = split_data(key_datapoints, **kwargs)
+    train_idxs, val_idxs, test_idxs = split_data(key_datapoints, split=split, **kwargs)
 
     match SplitType.get(split):
         case SplitType.CV_NO_VAL | SplitType.CV:

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -176,7 +176,7 @@ def split_data(
             train, val, test = _unpack_astartes_result(result, include_val)
 
         case _:
-            raise ValueError(f'split type "{split}" not supported.')
+            raise ValueError(f'Split type "{split}" not supported.')
 
     return train, val, test
 

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -179,14 +179,12 @@ def split_data(
 
 
 def _unpack_astartes_result(
-    data: Sequence[MoleculeDatapoint], result: tuple, include_val: bool
-) -> tuple[list[MoleculeDatapoint], list[MoleculeDatapoint], list[MoleculeDatapoint]]:
+    result: tuple, include_val: bool
+) -> tuple[list[int], list[int], list[int]]:
     """Helper function to partition input data based on output of astartes sampler
 
     Parameters
     -----------
-    data: MoleculeDataset
-        The data being partitioned. If None, returns indices.
     result: tuple
         Output from call to astartes containing the split indices
     include_val: bool
@@ -194,10 +192,10 @@ def _unpack_astartes_result(
 
     Returns
     ---------
-    train: MoleculeDataset
-    val: MoleculeDataset
+    train: list[int]
+    val: list[int]
         NOTE: possibly empty
-    test: MoleculeDataset
+    test: list[int]
     """
     train_idxs, val_idxs, test_idxs = [], [], []
     # astartes returns a set of lists containing the data, clusters (if applicable)
@@ -206,9 +204,4 @@ def _unpack_astartes_result(
         train_idxs, val_idxs, test_idxs = result[-3], result[-2], result[-1]
     else:
         train_idxs, test_idxs = result[-2], result[-1]
-    if data is None:
-        return train_idxs, val_idxs, test_idxs
-    train = [data[i] for i in train_idxs]
-    val = [data[i] for i in val_idxs]
-    test = [data[i] for i in test_idxs]
-    return train, val, test
+    return train_idxs, val_idxs, test_idxs

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -86,7 +86,7 @@ def split_data(
 
     train, val, test = None, None, None
     match SplitType.get(split):
-        case SplitType.CV_NO_VAL, SplitType.CV:
+        case SplitType.CV_NO_VAL | SplitType.CV:
             if (max_folds := len(datapoints)) > num_folds or num_folds <= 1:
                 raise ValueError(
                     f"Number of folds for cross-validation must be between 2 and {max_folds} (length of data) inclusive (got {num_folds})."
@@ -204,12 +204,12 @@ def split_monocomponent(
     train_idxs, val_idxs, test_idxs = split_data(datapoints, **kwargs)
 
     match SplitType.get(split):
-        case SplitType.CV_NO_VAL, SplitType.CV:
+        case SplitType.CV_NO_VAL | SplitType.CV:
             # convert indices to datapoints for each fold
             train = [[datapoints[i] for i in fold] for fold in train_idxs]
             val = [[datapoints[i] for i in fold] for fold in val_idxs]
             test = [[datapoints[i] for i in fold] for fold in test_idxs]
-        case SplitType.SCAFFOLD_BALANCED, SplitType.RANDOM_WITH_REPEATED_SMILES, SplitType.RANDOM, SplitType.KENNARD_STONE, SplitType.KMEANS:
+        case SplitType.SCAFFOLD_BALANCED | SplitType.RANDOM_WITH_REPEATED_SMILES | SplitType.RANDOM | SplitType.KENNARD_STONE | SplitType.KMEANS:
             # convert indices to datapoints
             train = [datapoints[i] for i in train_idxs]
             val = [datapoints[i] for i in val_idxs]
@@ -229,12 +229,12 @@ def split_multicomponent(
     train_idxs, val_idxs, test_idxs = split_data(key_datapoints, **kwargs)
 
     match SplitType.get(split):
-        case SplitType.CV_NO_VAL, SplitType.CV:
+        case SplitType.CV_NO_VAL | SplitType.CV:
             # convert indices to datapoints for each fold
             train = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in train_idxs]
             val = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in val_idxs]
             test = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in test_idxs]
-        case SplitType.SCAFFOLD_BALANCED, SplitType.RANDOM_WITH_REPEATED_SMILES, SplitType.RANDOM, SplitType.KENNARD_STONE, SplitType.KMEANS:
+        case SplitType.SCAFFOLD_BALANCED | SplitType.RANDOM_WITH_REPEATED_SMILES | SplitType.RANDOM | SplitType.KENNARD_STONE | SplitType.KMEANS:
             # convert indices to datapoints
             train = [[datapoints[i] for i in train_idxs] for datapoints in datapointss]
             val = [[datapoints[i] for i in val_idxs] for datapoints in datapointss]

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -231,9 +231,9 @@ def split_multicomponent(
     match SplitType.get(split):
         case SplitType.CV_NO_VAL | SplitType.CV:
             # convert indices to datapoints for each fold
-            train = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in train_idxs]
-            val = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in val_idxs]
-            test = [[datapoints[i] for i in fold] for datapoints in datapointss for fold in test_idxs]
+            train = [[[datapoints[i] for i in fold] for datapoints in datapointss] for fold in train_idxs]
+            val = [[[datapoints[i] for i in fold] for datapoints in datapointss] for fold in val_idxs]
+            test = [[[datapoints[i] for i in fold] for datapoints in datapointss] for fold in test_idxs]
         case SplitType.SCAFFOLD_BALANCED | SplitType.RANDOM_WITH_REPEATED_SMILES | SplitType.RANDOM | SplitType.KENNARD_STONE | SplitType.KMEANS:
             # convert indices to datapoints
             train = [[datapoints[i] for i in train_idxs] for datapoints in datapointss]

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -207,7 +207,7 @@ def _unpack_astartes_result(
         train_idxs, val_idxs, test_idxs = result[-3], result[-2], result[-1]
     else:
         train_idxs, test_idxs = result[-2], result[-1]
-    return train_idxs, val_idxs, test_idxs
+    return list(train_idxs), list(val_idxs), list(test_idxs)
 
 
 def split_monocomponent(

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -63,9 +63,7 @@ def split_data(
         Unsupported split method requested
     """
     if (num_splits := len(sizes)) != 3:
-        raise RuntimeError(
-            f"Specify sizes for train, validation, and test (got {num_splits} values)."
-        )
+        raise ValueError(f"Specify sizes for train, validation, and test (got {num_splits} values).")
     # typically include a validation set
     include_val = True
     split_fun = train_val_test_split

--- a/chemprop/v2/data/splitting.py
+++ b/chemprop/v2/data/splitting.py
@@ -212,7 +212,7 @@ def _unpack_astartes_result(
 
 def split_monocomponent(
     datapoints: Sequence[MoleculeDatapoint], *args, **kwargs
-) -> tuple[Sequence[MoleculeDatapoint], ...] | tuple[list[Sequence[MoleculeDatapoint], ...], ...]:
+) -> tuple[list[MoleculeDatapoint], ...] | tuple[list[list[MoleculeDatapoint]], ...]:
     """Splits monocomponent data into training, validation, and test splits."""
 
     # split the data
@@ -234,10 +234,7 @@ def split_monocomponent(
 
 def split_multicomponent(
     datapointss: Sequence[MulticomponentDatapoint], key_index: int = 0, *args, **kwargs
-) -> (
-    tuple[Sequence[MulticomponentDatapoint], ...]
-    | tuple[Sequence[Sequence[MulticomponentDatapoint], ...], ...]
-):
+) -> tuple[list[MulticomponentDatapoint], ...] | tuple[list[list[MulticomponentDatapoint]], ...]:
     """Splits multicomponent data into training, validation, and test splits."""
 
     key_datapoints = datapointss[key_index]

--- a/chemprop/v2/tests/unit/data/test_data_utils.py
+++ b/chemprop/v2/tests/unit/data/test_data_utils.py
@@ -41,7 +41,7 @@ def test_splits_sum2_warning(molecule_dataset):
 
 def test_three_splits_provided(molecule_dataset):
     """Testing that three splits are provided"""
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         split_data(datapoints=molecule_dataset, sizes=(0.8, 0.2))
 
 

--- a/chemprop/v2/tests/unit/data/test_data_utils.py
+++ b/chemprop/v2/tests/unit/data/test_data_utils.py
@@ -55,15 +55,9 @@ def test_seed0(molecule_dataset):
         train_val_test_split(np.arange(len(molecule_dataset)), sampler="random", random_state=0),
         True,
     )
-    assert set([Chem.MolToSmiles(i.mol) for i in train]) == set(
-        [Chem.MolToSmiles(i.mol) for i in train_astartes]
-    )
-    assert set([Chem.MolToSmiles(i.mol) for i in val]) == set(
-        [Chem.MolToSmiles(i.mol) for i in val_astartes]
-    )
-    assert set([Chem.MolToSmiles(i.mol) for i in test]) == set(
-        [Chem.MolToSmiles(i.mol) for i in test_astartes]
-    )
+    assert set(train) == set(train_astartes)
+    assert set(val) == set(val_astartes)
+    assert set(test) == set(test_astartes)
 
 
 def test_seed100(molecule_dataset):
@@ -76,22 +70,15 @@ def test_seed100(molecule_dataset):
         train_val_test_split(np.arange(len(molecule_dataset)), sampler="random", random_state=100),
         True,
     )
-    assert set([Chem.MolToSmiles(i.mol) for i in train]) == set(
-        [Chem.MolToSmiles(i.mol) for i in train_astartes]
-    )
-    assert set([Chem.MolToSmiles(i.mol) for i in val]) == set(
-        [Chem.MolToSmiles(i.mol) for i in val_astartes]
-    )
-    assert set([Chem.MolToSmiles(i.mol) for i in test]) == set(
-        [Chem.MolToSmiles(i.mol) for i in test_astartes]
-    )
+    assert set(train) == set(train_astartes)
+    assert set(val) == set(val_astartes)
+    assert set(test) == set(test_astartes)
 
 
 def test_split_4_4_2(molecule_dataset):
     """Testing the random split with changed sizes"""
     train, val, test = split_data(datapoints=molecule_dataset, sizes=(0.4, 0.4, 0.2))
     train_astartes, val_astartes, test_astartes = _unpack_astartes_result(
-        molecule_dataset,
         train_val_test_split(
             np.arange(len(molecule_dataset)),
             sampler="random",
@@ -102,21 +89,15 @@ def test_split_4_4_2(molecule_dataset):
         ),
         True,
     )
-    assert set([Chem.MolToSmiles(i.mol) for i in train]) == set(
-        [Chem.MolToSmiles(i.mol) for i in train_astartes]
-    )
-    assert set([Chem.MolToSmiles(i.mol) for i in val]) == set(
-        [Chem.MolToSmiles(i.mol) for i in val_astartes]
-    )
-    assert set([Chem.MolToSmiles(i.mol) for i in test]) == set(
-        [Chem.MolToSmiles(i.mol) for i in test_astartes]
-    )
+    assert set(train) == set(train_astartes)
+    assert set(val) == set(val_astartes)
+    assert set(test) == set(test_astartes)
 
 
 def test_split_empty_validation_set(molecule_dataset):
     """Testing the random split with an empty validation set"""
     train, val, test = split_data(datapoints=molecule_dataset, sizes=(0.4, 0, 0.6))
-    assert set([Chem.MolToSmiles(i.mol) for i in val]) == set([])
+    assert set(val) == set([])
 
 
 def test_random_split(molecule_dataset_with_repeated_smiles):
@@ -129,7 +110,7 @@ def test_random_split(molecule_dataset_with_repeated_smiles):
         datapoints=molecule_dataset_with_repeated_smiles, sizes=(0.4, 0.4, 0.2), split=split_type
     )
 
-    assert [Chem.MolToSmiles(i.mol) for i in train] == ["CN", "CC"]
+    assert train == [2, 1]
 
 
 def test_repeated_smiles(molecule_dataset_with_repeated_smiles):
@@ -142,8 +123,8 @@ def test_repeated_smiles(molecule_dataset_with_repeated_smiles):
         datapoints=molecule_dataset_with_repeated_smiles, sizes=(0.8, 0.0, 0.2), split=split_type
     )
 
-    assert [Chem.MolToSmiles(i.mol) for i in train] == ["CO", "CC", "C", "C"]
-    assert [Chem.MolToSmiles(i.mol) for i in test] == ["CN", "CN"]
+    assert train == [4, 1, 0, 5]
+    assert test == [2, 3]
 
 
 def test_kennard_stone(molecule_dataset):
@@ -156,7 +137,7 @@ def test_kennard_stone(molecule_dataset):
         datapoints=molecule_dataset, sizes=(0.4, 0.4, 0.2), split=split_type
     )
 
-    assert set([Chem.MolToSmiles(i.mol) for i in test]) == set(["CCCO", "CCCN"])
+    assert set(test) == set([9, 5])
 
 
 def test_kmeans(molecule_dataset):
@@ -169,7 +150,7 @@ def test_kmeans(molecule_dataset):
         datapoints=molecule_dataset, sizes=(0.5, 0.0, 0.5), split=split_type
     )
 
-    assert [Chem.MolToSmiles(i.mol) for i in train] == ["C", "CC", "CCC", "CN", "CO", "CCO", "CCCO"]
+    assert train == [0, 1, 2, 3, 7, 8, 9]
 
 
 def test_scaffold(molecule_dataset_with_rings):
@@ -182,4 +163,4 @@ def test_scaffold(molecule_dataset_with_rings):
         datapoints=molecule_dataset_with_rings, sizes=(0.3, 0.3, 0.3), split=split_type
     )
 
-    assert [Chem.MolToSmiles(i.mol) for i in train] == ["C", "CC", "CCC"]
+    assert train == [0, 1, 2]

--- a/chemprop/v2/tests/unit/data/test_data_utils.py
+++ b/chemprop/v2/tests/unit/data/test_data_utils.py
@@ -52,7 +52,6 @@ def test_seed0(molecule_dataset):
     """
     train, val, test = split_data(datapoints=molecule_dataset, seed=0)
     train_astartes, val_astartes, test_astartes = _unpack_astartes_result(
-        molecule_dataset,
         train_val_test_split(np.arange(len(molecule_dataset)), sampler="random", random_state=0),
         True,
     )
@@ -74,7 +73,6 @@ def test_seed100(molecule_dataset):
     """
     train, val, test = split_data(datapoints=molecule_dataset, seed=100)
     train_astartes, val_astartes, test_astartes = _unpack_astartes_result(
-        molecule_dataset,
         train_val_test_split(np.arange(len(molecule_dataset)), sampler="random", random_state=100),
         True,
     )


### PR DESCRIPTION
## Description
Texts below are copied from https://github.com/chemprop/chemprop/pull/500#issuecomment-1771956143.

During working on an example notebook for multicomponent training, there are several things I noticed that the split_data is currently awkward and can be improved for multi-components.

With https://github.com/chemprop/chemprop/pull/501, a MulticomponentDataset dataset contains K datasets where K is the number of components. These K datasets need to be split consistently. The current split_data function is not able to do that. I discussed this with @KnathanM and we thought of some ways to do this, and I implemented one of them. Here are the possible options we came up with:

Option 1: Generalize split_data to be able to take in K lists of datapoints, use one of them to do the splitting, apply the same splitting to the rest of lists of datapoints. Supply split_key_molecule to indicate which one is used for splitting.

Option 2: Deal with this analogous to data scaler. Make split_data also return the split indices. If train_val_test_indices are provided, split the datapoints. This is the approach I took.

I also had additional discussion with @JacksonBurns today in person and we will work on this together to improve data split for multicomponent.
