### PR TITLE
limit chempropv1 python version to 3.7, 3.8 only

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python>=3.7
+  - python>=3.7,<3.9
   - flask>=1.1.2
   - gunicorn>=20.0.4
   - hyperopt>=0.2.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ download_url = https://github.com/chemprop/chemprop/v_1.6.1.tar.gz
 long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
-    Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     License :: OSI Approved :: MIT License
@@ -45,7 +44,7 @@ install_requires =
     typed-argument-parser>=1.6.1
     rdkit>=2020.03.1.0
     descriptastorus
-python_requires = >=3.7
+python_requires = >=3.7,<3.9
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ project_urls =
     Documentation = https://chemprop.readthedocs.io/en/latest/
     Source = https://github.com/chemprop/chemprop
     PyPi = https://pypi.org/project/chemprop/
-    Demo = http://chemprop.csail.mit.edu/
 
 [options]
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         "Documentation": "https://chemprop.readthedocs.io/en/latest/",
         "Source": "https://github.com/chemprop/chemprop",
         "PyPi": "https://pypi.org/project/chemprop/",
-        "Demo": "http://chemprop.csail.mit.edu/",
     },
     license="MIT",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,8 @@ setup(
         "descriptastorus>=2.6.1 ; python_version=='3.8'",
     ],
     extras_require={"test": ["pytest>=6.2.2", "parameterized>=0.8.1"]},
-    python_requires=">=3.7",
+    python_requires=">=3.7,<3.9",
     classifiers=[
-        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
I have tested that both the conda environment can be built and the package can be installed using `conda create -n test_cprop -f environment.yml --dry-run` and `pip install . --dry-run` (from the chemprop dir).

This PR would close #565 if merged (see issue for more detail).

For clarity, I have removed the "Python 3" label from the setup scripts, emphasizing we don't support arbitrary versions of Python 3.
