### PR TITLE
switch v1 readthedocs build from conda to mamba

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "mambaforge-22.9"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Description
This PR changes the v1 Read the Docs (RTD) yml file to use mamba instead of conda to build the documentation. In preparation for the v2 release (which will have a new set of RTD documentation) I would like to have the v1 RTD working again so that the note I added to our RTD homepage in [this commit](https://github.com/chemprop/chemprop/commit/386d480553e493577b050d7c47f51aba3e0ac6dc) will show up if someone is still using v1.x and tries to look at the old documentation. We regularly get people asking questions in issues/discussions because they haven't looked at the README and assume that our RTD is up-to-date for v1.x (which is not an unreasonable assumption, IMO).

## Example / Current workflow
Our v1 documentation has been failing to build since October 2022, sometimes due to excessive memory consumption (e.g. see [here](https://readthedocs.org/projects/chemprop/builds/18376019/)). 

Our build sometimes also fails with the error `virtualenv: error: the following arguments are required: dest` when running `python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH` (e.g. see [here](https://readthedocs.org/projects/chemprop/builds/23445565/)). This is related to this RTD [issue](https://github.com/readthedocs/readthedocs.org/issues/10907).

## Bugfix / Desired workflow
Based on the RTD documentation [here](https://docs.readthedocs.io/en/stable/guides/conda.html#making-builds-faster-with-mamba) and [here](https://docs.readthedocs.io/en/stable/config-file/v2.html#conda), I believe this is the best way to speed up the build and reduce memory requirements. I think this may solve both errors encountered above. If this doesn't work, some other fixes are described [here](https://docs.readthedocs.io/en/stable/guides/build-using-too-many-resources.html). 

## Questions
The build sometimes also fails for no apparent reason and with no error message after running `git clean -d -f -f`, which appears to execute successfully (e.g. see [here](https://readthedocs.org/projects/chemprop/builds/23327660/)). It's unclear to me whether this PR can fix this issue since it's not clear what the issue is in the first place.
