### PR TITLE
Limit Maximum Allowed `flask` Version in v1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   - python>=3.7,<3.9
-  - flask>=1.1.2
+  - flask>=1.1.2,<=2.1.3
   - gunicorn>=20.0.4
   - hyperopt>=0.2.3
   - matplotlib>=3.1.3

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   - python>=3.7,<3.9
   - flask>=1.1.2,<=2.1.3
+  - Werkzeug<3
   - gunicorn>=20.0.4
   - hyperopt>=0.2.3
   - matplotlib>=3.1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ project_urls =
 packages = find:
 install_requires =
     flask>=1.1.2,<=2.1.3
+    Werkzeug<3
     hyperopt>=0.2.3
     matplotlib>=3.1.3
     numpy>=1.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    flask>=1.1.2
+    flask>=1.1.2,<=2.1.3
     hyperopt>=0.2.3
     matplotlib>=3.1.3
     numpy>=1.18.1

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     },
     install_requires=[
         "flask>=1.1.2,<=2.1.3",
+        "Werkzeug<3",
         "hyperopt>=0.2.3",
         "matplotlib>=3.1.3",
         "numpy>=1.18.1",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         ]
     },
     install_requires=[
-        "flask>=1.1.2",
+        "flask>=1.1.2,<=2.1.3",
         "hyperopt>=0.2.3",
         "matplotlib>=3.1.3",
         "numpy>=1.18.1",


### PR DESCRIPTION
## Description
#437 first reported that with versions of `flask` greater than 2.1.3, the Chemprop website running locally would break. PR #438 fixed this, but introduced backwards incompatible changes with previous versions of flask.

In the spirit of closing all of our v1 issues before v2, this PR simply caps the maximum allowed version of `flask` to one which supports the syntax used in Chemprop, rather than attempting to fix the syntax as done in #438. This isn't a better solution, but is less work for the (busy) maintainers.

Closes #437. Supersedes #438.
