### PR TITLE
V2: use seed and pytorch_seed appropriately

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -450,7 +450,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     #     help="Indices of files to use as train/val/test. Overrides :code:`--num_folds` and :code:`--seed`.",
     # )
     split_args.add_argument(
-        "--split-seed",
+        "--data-seed",
         type=int,
         default=0,
         help="Random seed to use when splitting data into train/val/test sets. When :code`num_folds > 1`, the first fold uses this seed and all subsequent folds add 1 to the seed.",
@@ -532,7 +532,7 @@ def build_splits(args, format_kwargs, featurization_kwargs):
     )
     multicomponent = len(all_data) > 1
 
-    split_kwargs = dict(sizes=args.split_sizes, seed=args.split_seed, num_folds=args.num_folds)
+    split_kwargs = dict(sizes=args.split_sizes, seed=args.data_seed, num_folds=args.num_folds)
     split_kwargs["key_index"] = args.split_key_molecule if multicomponent else 0
 
     if args.separate_val_path is None and args.separate_test_path is None:
@@ -795,7 +795,7 @@ def main(args):
         else:
             scaler = None
 
-        train_loader = MolGraphDataLoader(train_dset, args.batch_size, args.num_workers)
+        train_loader = MolGraphDataLoader(train_dset, args.batch_size, args.num_workers, seed=args.data_seed)
         val_loader = MolGraphDataLoader(val_dset, args.batch_size, args.num_workers, shuffle=False)
         if test_dset is not None:
             test_loader = MolGraphDataLoader(

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -461,7 +461,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         help="Save smiles for each train/val/test splits for prediction convenience later.",
     )
 
-    parser.add_argument(  # TODO: do we need this?
+    parser.add_argument(
         "--pytorch-seed",
         type=int,
         default=0,

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -458,6 +458,11 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     #     help="Indices of files to use as train/val/test. Overrides :code:`--num_folds` and :code:`--seed`.",
     # )
     split_args.add_argument(
+        "--save-smiles-splits",
+        action="store_true",
+        help="Save smiles for each train/val/test splits for prediction convenience later.",
+    )
+    split_args.add_argument(
         "--data-seed",
         type=int,
         default=0,
@@ -468,11 +473,6 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         type=int,
         default=0,
         help="Seed for PyTorch randomness (e.g., random initial weights).",
-    )
-    split_args.add_argument(
-        "--save-smiles-splits",
-        action="store_true",
-        help="Save smiles for each train/val/test splits for prediction convenience later.",
     )
     parser.add_argument(
         "--patience",

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -450,7 +450,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     #     help="Indices of files to use as train/val/test. Overrides :code:`--num_folds` and :code:`--seed`.",
     # )
     split_args.add_argument(
-        "--seed",
+        "--split-seed",
         type=int,
         default=0,
         help="Random seed to use when splitting data into train/val/test sets. When :code`num_folds > 1`, the first fold uses this seed and all subsequent folds add 1 to the seed.",
@@ -532,7 +532,7 @@ def build_splits(args, format_kwargs, featurization_kwargs):
     )
     multicomponent = len(all_data) > 1
 
-    split_kwargs = dict(sizes=args.split_sizes, seed=args.seed, num_folds=args.num_folds)
+    split_kwargs = dict(sizes=args.split_sizes, seed=args.split_seed, num_folds=args.num_folds)
     split_kwargs["key_index"] = args.split_key_molecule if multicomponent else 0
 
     if args.separate_val_path is None and args.separate_test_path is None:

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -705,6 +705,8 @@ def train_model(args, train_loader, val_loader, test_loader, output_dir, scaler)
         model_output_dir = output_dir / f"model_{model_idx}"
         model_output_dir.mkdir(exist_ok=True, parents=True)
 
+        torch.manual_seed(args.pytorch_seed + model_idx)
+
         model = build_model(args, train_loader.dataset)
         logger.info(model)
 


### PR DESCRIPTION
## Description
Fixes the usage of the `seed` and `pytorch-seed` CLI arguments, the latter of which was not used at all.

I've renamed `seed` to `data-seed` to better reflect its purpose. This argument was already used for data splitting, but I've now added it to the train dataloader as well. `shuffle` will still be `True` by default for the train dataloader (and `False` for the val and test dataloaders), but users who run the same training job multiple times without specifying the seed will now get reproducible results. This is how we did it in v1.

## Questions
* Should `seed` be `None` by default in `MolGraphDataLoader`? That's what we have now. If we're going to have the seed for the train dataloader be 0 by default when using the CLI (matching v1), should we also update this default to 0?

