### PR TITLE
remove unnecessary argument for reshape function

### DIFF
--- a/chemprop/multitask_utils.py
+++ b/chemprop/multitask_utils.py
@@ -9,7 +9,6 @@ def reshape_values(
     test_data: MoleculeDataset,
     natom_targets: int,
     nbond_targets: int,
-    num_tasks: int,
 ) -> List[List[List[float]]]:
     """
     Reshape the input from shape (num_tasks, number of atomic/bond properties for each task, 1)
@@ -20,11 +19,11 @@ def reshape_values(
     :param test_data: A :class:`~chemprop.data.MoleculeDataset` containing valid datapoints.
     :param natom_targets: The number of atomic targets.
     :param nbond_targets: The number of bond targets.
-    :param num_tasks: Number of tasks.
     :return: List of atomic/bond properties with shape
              (data_size, num_tasks, number of atomic/bond properties for this data in each task).
     """
     n_atoms, n_bonds = test_data.number_of_atoms, test_data.number_of_bonds
+    num_tasks = natom_targets + nbond_targets
     reshaped_values = np.empty([len(test_data), num_tasks], dtype=object)
 
     for i in range(natom_targets):
@@ -45,7 +44,6 @@ def reshape_individual_preds(
     test_data: MoleculeDataset,
     natom_targets: int,
     nbond_targets: int,
-    num_tasks: int,
     num_models: int,
 ) -> List[List[List[List[float]]]]:
     """
@@ -57,12 +55,12 @@ def reshape_individual_preds(
     :param test_data: A :class:`~chemprop.data.MoleculeDataset` containing valid datapoints.
     :param natom_targets: The number of atomic targets.
     :param nbond_targets: The number of bond targets.
-    :param num_tasks: Number of tasks.
     :param num_models: Number of models.
     :return: List of atomic/bond properties with shape
              (data_size, num_tasks, num_models, number of atomic/bond properties for this data in each task).
     """
     n_atoms, n_bonds = test_data.number_of_atoms, test_data.number_of_bonds
+    num_tasks = natom_targets + nbond_targets
     individual_values = np.empty([len(test_data), num_tasks], dtype=object)
 
     for i in range(natom_targets):

--- a/chemprop/multitask_utils.py
+++ b/chemprop/multitask_utils.py
@@ -23,8 +23,8 @@ def reshape_values(
              (data_size, num_tasks, number of atomic/bond properties for this data in each task).
     """
     n_atoms, n_bonds = test_data.number_of_atoms, test_data.number_of_bonds
-    num_tasks = natom_targets + nbond_targets
-    reshaped_values = np.empty([len(test_data), num_tasks], dtype=object)
+    num_atom_bond_tasks = natom_targets + nbond_targets
+    reshaped_values = np.empty([len(test_data), num_atom_bond_tasks], dtype=object)
 
     for i in range(natom_targets):
         atom_targets = values[i].reshape(-1,)
@@ -60,8 +60,8 @@ def reshape_individual_preds(
              (data_size, num_tasks, num_models, number of atomic/bond properties for this data in each task).
     """
     n_atoms, n_bonds = test_data.number_of_atoms, test_data.number_of_bonds
-    num_tasks = natom_targets + nbond_targets
-    individual_values = np.empty([len(test_data), num_tasks], dtype=object)
+    num_atom_bond_tasks = natom_targets + nbond_targets
+    individual_values = np.empty([len(test_data), num_atom_bond_tasks], dtype=object)
 
     for i in range(natom_targets):
         atom_targets = individual_preds[i].T.reshape(num_models, -1)

--- a/chemprop/train/make_predictions.py
+++ b/chemprop/train/make_predictions.py
@@ -177,7 +177,7 @@ def predict_and_save(
     )  # preds and unc are lists of shape(data,tasks)
 
     if calibrator is not None and args.is_atom_bond_targets and args.calibration_method == "isotonic":
-        unc = reshape_values(unc, test_data, len(args.atom_targets), len(args.bond_targets), num_tasks)
+        unc = reshape_values(unc, test_data, len(args.atom_targets), len(args.bond_targets))
 
     if args.individual_ensemble_predictions:
         individual_preds = (

--- a/chemprop/uncertainty/uncertainty_calibrator.py
+++ b/chemprop/uncertainty/uncertainty_calibrator.py
@@ -585,7 +585,6 @@ class MVEWeightingCalibrator(UncertaintyCalibrator):
                 self.calibration_data,
                 natom_targets,
                 nbond_targets,
-                len(weighted_stdev),
             )
             return uncal_preds, weighted_stdev
         else:

--- a/chemprop/uncertainty/uncertainty_predictor.py
+++ b/chemprop/uncertainty/uncertainty_predictor.py
@@ -199,14 +199,12 @@ class NoUncertaintyPredictor(UncertaintyPredictor):
                         )
 
         if model.is_atom_bond_targets:
