### PR TITLE
Add a `CITATIONS.bib`

### DIFF
--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -1,0 +1,37 @@
+# this was downloaded from ACS: https://pubs.acs.org/doi/10.1021/acs.jcim.9b00237
+@article{chemprop_theory,
+    author = {Yang, Kevin and Swanson, Kyle and Jin, Wengong and Coley, Connor and Eiden, Philipp and Gao, Hua and Guzman-Perez, Angel and Hopper, Timothy and Kelley, Brian and Mathea, Miriam and Palmer, Andrew and Settels, Volker and Jaakkola, Tommi and Jensen, Klavs and Barzilay, Regina},
+    title = {Analyzing Learned Molecular Representations for Property Prediction},
+    journal = {Journal of Chemical Information and Modeling},
+    volume = {59},
+    number = {8},
+    pages = {3370-3388},
+    year = {2019},
+    doi = {10.1021/acs.jcim.9b00237},
+        note ={PMID: 31361484},
+    URL = { 
+            https://doi.org/10.1021/acs.jcim.9b00237
+    },
+    eprint = { 
+            https://doi.org/10.1021/acs.jcim.9b00237
+    }
+}
+
+# this was downloaded from ACS: https://pubs.acs.org/doi/10.1021/acs.jcim.3c01250
+@article{chemprop_software,
+    author = {Heid, Esther and Greenman, Kevin P. and Chung, Yunsie and Li, Shih-Cheng and Graff, David E. and Vermeire, Florence H. and Wu, Haoyang and Green, William H. and McGill, Charles J.},
+    title = {Chemprop: A Machine Learning Package for Chemical Property Prediction},
+    journal = {Journal of Chemical Information and Modeling},
+    volume = {64},
+    number = {1},
+    pages = {9-17},
+    year = {2024},
+    doi = {10.1021/acs.jcim.3c01250},
+        note ={PMID: 38147829},
+    URL = { 
+            https://doi.org/10.1021/acs.jcim.3c01250
+    },
+    eprint = {     
+            https://doi.org/10.1021/acs.jcim.3c01250
+    }
+}


### PR DESCRIPTION
## Description
GitHub has a nice UI button to automatically cite a repo using a preferred citation, this just adds the necessary file to make it pop up.

Note that the original issue requested adding a `CITATION.cff` file, but this PR adds a `CITATIONS.bib` file instead. This is because we want to include multiple citations, and the former format does not support that use case (but the latter does).

## Questions
I have only included the two 'main' chemprop papers in the citations file, following some discussion with @kevingreenman. We considered adding others, but because these are the only two that are _required for all use of chemprop_, we decided against adding other feature-specific citations (which could be seen as citation farming).

## Relevant issues
Closes #394. 

## Additional Note
When v2 is eventually merged (or just changed to the default branch), this file will to be included (or ported).
