### PR TITLE
Change Chemprop output locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ cython_debug/
 *.DS_Store
 *.vscode
 *.csv
+*.pkl
 *.pt
 *.json
 *.sqlite3

--- a/chemprop/cli/convert.py
+++ b/chemprop/cli/convert.py
@@ -15,20 +15,26 @@ class ConvertSubcommand(Subcommand):
 
     @classmethod
     def add_args(cls, parser: ArgumentParser) -> ArgumentParser:
-        parser.add_argument("input_path", help="The path to a v1 model .pt checkpoint file.")
         parser.add_argument(
-            "output_path",
-            nargs="?",
-            help="The path to which the converted model will be saved. If not specified and the input file is '/path/to/checkpoint/model.pt', the output will default to '/path/to/checkpoint/model_v2.ckpt'",
+            "-i",
+            "--input-path",
+            required=True,
+            type=Path,
+            help="The path to a v1 model .pt checkpoint file.",
+        )
+        parser.add_argument(
+            "-o",
+            "--output-path",
+            type=Path,
+            help="The path to which the converted model will be saved. Defaults to '<current working directory>/<stem of input>_v2.ckpt'",
         )
         return parser
 
     @classmethod
     def func(cls, args: Namespace):
-        args.input_path = Path(args.input_path)
-        args.output_path = Path(
-            args.output_path or args.input_path.parent / (args.input_path.stem + "_v2.ckpt")
-        )
+        args.output_path = args.output_path or Path(args.input_path.stem + "_v2.ckpt")
+        if args.output_path.suffix != ".ckpt":
+            args.output_path = Path(str(args.output_path) + ".ckpt")
 
         logger.info(
             f"Converting v1 model checkpoint '{args.input_path}' to v2 model checkpoint '{args.output_path}'..."

--- a/chemprop/cli/main.py
+++ b/chemprop/cli/main.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 import logging
+import sys
 from pathlib import Path
 
 from chemprop.cli.train import TrainSubcommand
@@ -14,7 +15,6 @@ from chemprop.cli.utils import LOG_DIR, NOW, pop_attr
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LOGFILE = f"{LOG_DIR}/{NOW}.log"
 LOG_LEVELS = [logging.ERROR, logging.WARNING, logging.INFO, logging.DEBUG]
 SUBCOMMANDS = [
     TrainSubcommand,
@@ -32,7 +32,7 @@ def main():
         "--logfile",
         "--log",
         nargs="?",
-        default=DEFAULT_LOGFILE,
+        const="default",
         help=f"the path to which the log file should be written. Specifying just the flag (i.e., '--log/--logfile') will automatically log to a file '{LOG_DIR}/MODE/{NOW}.log', where 'MODE' is the CLI mode chosen.",
     )
     parent.add_argument("-v", "--verbose", action="count", default=0, help="the verbosity level")
@@ -46,11 +46,18 @@ def main():
         pop_attr(args, attr) for attr in ["logfile", "verbose", "mode", "func"]
     )
 
