### PR TITLE
Improve error message when gilbrat is needed.

### DIFF
--- a/chemprop/features/features_generators.py
+++ b/chemprop/features/features_generators.py
@@ -132,7 +132,7 @@ except ImportError:
         raise ImportError('Failed to import descriptastorus. Please install descriptastorus '
                           '(https://github.com/bp-kelley/descriptastorus) to use RDKit 2D normalized features.')
 except AttributeError as e:
-    raise AttributeError('`descriptastorus==2.6.1` is incompatible with `scipy<1.9`. Please try changing '
+    raise e('`descriptastorus==2.6.1` is incompatible with `scipy<1.9`. Please try changing '
                          'descriptastorus versions or update scipy to avoid issues with `scipy.stats.gibrat`.')
 
 """

--- a/chemprop/features/features_generators.py
+++ b/chemprop/features/features_generators.py
@@ -131,7 +131,9 @@ except ImportError:
         """Mock implementation raising an ImportError if descriptastorus cannot be imported."""
         raise ImportError('Failed to import descriptastorus. Please install descriptastorus '
                           '(https://github.com/bp-kelley/descriptastorus) to use RDKit 2D normalized features.')
-
+except AttributeError as e:
+    raise AttributeError('It appears you are using `scipy>=1.11` and `descriptastorus<=2.6.0`'
+                         'Please try updating descriptastorus to avoid issues with `scipy.stats.gibrat`.')
 
 """
 Custom features generator template.

--- a/chemprop/features/features_generators.py
+++ b/chemprop/features/features_generators.py
@@ -132,8 +132,16 @@ except ImportError:
         raise ImportError('Failed to import descriptastorus. Please install descriptastorus '
                           '(https://github.com/bp-kelley/descriptastorus) to use RDKit 2D normalized features.')
 except AttributeError as e:
-    raise e('`descriptastorus==2.6.1` is incompatible with `scipy<1.9`. Please try changing '
-                         'descriptastorus versions or update scipy to avoid issues with `scipy.stats.gibrat`.')
+    from packaging import version
+    from scipy import __version__ as scipy_version
+    from descriptastorus import __version__ as descriptastorus_version
+
+    if (version.parse(descriptastorus_version) == version.parse('2.5.1') or 
+        version.parse(descriptastorus_version) == version.parse('2.6.1')) and version.parse(scipy_version) < version.parse('1.9'):
+        raise Exception('`descriptastorus==2.6.1` and `==2.5.1` are incompatible with `scipy<1.9`. Please try changing '
+                        'descriptastorus versions or update scipy to avoid issues with `scipy.stats.gibrat`.') from e
+    else:
+        raise e
 
 """
 Custom features generator template.

--- a/chemprop/features/features_generators.py
+++ b/chemprop/features/features_generators.py
@@ -135,9 +135,9 @@ except AttributeError as e:
     from scipy import __version__ as scipy_version
     from descriptastorus import __version__ as descriptastorus_version
 
-    raise AttributeError(f'`descriptastorus==2.6.1` and `==2.5.1` are incompatible with `scipy<1.9`. Please try changing '
+    raise AttributeError('`descriptastorus==2.6.1` and `==2.5.1` are incompatible with `scipy<1.9`. Please try changing '
                     'descriptastorus versions or update scipy to avoid issues with `scipy.stats.gibrat`. '
-                    'Your versions are descriptastorus: {descriptastorus_version} and scipy {scipy_version}') from e
+                    f'Your versions are descriptastorus: {descriptastorus_version} and scipy {scipy_version}') from e
 
 """
 Custom features generator template.

--- a/chemprop/features/features_generators.py
+++ b/chemprop/features/features_generators.py
@@ -132,8 +132,8 @@ except ImportError:
         raise ImportError('Failed to import descriptastorus. Please install descriptastorus '
                           '(https://github.com/bp-kelley/descriptastorus) to use RDKit 2D normalized features.')
 except AttributeError as e:
-    raise AttributeError('It appears you are using `scipy>=1.11` and `descriptastorus<=2.6.0`'
-                         'Please try updating descriptastorus to avoid issues with `scipy.stats.gibrat`.')
+    raise AttributeError('`descriptastorus==2.6.1` is incompatible with `scipy<1.9`. Please try changing '
+                         'descriptastorus versions or update scipy to avoid issues with `scipy.stats.gibrat`.')
 
 """
 Custom features generator template.

--- a/chemprop/features/features_generators.py
+++ b/chemprop/features/features_generators.py
@@ -132,16 +132,12 @@ except ImportError:
         raise ImportError('Failed to import descriptastorus. Please install descriptastorus '
                           '(https://github.com/bp-kelley/descriptastorus) to use RDKit 2D normalized features.')
 except AttributeError as e:
-    from packaging import version
     from scipy import __version__ as scipy_version
     from descriptastorus import __version__ as descriptastorus_version
 
-    if (version.parse(descriptastorus_version) == version.parse('2.5.1') or 
-        version.parse(descriptastorus_version) == version.parse('2.6.1')) and version.parse(scipy_version) < version.parse('1.9'):
-        raise Exception('`descriptastorus==2.6.1` and `==2.5.1` are incompatible with `scipy<1.9`. Please try changing '
-                        'descriptastorus versions or update scipy to avoid issues with `scipy.stats.gibrat`.') from e
-    else:
-        raise e
+    raise Exception('`descriptastorus==2.6.1` and `==2.5.1` are incompatible with `scipy<1.9`. Please try changing '
+                    'descriptastorus versions or update scipy to avoid issues with `scipy.stats.gibrat`. '
+                    'Your versions are descriptastorus: ' + descriptastorus_version + ' and scipy: ' + scipy_version) from e
 
 """
 Custom features generator template.

--- a/chemprop/features/features_generators.py
+++ b/chemprop/features/features_generators.py
@@ -135,9 +135,9 @@ except AttributeError as e:
     from scipy import __version__ as scipy_version
     from descriptastorus import __version__ as descriptastorus_version
 
-    raise Exception('`descriptastorus==2.6.1` and `==2.5.1` are incompatible with `scipy<1.9`. Please try changing '
+    raise AttributeError(f'`descriptastorus==2.6.1` and `==2.5.1` are incompatible with `scipy<1.9`. Please try changing '
                     'descriptastorus versions or update scipy to avoid issues with `scipy.stats.gibrat`. '
-                    'Your versions are descriptastorus: ' + descriptastorus_version + ' and scipy: ' + scipy_version) from e
+                    'Your versions are descriptastorus: {descriptastorus_version} and scipy {scipy_version}') from e
 
 """
 Custom features generator template.


### PR DESCRIPTION
## Description
#435 describes a bug where `descriptastorus` complains that `scipy.stats` doesn't have the attribute `gilbrat`. This was fixed in the latest version of `descriptastorus`, but the error message doesn't indicate that is the problem. This PR makes the error message more helpful. 

Fixes #435
Closes #436
