### PR TITLE
V2: add grad clip

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -397,7 +397,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         "--epochs", type=int, default=50, help="the number of epochs to train over"
     )
     train_args.add_argument(
-        "--grad-clip", type=float, help="Maximum magnitude of gradient during training."
+        "--grad-clip", type=float, help="Passed directly to the lightning trainer which controls grad clipping. See the :code:`Trainer()` docstring for details."
     )
     train_args.add_argument(
         "--class-balance",
@@ -773,6 +773,7 @@ def main(args):
             devices=args.n_gpu if torch.cuda.is_available() else 1,
             max_epochs=args.epochs,
             callbacks=[checkpointing, early_stopping],
+            gradient_clip_val=args.grad_clip,
         )
         trainer.fit(model, train_loader, val_loader)
 


### PR DESCRIPTION
## Summary
Very simple PR to implement `--grad-clip`.

## Motivation
V1 had this option. This is a step towards feature parity. 

## Implementation details 
In v1 this is simply [passed](https://github.com/chemprop/chemprop/blob/d58d877fd1d652929b0216e7b0cc11355664fd97/chemprop/train/train.py#L221) to `torch.nn.utils.clip_grad_norm_()` with all model parameters. Lightning [says](https://lightning.ai/docs/pytorch/stable/advanced/training_tricks.html#gradient-clipping) it does the same thing through the `gradient_clip_val` argument to `Trainer`. `None` is the [default](https://lightning.ai/docs/pytorch/stable/_modules/lightning/pytorch/trainer/trainer.html) which disables gradient clipping. `None` is also the value of `args.grad_clip` if the user doesn't specify it. 

# Other notes
I welcome suggestions on the help string for `--grad-clip`. 