### PR TITLE
V2: save command config and smiles splits

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -478,8 +478,7 @@ def process_train_args(args: Namespace) -> Namespace:
 def validate_train_args(args):
     pass
 
-
-def main(args):
+def save_config(args: Namespace):
     command_config_path = args.output_dir / "config.json"
     with open(command_config_path, "w") as f:
         config = deepcopy(vars(args))
@@ -487,6 +486,10 @@ def main(args):
             if isinstance(config[key], Path):
                 config[key] = str(config[key])
         json.dump(config, f, indent=4)
+
+
+def main(args):
+    save_config(args)
 
     bond_messages = not args.atom_messages
     bounded = args.loss_function is not None and "bounded" in args.loss_function

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -489,19 +489,17 @@ def save_config(args: Namespace):
 
 def save_smiles_splits(args: Namespace, train_dset, val_dset, test_dset):
     train_smis = train_dset.smiles
+    df_train = pd.DataFrame(train_smis, columns=args.smiles_columns)
+    df_train.to_csv(args.output_dir / "train_smiles.csv", index=False)
+
     val_smis = val_dset.smiles
+    df_val = pd.DataFrame(val_smis, columns=args.smiles_columns)
+    df_val.to_csv(args.output_dir / "val_smiles.csv", index=False)
+
     if test_dset is not None:
         test_smis = test_dset.smiles
-    else:
-        test_smis = []
-    
-    df_train = pd.DataFrame(train_smis, columns=args.smiles_columns)
-    df_val = pd.DataFrame(val_smis, columns=args.smiles_columns)
-    df_test = pd.DataFrame(test_smis, columns=args.smiles_columns)
-
-    df_train.to_csv(args.output_dir / "train_smiles.csv", index=False)
-    df_val.to_csv(args.output_dir / "val_smiles.csv", index=False)
-    df_test.to_csv(args.output_dir / "test_smiles.csv", index=False)
+        df_test = pd.DataFrame(test_smis, columns=args.smiles_columns)
+        df_test.to_csv(args.output_dir / "test_smiles.csv", index=False)
 
 def main(args):
     save_config(args)

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -2,6 +2,8 @@ from argparse import ArgumentError, ArgumentParser, Namespace
 import logging
 from pathlib import Path
 import sys
+import json
+from copy import deepcopy
 
 from lightning import pytorch as pl
 from lightning.pytorch.loggers import TensorBoardLogger
@@ -476,6 +478,14 @@ def validate_train_args(args):
 
 
 def main(args):
+    command_config_path = args.output_dir / "config.json"
+    with open(command_config_path, "w") as f:
+        config = deepcopy(vars(args))
+        for key in config:
+            if isinstance(config[key], Path):
+                config[key] = str(config[key])
+        json.dump(config, f, indent=4)
+
     bond_messages = not args.atom_messages
     bounded = args.loss_function is not None and "bounded" in args.loss_function
 

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -34,7 +34,7 @@ def test_predict_quick(monkeypatch, data_path, model_path):
         main()
 
 def test_train_output_structure(monkeypatch, data_path, tmp_path):
-    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", str(tmp_path), "--save-smiles-splits"]
+    args = ["chemprop", "train", "-i", data_path, "--smiles-columns", "smiles", "solvent", "--epochs", "1", "--num-workers", "0", "--save-dir", str(tmp_path), "--save-smiles-splits"]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -32,3 +32,15 @@ def test_predict_quick(monkeypatch, data_path, model_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+def test_train_output_structure(monkeypatch, data_path, tmp_path):
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", str(tmp_path), "--save-smiles-splits"]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+    assert (tmp_path / "model.pt").exists()
+    assert (tmp_path / "chkpts" / "last.ckpt").exists()
+    assert (tmp_path / "tb_logs" / "version_0").exists()
+    assert (tmp_path / "smiles_train.csv").exists()

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -43,4 +43,4 @@ def test_train_output_structure(monkeypatch, data_path, tmp_path):
     assert (tmp_path / "model.pt").exists()
     assert (tmp_path / "chkpts" / "last.ckpt").exists()
     assert (tmp_path / "tb_logs" / "version_0").exists()
-    assert (tmp_path / "smiles_train.csv").exists()
+    assert (tmp_path / "train_smiles.csv").exists()

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -36,7 +36,7 @@ def test_predict_quick(monkeypatch, data_path, model_path):
 
 
 def test_train_output_structure(monkeypatch, data_path, tmp_path):
-    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", str(tmp_path)]
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--save-dir", str(tmp_path), "--save-smiles-splits"]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
@@ -45,6 +45,7 @@ def test_train_output_structure(monkeypatch, data_path, tmp_path):
     assert (tmp_path / "model.pt").exists()
     assert (tmp_path / "chkpts" / "last.ckpt").exists()
     assert (tmp_path / "tb_logs" / "version_0").exists()
+    assert (tmp_path / "smiles_train.csv").exists()
 
 
 def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -45,7 +45,7 @@ def test_train_output_structure(monkeypatch, data_path, tmp_path):
     assert (tmp_path / "model.pt").exists()
     assert (tmp_path / "chkpts" / "last.ckpt").exists()
     assert (tmp_path / "tb_logs" / "version_0").exists()
-    assert (tmp_path / "smiles_train.csv").exists()
+    assert (tmp_path / "train_smiles.csv").exists()
 
 
 def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):


### PR DESCRIPTION
## Description
This arises during implementing the CLI tests in https://github.com/chemprop/chemprop/pull/602.

- I save the Namespace object as a dictionary to a .json file at path `args.output_dir / "config.json"`
- I save the smiles splits for train, val, and test at paths `args.output_dir / "train_smiles.csv"`, `args.output_dir / "val_smiles.csv"`, and `args.output_dir / "test_smiles.csv"`.
