### PR TITLE
move num_unc_tasks definition to ensure always defined

### DIFF
--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -229,6 +229,16 @@ def predict_and_save(
     else:
         evaluations = None
 
+    if args.dataset_type == "multiclass":
+        num_tasks = num_tasks * args.multiclass_num_classes
+
+    if args.uncertainty_method == "spectra_roundrobin":
+        num_unc_tasks = 1
+    elif args.uncertainty_method == "dirichlet" and args.dataset_type == "multiclass":
+        num_unc_tasks = num_tasks // args.multiclass_num_classes # dirichlet only returns an uncertainty for each task rather than each class
+    else:
+        num_unc_tasks = num_tasks
+
     # Save results
     if save_results:
         print(f"Saving predictions to {args.preds_path}")
@@ -245,14 +255,6 @@ def predict_and_save(
                 for name in task_names
                 for i in range(args.multiclass_num_classes)
             ]
-            num_tasks = num_tasks * args.multiclass_num_classes
-
-        if args.uncertainty_method == "spectra_roundrobin":
-            num_unc_tasks = 1
-        elif args.uncertainty_method == "dirichlet" and args.dataset_type == "multiclass":
-            num_unc_tasks = num_tasks // args.multiclass_num_classes # dirichlet only returns an uncertainty for each task rather than each class
-        else:
-            num_unc_tasks = num_tasks
 
         # Copy predictions over to full_data
         for full_index, datapoint in enumerate(full_data):


### PR DESCRIPTION
## Description
As described in #603, the `num_unc_tasks` is sometimes referenced before assignment `if not save_results` and `if return_invalid_smiles`. Moving it outside of the `if save_results:` block should resolve this problem.

## Relevant issues
Fixes #603 
