### PR TITLE
V2: Fixing MVE regression and adding tests

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -781,10 +781,12 @@ def main(args):
         if args.save_smiles_splits:
             save_smiles_splits(args, output_dir, train_dset, val_dset, test_dset)
 
-        if args.task_type == "regression":
+        if "regression" in args.task_type:
             scaler = train_dset.normalize_targets()
             val_dset.normalize_targets(scaler)
             logger.info(f"Train data: mean = {scaler.mean_} | std = {scaler.scale_}")
+        else:
+            scaler = None
 
         train_loader = MolGraphDataLoader(train_dset, args.batch_size, args.num_workers)
         val_loader = MolGraphDataLoader(val_dset, args.batch_size, args.num_workers, shuffle=False)

--- a/chemprop/models/model.py
+++ b/chemprop/models/model.py
@@ -10,7 +10,7 @@ from torch import nn, Tensor, optim
 
 from chemprop.data import TrainingBatch, BatchMolGraph
 from chemprop.nn.metrics import Metric
-from chemprop.nn import MessagePassing, Aggregation, Predictor, LossFunction
+from chemprop.nn import MessagePassing, Aggregation, Predictor, LossFunction, MveFFN
 from chemprop.schedulers import NoamLR
 
 
@@ -172,6 +172,10 @@ class MPNN(pl.LightningModule):
         mask = targets.isfinite()
         targets = targets.nan_to_num(nan=0.0)
         preds = self(bmg, V_d, X_f)
+
+        if isinstance(self.predictor, MveFFN):
+            mean, _ = torch.chunk(preds, self.predictor.n_targets, 1)
+            preds = mean
 
         return [
             metric(preds, targets, mask, None, None, lt_mask, gt_mask)

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -27,6 +27,14 @@ def test_train_quick(monkeypatch, data_path):
         main()
 
 
+def test_train_quick(monkeypatch, data_path):
+    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0", "--task-type", "regression-mve"]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
 def test_predict_quick(monkeypatch, data_path, model_path):
     args = ["chemprop", "predict", "-i", data_path, "--model-path", model_path]
 


### PR DESCRIPTION
## Description
While working on saving the predictions for multitask MVE model, I have found errors in single-task MVE model. This PR aims to iron out the bugs and adds tests.

## Example / Current workflow
Current workflow passes the preds to metric for evaluation directly. For MVE regression, the preds contain both the mean and the var, so this fails with dimension mismatch error.
```
    def _evaluate_batch(self, batch) -> list[Tensor]:
        bmg, V_d, X_f, targets, _, lt_mask, gt_mask = batch

        mask = targets.isfinite()
        targets = targets.nan_to_num(nan=0.0)
        preds = self(bmg, V_d, X_f)

        return [
            metric(preds, targets, mask, None, None, lt_mask, gt_mask)
            for metric in self.metrics[:-1]
        ]
```

## Bugfix / Desired workflow
I added an if block to check if the predictor is an `MveFFN` and takes the mean portion of the preds. Happy to take suggestions on a more elegant to to solve this.
```
    def _evaluate_batch(self, batch) -> list[Tensor]:
        bmg, V_d, X_f, targets, _, lt_mask, gt_mask = batch

        mask = targets.isfinite()
        targets = targets.nan_to_num(nan=0.0)
        preds = self(bmg, V_d, X_f)

        if isinstance(self.predictor, MveFFN):
            mean, _ = torch.chunk(preds, self.predictor.n_targets, 1)
            preds = mean

        return [
            metric(preds, targets, mask, None, None, lt_mask, gt_mask)
            for metric in self.metrics[:-1]
        ]
```

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
