### PR TITLE
V2: Add pytest for CLI functionality

### DIFF
--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -208,7 +208,7 @@ def main(args):
     if multicomponent:
         test_dset = data.MulticomponentDataset(test_dsets)
     else:
-        test_data = test_data[0]
+        test_dset = test_dsets[0]
 
     # TODO: add uncertainty and calibration
     # if args.cal_path is not None:

--- a/chemprop/models/model.py
+++ b/chemprop/models/model.py
@@ -28,7 +28,7 @@ class MPNN(pl.LightningModule):
 
     Parameters
     ----------
-    message_passing : MessagePassingBlock
+    message_passing : MessagePassing
         the message passing block to use to calculate learned fingerprints
     agg : Aggregation
         the aggregation operation to use during molecule-level predictor

--- a/chemprop/nn/message_passing/proto.py
+++ b/chemprop/nn/message_passing/proto.py
@@ -20,7 +20,7 @@ class MessagePassing(nn.Module, HasHParams):
         Parameters
         ----------
         bmg: BatchMolGraph
-            the batch of :class:`~chemprop.v2.featurizers.molgraph.MolGraph`s to encode
+            the batch of :class:`~chemprop.featurizers.molgraph.MolGraph`s to encode
         V_d : Tensor | None, default=None
             an optional tensor of shape `V x d_vd` containing additional descriptors for each atom
             in the batch. These will be concatenated to the learned atomic descriptors and

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -1,0 +1,34 @@
+"""This tests the CLI functionality of training and predicting a regression model on a multi-molecule.
+"""
+
+import pytest
+
+from chemprop.cli.main import main
+
+pytestmark = pytest.mark.CLI
+
+
+@pytest.fixture
+def data_path(data_dir):
+    return str(data_dir / "regression" / "mol+mol.csv")
+
+
+@pytest.fixture
+def checkpoint_path(data_dir):
+    return str(data_dir / "example_model_v2_regression_multi.ckpt")
+
+
+def test_training(monkeypatch, data_path):
+    args = ["chemprop", "train", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--epochs", "1", "--num-workers", "4"]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
+def test_predicting(monkeypatch, data_path, checkpoint_path):
+    args = ["chemprop", "predict", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--checkpoint", checkpoint_path]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -26,7 +26,7 @@ def test_train(monkeypatch, data_path):
         main()
 
 
-def test_predicting(monkeypatch, data_path, checkpoint_path):
+def test_predict(monkeypatch, data_path, checkpoint_path):
     args = ["chemprop", "predict", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--checkpoint", checkpoint_path]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -19,7 +19,7 @@ def checkpoint_path(data_dir):
 
 
 def test_train(monkeypatch, data_path):
-    args = ["chemprop", "train", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--epochs", "1", "--num-workers", "4"]
+    args = ["chemprop", "train", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--epochs", "1", "--num-workers", "0"]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -18,7 +18,7 @@ def checkpoint_path(data_dir):
     return str(data_dir / "example_model_v2_regression_multi.ckpt")
 
 
-def test_train(monkeypatch, data_path):
+def test_quick_train(monkeypatch, data_path):
     args = ["chemprop", "train", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--epochs", "1", "--num-workers", "0"]
 
     with monkeypatch.context() as m:
@@ -26,7 +26,7 @@ def test_train(monkeypatch, data_path):
         main()
 
 
-def test_predict(monkeypatch, data_path, checkpoint_path):
+def test_quick_predict(monkeypatch, data_path, checkpoint_path):
     args = ["chemprop", "predict", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--checkpoint", checkpoint_path]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -18,7 +18,7 @@ def checkpoint_path(data_dir):
     return str(data_dir / "example_model_v2_regression_multi.ckpt")
 
 
-def test_training(monkeypatch, data_path):
+def test_train(monkeypatch, data_path):
     args = ["chemprop", "train", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--epochs", "1", "--num-workers", "4"]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -18,7 +18,7 @@ def checkpoint_path(data_dir):
     return str(data_dir / "example_model_v2_regression_multi.ckpt")
 
 
-def test_quick_train(monkeypatch, data_path):
+def test_train_quick(monkeypatch, data_path):
     args = ["chemprop", "train", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--epochs", "1", "--num-workers", "0"]
 
     with monkeypatch.context() as m:
@@ -26,7 +26,7 @@ def test_quick_train(monkeypatch, data_path):
         main()
 
 
-def test_quick_predict(monkeypatch, data_path, checkpoint_path):
+def test_predict_quick(monkeypatch, data_path, checkpoint_path):
     args = ["chemprop", "predict", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--checkpoint", checkpoint_path]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -36,7 +36,7 @@ def test_predict_quick(monkeypatch, data_path, checkpoint_path):
 
 
 def test_train_output_structure(monkeypatch, data_path, tmp_path):
-    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", tmp_path]
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", str(tmp_path)]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
@@ -49,7 +49,7 @@ def test_train_output_structure(monkeypatch, data_path, tmp_path):
 
 
 def test_predict_output_structure(monkeypatch, data_path, tmp_path):
-    args = ["chemprop", "predict", "-i", data_path, "--checkpoint", "tests/data/example_model_v2.ckpt", "--output", tmp_path / "preds.csv"]
+    args = ["chemprop", "predict", "-i", data_path, "--checkpoint", "tests/data/example_model_v2.ckpt", "--output", str(tmp_path / "preds.csv")]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
@@ -61,7 +61,7 @@ def test_predict_output_structure(monkeypatch, data_path, tmp_path):
 
 
 def test_train_outputs(monkeypatch, data_path, tmp_path):
-    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", tmp_path]
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", str(tmp_path)]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -18,7 +18,7 @@ def checkpoint_path(data_dir):
     return str(data_dir / "example_model_v2.ckpt")
 
 
-def test_training(monkeypatch, data_path):
+def test_quick_train(monkeypatch, data_path):
     args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "4"]
 
     with monkeypatch.context() as m:
@@ -26,7 +26,7 @@ def test_training(monkeypatch, data_path):
         main()
 
 
-def test_predicting(monkeypatch, data_path, checkpoint_path):
+def test_quick_predict(monkeypatch, data_path, checkpoint_path):
     args = ["chemprop", "predict", "-i", data_path, "--checkpoint", checkpoint_path]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -42,10 +42,9 @@ def test_train_output_structure(monkeypatch, data_path, tmp_path):
         m.setattr("sys.argv", args)
         main()
 
-    assert (tmp_path / "logs" / "chemprop").exists()
-    assert (tmp_path / "mol" / "model.pt").exists()
-    assert (tmp_path / "mol" / "chkpts" / "last.ckpt").exists()
-    assert (tmp_path / "mol" / "tb_logs" / "version_0").exists()
+    assert (tmp_path / "model.pt").exists()
+    assert (tmp_path / "chkpts" / "last.ckpt").exists()
+    assert (tmp_path / "tb_logs" / "version_0").exists()
 
 
 def test_predict_output_structure(monkeypatch, data_path, tmp_path):
@@ -55,8 +54,6 @@ def test_predict_output_structure(monkeypatch, data_path, tmp_path):
         m.setattr("sys.argv", args)
         main()
 
-    assert (tmp_path / "logs" / "chemprop").exists()
-    assert (tmp_path / "lightning_logs").exists()
     assert (tmp_path / "preds.csv").exists()
 
 
@@ -67,6 +64,6 @@ def test_train_outputs(monkeypatch, data_path, tmp_path):
         m.setattr("sys.argv", args)
         main()
 
-    checkpoint_path = tmp_path / "mol" / "chkpts" / "last.ckpt"
+    checkpoint_path = tmp_path / "chkpts" / "last.ckpt"
 
     model = MPNN.load_from_checkpoint(checkpoint_path)

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -18,7 +18,7 @@ def checkpoint_path(data_dir):
     return str(data_dir / "example_model_v2.ckpt")
 
 
-def test_quick_train(monkeypatch, data_path):
+def test_train_quick(monkeypatch, data_path):
     args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0"]
 
     with monkeypatch.context() as m:
@@ -26,7 +26,7 @@ def test_quick_train(monkeypatch, data_path):
         main()
 
 
-def test_quick_predict(monkeypatch, data_path, checkpoint_path):
+def test_predict_quick(monkeypatch, data_path, checkpoint_path):
     args = ["chemprop", "predict", "-i", data_path, "--checkpoint", checkpoint_path]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -4,6 +4,7 @@
 import pytest
 
 from chemprop.cli.main import main
+from chemprop.models.model import MPNN
 
 pytestmark = pytest.mark.CLI
 
@@ -58,3 +59,14 @@ def test_predict_output_structure(monkeypatch, data_path, tmp_path):
     assert (tmp_path / "lightning_logs").exists()
     assert (tmp_path / "preds.csv").exists()
 
+
+def test_train_outputs(monkeypatch, data_path, tmp_path):
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", tmp_path]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+    checkpoint_path = tmp_path / "mol" / "chkpts" / "last.ckpt"
+
+    model = MPNN.load_from_checkpoint(checkpoint_path)

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -1,0 +1,34 @@
+"""This tests the CLI functionality of training and predicting a regression model on a single molecule.
+"""
+
+import pytest
+
+from chemprop.cli.main import main
+
+pytestmark = pytest.mark.CLI
+
+
+@pytest.fixture
+def data_path(data_dir):
+    return str(data_dir / "regression" / "mol.csv")
+
+
+@pytest.fixture
+def checkpoint_path(data_dir):
+    return str(data_dir / "example_model_v2.ckpt")
+
+
+def test_training(monkeypatch, data_path):
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "4"]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
+def test_predicting(monkeypatch, data_path, checkpoint_path):
+    args = ["chemprop", "predict", "-i", data_path, "--checkpoint", checkpoint_path]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -19,7 +19,7 @@ def checkpoint_path(data_dir):
 
 
 def test_quick_train(monkeypatch, data_path):
-    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "4"]
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0"]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -32,3 +32,29 @@ def test_predict_quick(monkeypatch, data_path, checkpoint_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+
+def test_train_output_structure(monkeypatch, data_path, tmp_path):
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", tmp_path]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+    assert (tmp_path / "logs" / "chemprop").exists()
+    assert (tmp_path / "mol" / "model.pt").exists()
+    assert (tmp_path / "mol" / "chkpts" / "last.ckpt").exists()
+    assert (tmp_path / "mol" / "tb_logs" / "version_0").exists()
+
+
+def test_predict_output_structure(monkeypatch, data_path, tmp_path):
+    args = ["chemprop", "predict", "-i", data_path, "--checkpoint", "tests/data/example_model_v2.ckpt", "--output", tmp_path / "preds.csv"]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+    assert (tmp_path / "logs" / "chemprop").exists()
+    assert (tmp_path / "lightning_logs").exists()
+    assert (tmp_path / "preds.csv").exists()
+

--- a/tests/integration/test_regression_mol.py
+++ b/tests/integration/test_regression_mol.py
@@ -9,9 +9,12 @@ from torch.utils.data import DataLoader
 from chemprop import nn
 from chemprop.data import MoleculeDatapoint, MoleculeDataset, collate_batch
 
-pytestmark = pytest.mark.parametrize(
-    "mpnn", [nn.BondMessagePassing(), nn.AtomMessagePassing()], indirect=True
-)
+pytestmark = [
+    pytest.mark.parametrize(
+        "mpnn", [nn.BondMessagePassing(), nn.AtomMessagePassing()], indirect=True
+    ),
+    pytest.mark.integration,
+]
 
 
 @pytest.fixture

--- a/tests/integration/test_regression_multimol.py
+++ b/tests/integration/test_regression_multimol.py
@@ -17,9 +17,15 @@ from chemprop.data import (MoleculeDatapoint, MoleculeDataset,
 from chemprop.models import multi
 
 N_COMPONENTS = 2
-pytestmark = pytest.mark.parametrize(
-    "mcmpnn", [(nn.BondMessagePassing(), N_COMPONENTS), (nn.AtomMessagePassing(), N_COMPONENTS)], indirect=True
-)
+pytestmark = [
+    pytest.mark.parametrize(
+        "mcmpnn",
+        [(nn.BondMessagePassing(), N_COMPONENTS), (nn.AtomMessagePassing(), N_COMPONENTS)],
+        indirect=True,
+    ),
+    pytest.mark.integration,
+]
+
 
 @pytest.fixture
 def datas(mol_mol_regression_data):


### PR DESCRIPTION
## Description
This PR addresses https://github.com/chemprop/chemprop/issues/590. I added pytest for the CLI functionality. 

## Questions
- Currently the test only tests that the CLI can run and use only 1 epoch. Should we increase the epoch and test the model performance? For example, we can pass the model generated by the training CLI test, and load it using the predicting CLI, and test the errors. I don't think it's necessary as this test focuses on the CLI connection aspect, and the model performance is tested by the integration test. But I want to know people's thoughts.

## Relevant issues
This PR addresses https://github.com/chemprop/chemprop/issues/590.