### PR TITLE
Fix v1 docs theme

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 The Chemprop Development Team (Regina Barzilay, Jackson Burns, 
+Copyright (c) 2024 The Chemprop Development Team (Regina Barzilay, Jackson Burns, 
 Yunsie Chung, David Graff, William Green, Kevin Greenman, Yanfei Guan, 
 Esther Heid, Lior Hirschfeld, Tommi Jaakkola, Wengong Jin, Shih-Cheng Li, 
 Mengjie Liu, Charles McGill, Kyle Swanson, Allison Tam, Florence Vermeire, 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/chemprop)](https://badge.fury.io/py/chemprop)
 [![PyPI version](https://badge.fury.io/py/chemprop.svg)](https://badge.fury.io/py/chemprop)
 [![Build Status](https://github.com/chemprop/chemprop/workflows/tests/badge.svg)](https://github.com/chemprop/chemprop)
+[![Documentation Status](https://readthedocs.org/projects/chemprop/badge/?version=latest)](https://chemprop.readthedocs.io/en/latest/?badge=latest)
 
 Chemprop is a repository containing message passing neural networks for molecular property prediction.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Chemprop is a repository containing message passing neural networks for molecular property prediction.
 
-**License:** Chemprop is free to use under the [MIT License](LICENSE.txt). The Chemprop logo is free to use under [CCO 1.0](logo/LICENSE.txt).
+**License:** Chemprop is free to use under the [MIT License](LICENSE.txt). The Chemprop logo is free to use under [CC0 1.0](logo/LICENSE.txt).
 
 **References**: Please cite the appropriate papers if Chemprop is helpful to your research.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/chemprop)](https://badge.fury.io/py/chemprop)
 [![PyPI version](https://badge.fury.io/py/chemprop.svg)](https://badge.fury.io/py/chemprop)
-[![Build Status](https://github.com/chemprop/chemprop/workflows/tests/badge.svg)](https://github.com/chemprop/chemprop)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/chemprop/badges/version.svg)](https://anaconda.org/conda-forge/chemprop)
+[![Build Status](https://github.com/chemprop/chemprop/workflows/tests/badge.svg)](https://github.com/chemprop/chemprop/actions/workflows/tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/chemprop/badge/?version=latest)](https://chemprop.readthedocs.io/en/latest/?badge=latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Downloads](https://static.pepy.tech/badge/chemprop)](https://pepy.tech/project/chemprop)
+[![Downloads](https://static.pepy.tech/badge/chemprop/month)](https://pepy.tech/project/chemprop)
+[![Downloads](https://static.pepy.tech/badge/chemprop/week)](https://pepy.tech/project/chemprop)
 
 Chemprop is a repository containing message passing neural networks for molecular property prediction.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,8 +18,8 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 
 project = 'chemprop'
-copyright = '2020, Kyle Swanson, Kevin Yang, Wengong Jin, Lior Hirschfeld, Allison Tam'
-author = 'Kyle Swanson, Kevin Yang, Wengong Jin, Lior Hirschfeld, Allison Tam'
+copyright = '2024, The Chemprop Development Team'
+author = 'The Chemprop Development Team'
 
 # The full version, including alpha/beta/rc tags
 release = '1.6.1'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 Chemprop
 ========
 
-Note: this site is several versions behind. An up-to-date version of our Read the Docs is forthcoming with the release of Chemprop v2.0 in early 2024. The `README <https://github.com/chemprop/chemprop/blob/master/README.md>`_ and `args.py <https://github.com/chemprop/chemprop/blob/master/chemprop/args.py>`_ files are currently the best sources for documentation on more recently-added features.
+.. warning:: This documentation site is several versions behind the codebase. An up-to-date version of our Read the Docs is forthcoming with the release of Chemprop v2.0 in early 2024. The `README <https://github.com/chemprop/chemprop/blob/master/README.md>`_ and `args.py <https://github.com/chemprop/chemprop/blob/master/chemprop/args.py>`_ files are currently the best sources for documentation on more recently-added features.
 
 `Chemprop <https://github.com/chemprop/chemprop>`_ is a message passing neural network for molecular property prediction.
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - tensorboardX>=2.0
   - torchvision>=0.5.0
   - tqdm>=4.45.0
+  - sphinx-rtd-theme>=2.0.0
   - pip:
-    - typed-argument-parser>=1.6.1
-    - git+https://github.com/bp-kelley/descriptastorus
+      - typed-argument-parser>=1.6.1
+      - git+https://github.com/bp-kelley/descriptastorus

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     scikit-learn>=0.22.2.post1
     scipy>=1.4.1
     sphinx>=3.1.2
+    sphinx-rtd-theme>=2.0.0
     tensorboardX>=2.0
     torch>=1.4.0
     tqdm>=4.45.0

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "pandas-flavor>=0.2.0",
         "scikit-learn>=0.22.2.post1",
         "sphinx>=3.1.2",
+        "sphinx-rtd-theme>=2.0.0",
         "tensorboardX>=2.0",
         "torch>=1.4.0",
         "tqdm>=4.45.0",


### PR DESCRIPTION
## Description
The v1 docs are successfully building again, but their theme looks very different from what it did before. The theme was previously set to `default`, but it displayed as if the theme was `sphinx_rtd_theme`. This PR makes the `sphinx_rtd_theme` explicit so the docs look like they did before (which I think looks much nicer than the default). 

Some pages (e.g. [here](https://chemprop.readthedocs.io/en/latest/args.html)) are also formatted poorly using the default theme. The new theme fixes that.

Additionally, I made the note I added in #660 into warning using the "admonition" format so it will stand out from the other paragraphs on the page and be more noticeable. 

[Build status](https://readthedocs.org/projects/chemprop/builds/23545535/) - succeeded

[Preview of new version of docs](https://chemprop.readthedocs.io/en/fix-v1-docs-theme/)