### PR TITLE
Change Hyperopt Search Space

### DIFF
--- a/chemprop/hyperopt_utils.py
+++ b/chemprop/hyperopt_utils.py
@@ -36,7 +36,7 @@ def build_search_space(search_parameters: List[str], train_epochs: int = None) -
             ]
         ),
         "ffn_hidden_size": hp.quniform("ffn_hidden_size", low=300, high=2400, q=100),
-        "ffn_num_layers": hp.quniform("ffn_num_layers", low=1, high=3, q=1),
+        "ffn_num_layers": hp.quniform("ffn_num_layers", low=2, high=6, q=1),
         "final_lr_ratio": hp.loguniform("final_lr_ratio", low=np.log(1e-4), high=0.),
         "hidden_size": hp.quniform("hidden_size", low=300, high=2400, q=100),
         "init_lr_ratio": hp.loguniform("init_lr_ratio", low=np.log(1e-4), high=0.),

--- a/chemprop/hyperparameter_optimization.py
+++ b/chemprop/hyperparameter_optimization.py
@@ -135,6 +135,7 @@ def hyperopt(args: HyperoptArgs) -> None:
             dir_path=args.hyperopt_checkpoint_dir, previous_trials=manual_trials
         )
         if len(trials) > 0 and set(space.keys()) != set(trials.vals.keys()):
+        if len(trials) > 0 and set(space.keys()) != set(trials.best_trial["result"]["hyperparams"].keys()):
             raise ValueError(
                 f"Loaded hyperopt checkpoints files must be searching over the same parameters as \
                     the hyperparameter optimization job. Loaded trials covered variation in the parameters {set(trials.vals.keys())}. \

--- a/chemprop/hyperparameter_optimization.py
+++ b/chemprop/hyperparameter_optimization.py
@@ -134,7 +134,6 @@ def hyperopt(args: HyperoptArgs) -> None:
         trials = load_trials(
             dir_path=args.hyperopt_checkpoint_dir, previous_trials=manual_trials
         )
-        if len(trials) > 0 and set(space.keys()) != set(trials.vals.keys()):
         if len(trials) > 0 and set(space.keys()) != set(trials.best_trial["result"]["hyperparams"].keys()):
             raise ValueError(
                 f"Loaded hyperopt checkpoints files must be searching over the same parameters as \


### PR DESCRIPTION
## Description
This PR makes two changes to the hyperopt search space and default settings. This is driven by the observation that the optimal hyperparameters are found to be no dropout or large numbers of ffn layers. I have never observed the best number of ffn layers to be 1 or even for 1 ffn layer to perform particularly well.

1. It reduces the amount of time that dropout is included in random sampling trials. Previously the space was uniform probability of 0-0.4 at 0.05 intervals, so that the chances of having no dropout was 1/9. Dropout is commonly detrimental to some datasets, sometimes severely, and having 8/9 of the random trials include it could lead to poor parameter searching. Now the decision to have dropout at all is initially a 50/50 choice and only if dropout is included is it sampled from 0.05-0.4 at 0.05 intervals.
2. It changes the ffn_num_layers search space from [1,3] to [2,6]. This reduces the likelihood that a very likely poor value of 1 is pulled during random trials and it provides potentially better top end performance for high complexity models.

The performance of these new parameters is similar to defaults for most of the moleculenet datasets. @khashrva tested settings similar but not the same as these (1/3 likelihood of no dropout rather than 1/2). Tests were done with the default with the addition of running num_folds=5. The changes were not tested fully independently but added sequentially. Bold best. The crossval std is larger than the improvement for all of these (which is not the same as saying they are indistinguishable since they have the same seeds and not independent seed samples). 

| Dataset | Prior Default | Similar dropout change | dropout + ffn layers | 
|--------|--------|--------|--------|
| Freesolv (RMSE) | 0.9603+/-0.24 | **0.9540+/-0.22** | 0.9809+/-0.23 | 
| Lipo (RMSE)| 0.5292+/-0.041 | 0.5282+/-0.036 | **0.5271+/-0.036** |
| QM9_U0 (RMSE) | 0.1629+/-0.14 | **0.1480+/-0.15** | 0.1490+/-0.15 | 
| Esol (RMSE) | 0.6017+/-0.060 | 0.6006+/-0.054 | **0.6000+/-0.068** | 
| HIV (AUC) | 0.8197+/-0.007 | 0.8183+/-0.019 | **0.8221+/-0.007** | 
| ClinTox (AUC) | 0.8946+/-0.045 | 0.8943+/-0.037 | **0.9080+/-0.036** |

## Questions

- This change may be better wrapped up into v2 rollout because it makes changes to the default hyperparameter search space.
- Since testing was not done on these exact settings but similar ones, it may be desired to repeat tests.
- These changes to the search spaces affect hyperopt search even under non-default settings, with more trials etc. Signal may be stronger or weaker then.
- For most datasets tested here, the change in outcome is not large and perhaps the datasets are not significantly hyperparameter sensitive. On face this makes the changes seem not significant, but other datasets may  be more sensitive, as with QM9 performance with 10% improvement. 