-    logfile = Path(LOG_DIR / mode / f"{NOW}.log" if logfile is None else logfile)
-    logfile.parent.mkdir(parents=True, exist_ok=True)
+    match logfile:
+        case None:
+            handler = logging.StreamHandler(sys.stderr)
+        case "default":
+            (LOG_DIR / mode).mkdir(parents=True, exist_ok=True)
+            handler = logging.FileHandler(str(LOG_DIR / mode / f"{NOW}.log"))
+        case _:
+            Path(logfile).parent.mkdir(parents=True, exist_ok=True)
+            handler = logging.FileHandler(logfile)
 
     logging.basicConfig(
-        filename=str(logfile),
+        handlers=[handler],
         format="%(asctime)s - %(levelname)s:%(name)s - %(message)s",
         level=LOG_LEVELS[min(verbose, len(LOG_LEVELS) - 1)],
         datefmt="%Y-%m-%dT%H:%M:%S",

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -50,7 +50,7 @@ def add_predict_args(parser: ArgumentParser) -> ArgumentParser:
         "--output",
         "--preds-path",
         type=Path,
-        help="Path to CSV or PICKLE file where predictions will be saved. If the file extension is .pkl, will be saved as a PICKLE file. If not provided and the test_path is /path/to/test/test.csv, predictions will be saved to /path/to/test/test_preds.csv.",
+        help="Path to CSV or PICKLE file where predictions will be saved. If the file extension is .pkl, will be saved as a PICKLE file. Defaults to '<current working directory>/<stem of input>_preds.csv'.",
     )
     parser.add_argument(
         "--drop-extra-columns",
@@ -145,13 +145,9 @@ def add_predict_args(parser: ArgumentParser) -> ArgumentParser:
 
 
 def process_predict_args(args: Namespace) -> Namespace:
-    if args.output is None:
-        args.test_path = Path(args.test_path)
-        name = f"{args.test_path.stem}_preds.csv"
-        args.output = args.test_path.with_name(name)
-    else:
-        args.output = Path(args.output)
-
+    args.output = args.output or Path(args.test_path.stem + "_preds.csv")
+    if args.output.suffix not in [".csv", ".pkl"]:
+        args.output = Path(str(args.output) + ".csv")
     return args
 
 

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -39,12 +39,17 @@ class PredictSubcommand(Subcommand):
 
 def add_predict_args(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
-        "-i", "--test-path", required=True, help="Path to an input CSV file containing SMILES."
+        "-i",
+        "--test-path",
+        required=True,
+        type=Path,
+        help="Path to an input CSV file containing SMILES.",
     )
     parser.add_argument(
         "-o",
         "--output",
         "--preds-path",
+        type=Path,
         help="Path to CSV or PICKLE file where predictions will be saved. If the file extension is .pkl, will be saved as a PICKLE file. If not provided and the test_path is /path/to/test/test.csv, predictions will be saved to /path/to/test/test_preds.csv.",
     )
     parser.add_argument(
@@ -264,6 +269,7 @@ def main(args):
         df_test.to_pickle(args.output)
     else:
         df_test.to_csv(args.output, index=False)
+    logger.info(f"predictions saved to '{args.output}'")
 
 
 if __name__ == "__main__":

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -240,7 +240,7 @@ def main(args):
 
     with torch.inference_mode():
         trainer = pl.Trainer(
-            logger=None,
+            logger=False,
             enable_progress_bar=True,
             accelerator="auto",
             devices=args.n_gpu if torch.cuda.is_available() else 1,
@@ -261,7 +261,7 @@ def main(args):
         "preds"
     ] = preds.flatten()  # TODO: this will not work correctly for multi-target predictions
     if args.output.suffix == ".pkl":
-        df_test.to_pickle(args.output, index=False)
+        df_test.to_pickle(args.output)
     else:
         df_test.to_csv(args.output, index=False)
 

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -213,7 +213,7 @@ def main(args):
     if multicomponent:
         test_dset = data.MulticomponentDataset(test_dsets)
     else:
-        test_data = test_data[0]
+        test_dset = test_dsets[0]
 
     # TODO: add uncertainty and calibration
     # if args.cal_path is not None:

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -250,7 +250,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         "--task-type",
         default="regression",
         action=LookupAction(PredictorRegistry),
-        help="Type of dataset. This determines the default loss function used during training.",
+        help="Type of dataset. This determines the default loss function used during training. Defaults to regression.",
     )
     data_args.add_argument(
         "--spectra-phase-mask-path",
@@ -338,7 +338,8 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         help="spectral threshold limit. v1 help string: Values in targets for dataset type spectra are replaced with this value, intended to be a small positive number used to enforce positive values.",
     )
     train_args.add_argument(
-        "--metric" "--metrics",
+        "--metric",
+        "--metrics",
         nargs="+",
         action=LookupAction(MetricRegistry),
         help="evaluation metrics. If unspecified, will use the following metrics for given dataset types: regression->rmse, classification->roc, multiclass->ce ('cross entropy'), spectral->sid. If multiple metrics are provided, the 0th one will be used for early stopping and checkpointing",
@@ -532,7 +533,8 @@ def main(args):
                 train_data, val_data, _ = split_monocomponent(all_data, args.split, **split_kwargs)
     else:
         raise ArgumentError(
-            argument=None, message="'val_path' must be specified if 'test_path' is provided!"
+            argument=None,
+            message="'separate_val_path' must be specified if 'separate_test_path' is provided!",
         )  # TODO: In v1 this wasn't the case?
 
     if multicomponent:

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -49,12 +49,14 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         "-i",
         "--data-path",
         required=True,
+        type=Path,
         help="Path to an input CSV file containing SMILES and the associated target values.",
     )
     parser.add_argument(
         "-o",
         "--output-dir",
         "--save-dir",
+        type=Path,
         help="Directory where model checkpoints will be saved. Defaults to a directory in the current working directory with the same base name as the input file.",
     )
     # TODO: see if we can tell lightning how often to log training loss
@@ -476,6 +478,7 @@ def main(args):
         features_generators=args.features_generators, keep_h=args.keep_h, add_h=args.add_h
     )
 
