### PR TITLE
add note on feature releases and instructions for ssl+ddp

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Then proceed to either option below to complete the installation. If installing 
 2. `conda activate chemprop`
 3. `pip install chemprop`
 
+> [!NOTE]  
+> Some features that were not made available in the main releases of Chemprop are instead available through 'feature releases' via PyPI: 
+> - SSL Pre-train with DDP - available in version `1.6.1.dev0`, install with `pip install chemprop==1.6.1.dev0`.
+
 ### Option 2: Installing from source
 
 1. `git clone https://github.com/chemprop/chemprop.git`


### PR DESCRIPTION
## Description
SSL+DDP was not merged into `master` Chemprop, but we need to let people know how to get it.

## Solution
![image](https://github.com/chemprop/chemprop/assets/33505528/f137f422-7a13-40ad-882c-758ab22691e7)