-            num_tasks = sum_preds.shape[1]
             uncal_preds = sum_preds / self.num_models
             self.uncal_preds = reshape_values(
                 uncal_preds,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             uncal_vars = np.zeros_like(self.uncal_preds)
             uncal_vars[:] = np.nan
@@ -215,7 +213,6 @@ class NoUncertaintyPredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             if self.individual_ensemble_predictions:
                 self.individual_preds = reshape_individual_preds(
@@ -223,7 +220,6 @@ class NoUncertaintyPredictor(UncertaintyPredictor):
                     self.test_data,
                     len(model.atom_targets),
                     len(model.bond_targets),
-                    num_tasks,
                     self.num_models,
                 )
         else:
@@ -420,14 +416,12 @@ class MVEPredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.uncal_vars = reshape_values(
                 uncal_vars,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.individual_vars = individual_vars
             if self.individual_ensemble_predictions:
@@ -436,7 +430,6 @@ class MVEPredictor(UncertaintyPredictor):
                     self.test_data,
                     len(model.atom_targets),
                     len(model.bond_targets),
-                    num_tasks,
                     self.num_models,
                 )
         else:
@@ -566,14 +559,12 @@ class EvidentialTotalPredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.uncal_vars = reshape_values(
                 uncal_vars,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.individual_vars = individual_vars
             if self.individual_ensemble_predictions:
@@ -582,7 +573,6 @@ class EvidentialTotalPredictor(UncertaintyPredictor):
                     self.test_data,
                     len(model.atom_targets),
                     len(model.bond_targets),
-                    num_tasks,
                     self.num_models,
                 )
         else:
@@ -712,14 +702,12 @@ class EvidentialAleatoricPredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.uncal_vars = reshape_values(
                 uncal_vars,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.individual_vars = individual_vars
             if self.individual_ensemble_predictions:
@@ -728,7 +716,6 @@ class EvidentialAleatoricPredictor(UncertaintyPredictor):
                     self.test_data,
                     len(model.atom_targets),
                     len(model.bond_targets),
-                    num_tasks,
                     self.num_models,
                 )
         else:
@@ -858,14 +845,12 @@ class EvidentialEpistemicPredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.uncal_vars = reshape_values(
                 uncal_vars,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.individual_vars = individual_vars
             if self.individual_ensemble_predictions:
@@ -874,7 +859,6 @@ class EvidentialEpistemicPredictor(UncertaintyPredictor):
                     self.test_data,
                     len(model.atom_targets),
                     len(model.bond_targets),
-                    num_tasks,
                     self.num_models,
                 )
         else:
@@ -1005,14 +989,12 @@ class EnsemblePredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.uncal_vars = reshape_values(
                 uncal_vars,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
 
             if self.individual_ensemble_predictions:
@@ -1021,7 +1003,6 @@ class EnsemblePredictor(UncertaintyPredictor):
                     self.test_data,
                     len(model.atom_targets),
                     len(model.bond_targets),
-                    num_tasks,
                     self.num_models,
                 )
         else:
@@ -1117,14 +1098,12 @@ class DropoutPredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.uncal_vars = reshape_values(
                 uncal_vars,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
         else:
             uncal_preds = sum_preds / self.dropout_sampling_size
@@ -1237,7 +1216,6 @@ class ClassPredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.uncal_confidence = self.uncal_preds
             if self.individual_ensemble_predictions:
@@ -1246,7 +1224,6 @@ class ClassPredictor(UncertaintyPredictor):
                     self.test_data,
                     len(model.atom_targets),
                     len(model.bond_targets),
-                    num_tasks,
                     self.num_models,
                 )
         else:
@@ -1368,14 +1345,12 @@ class DirichletPredictor(UncertaintyPredictor):
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             self.uncal_uncertainty = reshape_values(
                 uncal_u,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
-                num_tasks,
             )
             if self.individual_ensemble_predictions:
                 self.individual_preds = reshape_individual_preds(
@@ -1383,7 +1358,6 @@ class DirichletPredictor(UncertaintyPredictor):
                     self.test_data,
                     len(model.atom_targets),
                     len(model.bond_targets),
-                    num_tasks,
                     self.num_models,
                 )
         else:


### PR DESCRIPTION
## Description
The `num_tasks` argument of the reshape functions can actually be calculated as the summation of `natom_targets` and `nbond_targets`.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