+    logger.info(f"Pulling data from file: {args.data_path}")
     all_data = build_data_from_files(
         args.data_path,
         **format_kwargs,

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -20,7 +20,7 @@ from chemprop.nn import AggregationRegistry, LossFunctionRegistry, MetricRegistr
 from chemprop.nn.predictors import PredictorRegistry, RegressionFFN
 from chemprop.nn.message_passing import BondMessagePassing, AtomMessagePassing
 
-from chemprop.cli.utils import Subcommand, LookupAction, build_data_from_files, make_dataset
+from chemprop.cli.utils import Subcommand, LookupAction, build_data_from_files, make_dataset, NOW
 from chemprop.cli.common import add_common_args, process_common_args, validate_common_args
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         "--output-dir",
         "--save-dir",
         type=Path,
-        help="Directory where model checkpoints will be saved. Defaults to a directory in the current working directory with the same base name as the input file.",
+        help="Directory where training outputs will be saved. Defaults to '<current directory>/chemprop_training/<stem of input>_<time stamp>'.",
     )
     # TODO: see if we can tell lightning how often to log training loss
     parser.add_argument(
@@ -449,9 +449,9 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
 
 
 def process_train_args(args: Namespace) -> Namespace:
-    args.data_path = Path(args.data_path)
-
-    args.output_dir = Path(args.output_dir or Path.cwd() / args.data_path.stem)
+    args.output_dir = args.output_dir or Path("chemprop_training") / (
+        "_".join([args.data_path.stem, NOW])
+    )
     args.output_dir.mkdir(exist_ok=True, parents=True)
 
     return args

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import sys
 
 from lightning import pytorch as pl
-from lightning.pytorch.loggers import TensorBoardLogger
+from lightning.pytorch.loggers import TensorBoardLogger, CSVLogger
 from lightning.pytorch.callbacks import ModelCheckpoint, EarlyStopping
 import torch
 
@@ -659,7 +659,11 @@ def main(args):
     monitor_mode = "min" if model.metrics[0].minimize else "max"
     logger.debug(f"Evaluation metric: '{model.metrics[0].alias}', mode: '{monitor_mode}'")
 
-    tb_logger = TensorBoardLogger(args.output_dir, "tb_logs")
+    try:
+        trainer_logger = TensorBoardLogger(args.output_dir, "trainer_logs")
+    except ImportError:
+        trainer_logger = CSVLogger(args.output_dir, "trainer_logs")
+
     checkpointing = ModelCheckpoint(
         args.output_dir / "chkpts",
         "{epoch}-{val_loss:.2f}",
@@ -670,7 +674,7 @@ def main(args):
     early_stopping = EarlyStopping("val_loss", patience=5, mode=monitor_mode)
 
     trainer = pl.Trainer(
-        logger=tb_logger,
+        logger=trainer_logger,
         enable_progress_bar=True,
         accelerator="auto",
         devices=args.n_gpu if torch.cuda.is_available() else 1,

--- a/chemprop/cli/utils/__init__.py
+++ b/chemprop/cli/utils/__init__.py
@@ -1,6 +1,6 @@
 from .args import bounded
 from .actions import LookupAction
 from .command import Subcommand
-from .conf import CKPT_DIR, LOG_DIR, NOW
+from .conf import LOG_DIR, NOW
 from .parsing import build_data_from_files, make_datapoints, make_dataset
 from .utils import *

--- a/chemprop/cli/utils/conf.py
+++ b/chemprop/cli/utils/conf.py
@@ -2,5 +2,5 @@ from datetime import datetime
 import os
 from pathlib import Path
 
-LOG_DIR = Path(os.getenv("CHEMPROP_LOG_DIR", "logs/chemprop"))
+LOG_DIR = Path(os.getenv("CHEMPROP_LOG_DIR", "chemprop_logs"))
 NOW = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")

--- a/chemprop/cli/utils/conf.py
+++ b/chemprop/cli/utils/conf.py
@@ -2,6 +2,5 @@ from datetime import datetime
 import os
 from pathlib import Path
 
-CKPT_DIR = Path(os.getenv("CHEMPROP_CKPT_DIR", "model_checkpoints"))
 LOG_DIR = Path(os.getenv("CHEMPROP_LOG_DIR", "logs/chemprop"))
 NOW = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -89,7 +89,7 @@ def make_datapoints(
         a list of lists of :class:`MoleculeDatapoint`s of shape ``j x n``, where ``j`` is the
         number of molecule components per datapoint and ``n`` is the total number of datapoints
     list[list[ReactionDatapoint]]
-        a list of lists of :class:`MoleculeDatapoint`s of shape ``k x n``, where ``k`` is the
+        a list of lists of :class:`ReactionDatapoint`s of shape ``k x n``, where ``k`` is the
         number of reaction components per datapoint and ``n`` is the total number of datapoints
     .. note::
         either ``j`` or ``k`` may be 0, in which case the corresponding list will be empty.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "rdkit",
     "scikit-learn",
     "scipy",
-    "tensorboard",
     "torch >= 2.1",
     "torch_scatter",
     "astartes[molecules]",


### PR DESCRIPTION
## Related topics
Partly related to #588 after discussion in #591. Should be merged after #597. 

## Summary
This PR is an attempt to find good defaults and user options for where to put Chemprop outputs. 

## Details
`chemprop train` outputs a structured directory with chkpts, trainer_logs, and model.pt (and eventually args.json). I propose defaulting this structured directory to `<CWD>/chemprop_training/<input.stem>_<time stamp>/`. This is based on the assumption that users may want to quickly train multiple models with different arguments and datasets. Including both the <input.stem> (the basename of the input data) and a time stamp will make it easy to differentiate experiments from each other. Grouping all structured directories together under `chemprop_training` keeps the working directory from filling up with runs. 

`chemprop predict` outputs a prediction file. I propose this defaults to `<CWD>/<input.stem>_preds.csv`. This is similar to the current except it is in the current working directory. I have assumed that if a user has their datasets in a separate folder (e.g. `chemprop/tests/data/`) and don't specify where to put their predictions, they would rather get the predictions where they are than to have to move them out of their data folder. 

`chemprop convert` is the same as predict but produces a checkpoint file. 

In terms of logging, by default the logging info will print to stderr. I prefer to send this to the terminal by default because then the user won't have to manage/delete a bunch of log files. (And the default logging level is ERROR which will typically print nothing, resulting in many empty log files.) I prefer stderr over stdout because progress bars get sent to stdout and if the user wanted to redirect the log stream to their own logfile, the progress bars quickly make a mess. 

If the user specifies just the flag `--log`, then the log is written to `<CWD>/chemprop_logs/<mode>/<time stamp>.log` (where mode is train, or predict, etc.). I chose "chemprop_logs" as an analogy to lightning's default log location "lightning_logs". 