### PR TITLE
V2: Debug V_d in collate and dataloader test

### DIFF
--- a/chemprop/data/collate.py
+++ b/chemprop/data/collate.py
@@ -85,7 +85,7 @@ def collate_batch(batch: Iterable[Datum]) -> TrainingBatch:
 
     return TrainingBatch(
         BatchMolGraph(mgs),
-        None if V_ds[0] is None else torch.from_numpy(np.stack(V_ds, axis=0)).float(),
+        None if V_ds[0] is None else torch.from_numpy(np.concatenate(V_ds)).float(),
         None if x_fs[0] is None else torch.from_numpy(np.array(x_fs)).float(),
         None if ys[0] is None else torch.from_numpy(np.array(ys)).float(),
         torch.tensor(weights).unsqueeze(1),

--- a/tests/unit/data/test_dataloader.py
+++ b/tests/unit/data/test_dataloader.py
@@ -17,7 +17,7 @@ def datum_1():
     )
     return Datum(
         mol_graph1,
-        V_d=np.array([1.0, 2.0]),
+        V_d=np.array([[1.0], [2.0], [4.0]]),
         x_f=[3, 4],
         y=[6, 7],
         weight=[8.0],
@@ -36,7 +36,7 @@ def datum_2():
     )
     return Datum(
         mol_graph2,
-        V_d=np.array([5.0, 7.0]),
+        V_d=np.array([[5.0], [7.0]]),
         x_f=[8, 9],
         y=[6, 4],
         weight=[1.0],
@@ -53,7 +53,8 @@ def test_collate_batch_single_graph(datum_1):
 
     assert isinstance(result, tuple)
     assert isinstance(mgs, BatchMolGraph)
-    torch.testing.assert_close(V_ds, torch.tensor([[1.0, 2.0]], dtype=torch.float32))
+    assert mgs.V.shape[0] == V_ds.shape[0] # V is number of atoms x number of atom features, V_ds is number of atoms x number of atom descriptors
+    torch.testing.assert_close(V_ds, torch.tensor([[1.0], [2.0], [4.0]], dtype=torch.float32))
     torch.testing.assert_close(x_fs, torch.tensor([[3.0, 4.0]], dtype=torch.float32))
     torch.testing.assert_close(ys, torch.tensor([[6.0, 7.0]], dtype=torch.float32))
     torch.testing.assert_close(weights, torch.tensor([[[8.0]]], dtype=torch.float32))
@@ -68,7 +69,8 @@ def test_collate_batch_multiple_graphs(datum_1, datum_2):
     mgs, V_ds, x_fs, ys, weights, lt_masks, gt_masks = result
 
     assert isinstance(mgs, BatchMolGraph)
-    torch.testing.assert_close(V_ds, torch.tensor([[1.0, 2.0], [5.0, 7.0]], dtype=torch.float32))
+    assert mgs.V.shape[0] == V_ds.shape[0] # V is number of atoms x number of atom features, V_ds is number of atoms x number of atom descriptors
+    torch.testing.assert_close(V_ds, torch.tensor([[1.0], [2.0], [4.0], [5.0], [7.0]], dtype=torch.float32))
     torch.testing.assert_close(x_fs, torch.tensor([[3.0, 4.0], [8.0, 9.0]], dtype=torch.float32))
     torch.testing.assert_close(ys, torch.tensor([[6.0, 7.0], [6.0, 4.0]], dtype=torch.float32))
     torch.testing.assert_close(weights, torch.tensor([[[8.0]], [[1.0]]], dtype=torch.float32))


### PR DESCRIPTION
## Description
This problem was found during https://github.com/chemprop/chemprop/pull/635, where I encountered dimension issue when trying to add tests for atom descriptors. I found that the `collate` for `V_d` is incorrect.

## Example / Current workflow
Currently, `collate` stack `V_d`. However, the dimension of `V_d` should be number of atoms by number of atom descriptors. Due to the different number of atoms, we're not able to stack them. Instead, they should be concatenated. A sanity check on this is that the `V` from batch mol graph should contain the same number of atoms as the `V_d`.

The V and V_d in each datum should have the same number of atoms, but the current test case in the dataloader test doesn't.

## Bugfix / Desired workflow
I change `stack` to concatenate and update the test to check that number of atoms in `V` and `V_ds` match. I also update the test results in the dataloader.

## Checklist
- [ ] linted with flake8?
- [x] (if appropriate) unit tests added?
