### PR TITLE
V2: run example notebooks in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,12 +34,18 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          mamba install flake8 pytest parameterized
+          mamba install flake8 pytest parameterized nbmake
           python -m pip install -e ".[dev,docs,test]"
       - name: Test with pytest
         shell: bash -l {0}
         run: |
           pytest -v tests
+      - name: Test notebooks
+        shell: bash -l {0}
+        run: |
+          pytest --nbmake examples/training.ipynb
+          pytest --nbmake examples/predicting.ipynb
+          pytest --nbmake examples/convert_v1_to_v2.ipynb
       # TODO: move this back before the tests after v2 development is done
       - name: Lint with flake8
         shell: bash -l {0}


### PR DESCRIPTION
## Description
Addressed questions regarding testing example notebooks raised in https://github.com/chemprop/chemprop/issues/559. Building on top of and should be merged after https://github.com/chemprop/chemprop/pull/560. Attempting to run example notebooks using pytest plugin https://github.com/treebeardtech/nbmake in GitHub Action.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
