### PR TITLE
V2: add integration test for mol+mol regression

### DIFF
--- a/chemprop/nn/message_passing/multi.py
+++ b/chemprop/nn/message_passing/multi.py
@@ -71,4 +71,7 @@ class MulticomponentMessagePassing(nn.Module, HasHParams):
         list[Tensor]
             a list of tensors of shape `b x d_i` containing the respective encodings of the `i`th component, where `b` is the number of components in the batch, and `d_i` is the output dimension of the `i`th encoder
         """
-        return [block(bmg, V_d) for block, bmg, V_d in zip(self.blocks, bmgs, V_ds)]
+        if V_ds is None:
+            return [block(bmg) for block, bmg in zip(self.blocks, bmgs)]
+        else:
+            return [block(bmg, V_d) for block, bmg, V_d in zip(self.blocks, bmgs, V_ds)]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@ import warnings
 import pytest
 
 from chemprop import models, nn
+from chemprop.models import multi
 
 warnings.filterwarnings("ignore", module=r"lightning.*", append=True)
 
@@ -13,3 +14,13 @@ def mpnn(request):
     ffn = nn.RegressionFFN()
 
     return models.MPNN(request.param, agg, ffn, True)
+
+
+@pytest.fixture(scope="session")
+def mcmpnn(request):
+    block, n_components = request.param
+    mcmp = nn.MulticomponentMessagePassing([block for _ in range(n_components)], n_components)
+    agg = nn.SumAggregation()
+    ffn = nn.RegressionFFN(input_dim=mcmp.output_dim,)
+
+    return multi.MulticomponentMPNN(mcmp, agg, ffn, True)

--- a/tests/integration/test_regression_multimol.py
+++ b/tests/integration/test_regression_multimol.py
@@ -1,0 +1,79 @@
+"""This integration test is designed to ensure that the chemprop model can _overfit_ the training
+data. A small enough dataset should be memorizable by even a moderately sized model, so this test
+should generally pass."""
+
+import warnings
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import torch
+from lightning import pytorch as pl
+from torch.utils.data import DataLoader
+
+from chemprop import featurizers, nn
+from chemprop.data import (MoleculeDatapoint, MoleculeDataset,
+                           MulticomponentDataset, collate_multicomponent)
+from chemprop.models import multi
+
+N_COMPONENTS = 2
+pytestmark = pytest.mark.parametrize(
+    "mcmpnn", [(nn.BondMessagePassing(), N_COMPONENTS), (nn.AtomMessagePassing(), N_COMPONENTS)], indirect=True
+)
+
+@pytest.fixture
+def datas(mol_mol_regression_data):
+    smis1, smis2, Y = mol_mol_regression_data
+
+    return [[MoleculeDatapoint.from_smi(smi, y) for smi, y in zip(smis1, Y)], [MoleculeDatapoint.from_smi(smi) for smi in smis2]]
+
+
+@pytest.fixture
+def dataloader_scaler(datas):
+    dsets = [MoleculeDataset(data) for data in datas]
+    mcdset = MulticomponentDataset(dsets)
+    scaler = mcdset.normalize_targets()
+
+    return DataLoader(mcdset, 32, collate_fn=collate_multicomponent), scaler
+
+
+def test_quick(mcmpnn, dataloader_scaler):
+    dataloader, _ = dataloader_scaler
+    trainer = pl.Trainer(
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        accelerator="cpu",
+        devices=1,
+        fast_dev_run=True,
+    )
+    trainer.fit(mcmpnn, dataloader)
+
+
+def test_overfit(mcmpnn, dataloader_scaler):
+    dataloader, scaler = dataloader_scaler
+    mcmpnn.loc = scaler.mean_
+    mcmpnn.scale = scaler.scale_
+    trainer = pl.Trainer(
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=True,
+        enable_model_summary=False,
+        accelerator="cpu",
+        devices=1,
+        max_epochs=100,
+        overfit_batches=1.00
+    )
+    trainer.fit(mcmpnn, dataloader)
+
+    errors = []
+    for batch in dataloader:
+        bmg, _, _, targets, *_ = batch
+        preds = mcmpnn(bmg)
+        errors.append(preds - targets)
+
+    errors = torch.cat(errors)
+    mse = errors.square().mean().item()
+
+    assert mse <= 0.05

--- a/tests/integration/test_regression_multimol.py
+++ b/tests/integration/test_regression_multimol.py
@@ -29,16 +29,15 @@ def datas(mol_mol_regression_data):
 
 
 @pytest.fixture
-def dataloader_scaler(datas):
+def dataloader(datas):
     dsets = [MoleculeDataset(data) for data in datas]
     mcdset = MulticomponentDataset(dsets)
-    scaler = mcdset.normalize_targets()
+    mcdset.normalize_targets()
 
-    return DataLoader(mcdset, 32, collate_fn=collate_multicomponent), scaler
+    return DataLoader(mcdset, 32, collate_fn=collate_multicomponent)
 
 
-def test_quick(mcmpnn, dataloader_scaler):
-    dataloader, _ = dataloader_scaler
+def test_quick(mcmpnn, dataloader):
     trainer = pl.Trainer(
         logger=False,
         enable_checkpointing=False,
@@ -51,10 +50,7 @@ def test_quick(mcmpnn, dataloader_scaler):
     trainer.fit(mcmpnn, dataloader)
 
 
-def test_overfit(mcmpnn, dataloader_scaler):
-    dataloader, scaler = dataloader_scaler
-    mcmpnn.loc = scaler.mean_
-    mcmpnn.scale = scaler.scale_
+def test_overfit(mcmpnn, dataloader):
     trainer = pl.Trainer(
         logger=False,
         enable_checkpointing=False,


### PR DESCRIPTION
## Description
This PR will close https://github.com/chemprop/chemprop/issues/575 by adding an integration test for mol+mol regression.

## Relevant issues
[If appropriate, please tag them here and include a quick summary](https://github.com/chemprop/chemprop/issues/575)

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
