### PR TITLE
update authors in LICENSE and setup files for v1

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,9 @@
 MIT License
 
 Copyright (c) 2023 Regina Barzilay, Jackson Burns, Yunsie Chung, David Graff,
-William Green, Kevin Greenman, Esther Heid, Tommi Jaakkola, Wengong Jin, Shih-Cheng Li,
-Mengjie Liu, Charles McGill, Kyle Swanson, Florence Vermeire, Haoyang Wu, Kevin Yang
+William Green, Kevin Greenman, Yanfei Guan, Esther Heid, Lior Hirschfeld,
+Tommi Jaakkola, Wengong Jin, Shih-Cheng Li, Mengjie Liu, Charles McGill,
+Kyle Swanson, Allison Tam, Florence Vermeire, Haoyang Wu, Kevin Yang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,9 +1,10 @@
 MIT License
 
-Copyright (c) 2023 Regina Barzilay, Jackson Burns, Yunsie Chung, David Graff,
-William Green, Kevin Greenman, Yanfei Guan, Esther Heid, Lior Hirschfeld,
-Tommi Jaakkola, Wengong Jin, Shih-Cheng Li, Mengjie Liu, Charles McGill,
-Kyle Swanson, Allison Tam, Florence Vermeire, Haoyang Wu, Kevin Yang
+Copyright (c) 2023 The Chemprop Development Team (Regina Barzilay, Jackson Burns, 
+Yunsie Chung, David Graff, William Green, Kevin Greenman, Yanfei Guan, 
+Esther Heid, Lior Hirschfeld, Tommi Jaakkola, Wengong Jin, Shih-Cheng Li, 
+Mengjie Liu, Charles McGill, Kyle Swanson, Allison Tam, Florence Vermeire, 
+Haoyang Wu, and Kevin Yang)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = chemprop
 version = 1.6.1
-author = Regina Barzilay, Jackson Burns, Yunsie Chung, David Graff, William Green, Kevin Greenman, Yanfei Guan, Esther Heid, Lior Hirschfeld, Tommi Jaakkola, Wengong Jin, Shih-Cheng Li, Mengjie Liu, Charles McGill, Kyle Swanson, Allison Tam, Florence Vermeire, Haoyang Wu, Kevin Yang
+author = The Chemprop Development Team (see LICENSE.txt)
 author_email = chemprop@mit.edu
 license = MIT
 description = Molecular Property Prediction with Message Passing Neural Networks

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = chemprop
 version = 1.6.1
-author = Kyle Swanson, Kevin Yang, Wengong Jin, Lior Hirschfeld, Allison Tam
+author = Regina Barzilay, Jackson Burns, Yunsie Chung, David Graff, William Green, Kevin Greenman, Yanfei Guan, Esther Heid, Lior Hirschfeld, Tommi Jaakkola, Wengong Jin, Shih-Cheng Li, Mengjie Liu, Charles McGill, Kyle Swanson, Allison Tam, Florence Vermeire, Haoyang Wu, Kevin Yang
 author_email = chemprop@mit.edu
 license = MIT
 description = Molecular Property Prediction with Message Passing Neural Networks

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="chemprop",
-    author="Kyle Swanson, Kevin Yang, Wengong Jin, Lior Hirschfeld, Allison Tam",
+    author="Regina Barzilay, Jackson Burns, Yunsie Chung, David Graff, William Green, Kevin Greenman, Yanfei Guan, Esther Heid, Lior Hirschfeld, Tommi Jaakkola, Wengong Jin, Shih-Cheng Li, Mengjie Liu, Charles McGill, Kyle Swanson, Allison Tam, Florence Vermeire, Haoyang Wu, Kevin Yang",
     author_email="chemprop@mit.edu",
     description="Molecular Property Prediction with Message Passing Neural Networks",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="chemprop",
-    author="Regina Barzilay, Jackson Burns, Yunsie Chung, David Graff, William Green, Kevin Greenman, Yanfei Guan, Esther Heid, Lior Hirschfeld, Tommi Jaakkola, Wengong Jin, Shih-Cheng Li, Mengjie Liu, Charles McGill, Kyle Swanson, Allison Tam, Florence Vermeire, Haoyang Wu, Kevin Yang",
+    author="The Chemprop Development Team (see LICENSE.txt)",
     author_email="chemprop@mit.edu",
     description="Molecular Property Prediction with Message Passing Neural Networks",
     long_description=long_description,


### PR DESCRIPTION
I realized a couple things after merging #532:
* there are also authors lists in the `setup.py` and `setup.cfg` files that should probably also be updated to match the new list in the `LICENSE.txt`
* we left out a couple people in #532: Lior Hirschfeld and Yanfei Guan (who are both relatively high on the [contributors list](https://github.com/chemprop/chemprop/graphs/contributors)), and Allison Tam (who does not show up under GitHub contributions, but was listed in the `setup.py` and `setup.cfg` files)

Note that these new author lists do not include several people who have made significant contributions to the v2 code. They will be added in a future PR related to #489 