### PR TITLE
Pass num_workers to MoleculeDataLoader during interpretation

### DIFF
--- a/chemprop/interpret.py
+++ b/chemprop/interpret.py
@@ -56,7 +56,7 @@ class ChempropModel:
         if self.train_args.bond_descriptor_scaling and self.args.bond_descriptors_size > 0:
             test_data.normalize_features(self.bond_descriptor_scaler, scale_bond_descriptors=True)
 
-        test_data_loader = MoleculeDataLoader(dataset=test_data, batch_size=batch_size)
+        test_data_loader = MoleculeDataLoader(dataset=test_data, batch_size=batch_size, num_workers=self.args.num_workers)
 
         sum_preds = []
         for model in self.checkpoints:


### PR DESCRIPTION
Fixes #689 

As mentioned there, this argument is not passed to `MoleculeDataLoader` during interpretation [here](https://github.com/chemprop/chemprop/blob/1785627d714c17f910af921fe518db76f4892026/chemprop/interpret.py#L59), whereas it is passed to `MoleculeDataLoader` during [training](https://github.com/chemprop/chemprop/blob/1785627d714c17f910af921fe518db76f4892026/chemprop/train/run_training.py#L238), [prediction](https://github.com/chemprop/chemprop/blob/1785627d714c17f910af921fe518db76f4892026/chemprop/train/make_predictions.py#L92), and [fingerprinting](https://github.com/chemprop/chemprop/blob/1785627d714c17f910af921fe518db76f4892026/chemprop/train/molecule_fingerprint.py#L87).