### PR TITLE
V2: consolidate `--checkpoint` CLI

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -67,16 +67,6 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     )
     # TODO: as we plug the three checkpoint options, see if we can reduce from three option to two or to just one.
     #        similar to how --features-path is/will be implemented
-    parser.add_argument(
-        "--checkpoint-dir",
-        help="Directory from which to load model checkpoints (walks directory and ensembles all models that are found).",
-    )
-    parser.add_argument("--checkpoint-path", help="Path to model checkpoint (:code:`.pt` file).")
-    parser.add_argument(
-        "--checkpoint-paths",
-        type=list[str],
-        help="List of paths to model checkpoints (:code:`.pt` files).",
-    )
     # TODO: Is this a prediction only argument?
     parser.add_argument(
         "--checkpoint",


### PR DESCRIPTION
## Description
Consolidating the `--checkpoint-dir`, `--checkpoint-path`, and `--checpoint-paths` into `--checkpoint`. Currently, I just remove `--checkpoint-dir` and `--checkpoint-path`.

## Questions
- `--checkpoint` is not currently used anywhere in `train.py`. Is `--checkpoint` to be used for resuming training? If so, I can work on this in this PR or open another PR for it.
- I think we should do the same thing for `--model-path` in `predict.py`, where if a directory is given, we look for all the model files in the directory and make predictions using all the ensemble models. I have made changes to find all model files and checkpoint files under `--model-path` if it's a directory. Since we aim to support uncertainty in v2.1, I didn't write a function to compute the mean and variance from the predictions, but rather just let it save the predictions for all models individually. Should I delay making this part of changes till v2.1 all along?
