### PR TITLE
V2: Modify DataLoader to drop last batch if its size is 1, to avoid batch norm issues

### DIFF
--- a/chemprop/data/dataloader.py
+++ b/chemprop/data/dataloader.py
@@ -55,7 +55,7 @@ class MolGraphDataLoader(DataLoader):
             warnings.warn(
                 f"Dropping last batch of size 1 to avoid issues with batch normalization \
 (dataset size = {len(dataset)}, batch_size = {batch_size})"
-                )
+            )
             drop_last = True
         else:
             drop_last = False
@@ -67,5 +67,5 @@ class MolGraphDataLoader(DataLoader):
             sampler,
             num_workers=num_workers,
             collate_fn=collate_fn,
-            drop_last=drop_last
+            drop_last=drop_last,
         )

--- a/chemprop/data/dataloader.py
+++ b/chemprop/data/dataloader.py
@@ -1,3 +1,5 @@
+import warnings
+
 from torch.utils.data import DataLoader
 
 from chemprop.data.collate import collate_batch, collate_multicomponent
@@ -49,6 +51,15 @@ class MolGraphDataLoader(DataLoader):
         else:
             collate_fn = collate_batch
 
+        if len(dataset) % batch_size == 1:
+            warnings.warn(
+                f"Dropping last batch of size 1 to avoid issues with batch normalization \
+(dataset size = {len(dataset)}, batch_size = {batch_size})"
+                )
+            drop_last = True
+        else:
+            drop_last = False
+
         super().__init__(
             dataset,
             batch_size,
@@ -56,4 +67,5 @@ class MolGraphDataLoader(DataLoader):
             sampler,
             num_workers=num_workers,
             collate_fn=collate_fn,
+            drop_last=drop_last
         )


### PR DESCRIPTION
## Description
Calling `nn.BatchNorm1d` on a batch of size 1 will lead to a ValueError. This can occur if the remainder of the dataset and the batch size is 1 (for example, dataset has 101 samples and the batch size is 10). 

## Example / Current workflow
From a clean install of Chemprop, install the FreeSolv dataset and run the command:
`chemprop train --data-path data/freesolv.csv --task-type regression --output-dir freesolv`
which will lead to a ValueError. Traceback shows that this is due to calling `batch_norm` for a batch of size 1.

## Bugfix / Desired workflow
This PR implements one fix suggested in https://github.com/pytorch/pytorch/issues/4534, which is to drop the last batch if its size is 1. This also includes a warning so that the user can see that this happened.

## Questions
do we expect any problems with using `len(dataset)` for `MulticomponentDataset` and `ReactionDataset`?

this is an overly-aggressive option; what if `batch_norm=False`? is there a smooth way to only activate this if batch norm is desired?

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
