### PR TITLE
Fixing SpectralFNN self.fnn.fnn issue

### DIFF
--- a/chemprop/nn/predictors.py
+++ b/chemprop/nn/predictors.py
@@ -296,4 +296,4 @@ class SpectralFFN(_FFNPredictorBase):
                     "Expected one of 'exp', 'softplus' or None."
                 )
 
-        self.ffn.ffn.add_module("spectral_activation", spectral_activation)
+        self.ffn.add_module("spectral_activation", spectral_activation)


### PR DESCRIPTION
Following from https://github.com/chemprop/chemprop/issues/615 , this PR fixes the Attribute error that currently throws when trying to create a SpectralFNN class.
