### PR TITLE
V2: Use output scaler for output scaling

### DIFF
--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -9,7 +9,7 @@ import torch
 
 from chemprop import data
 from chemprop.nn.loss import LossFunctionRegistry
-from chemprop.nn.predictors import MulticlassClassificationFFN
+from chemprop.nn.predictors import MulticlassClassificationFFN, RegressionFFN
 from chemprop.models import load_model
 
 from chemprop.cli.utils import Subcommand, build_data_from_files, make_dataset
@@ -260,6 +260,8 @@ def make_prediction_for_model(
     # TODO: might want to write a shared function for this as train.py might also want to do this.
     df_test = pd.read_csv(args.test_path)
     preds = torch.concat(predss, 0)
+    if isinstance(model.predictor, RegressionFFN):
+        preds = output_scaler.inverse_transform(preds)
     if isinstance(model.predictor, MulticlassClassificationFFN):
         preds = torch.argmax(preds, dim=-1)
     target_columns = [f"pred_{i}" for i in range(preds.shape[1])]  # TODO: need to improve this

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -739,9 +739,9 @@ def train_model(args, train_loader, val_loader, test_loader, output_dir, output_
                 predss = trainer.predict(model, test_loader)
                 preds = torch.concat(predss, 0).numpy()
                 if args.task_type == "regression":
-                    unscaled_preds = output_scaler.inverse_transform(preds)
+                    preds = output_scaler.inverse_transform(preds)
                 columns = get_column_names(args.data_path, args.smiles_columns, args.reaction_columns, args.target_columns, args.ignore_columns, args.no_header_row)
-                df_preds = pd.DataFrame(list(zip(test_loader.dataset.smiles, *unscaled_preds.T)), columns = columns)
+                df_preds = pd.DataFrame(list(zip(test_loader.dataset.smiles, *preds.T)), columns = columns)
                 df_preds.to_csv(model_output_dir / "test_predictions.csv", index=False)
 
         p_model = model_output_dir / "model.pt"

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -732,9 +732,6 @@ def train_model(args, train_loader, val_loader, test_loader, output_dir, scaler)
         trainer.fit(model, train_loader, val_loader)
 
         if test_loader is not None:
-            if args.task_type == "regression":
-                model.predictor.register_buffer("loc", torch.tensor(scaler.mean_).view(1, -1))
-                model.predictor.register_buffer("scale", torch.tensor(scaler.scale_).view(1, -1))
             results = trainer.test(model, test_loader)[0]
             logger.info(f"Test results: {results}")
 

--- a/chemprop/nn/predictors.py
+++ b/chemprop/nn/predictors.py
@@ -115,18 +115,11 @@ class RegressionFFN(_FFNPredictorBase):
         dropout: float = 0,
         activation: str = "relu",
         criterion: LossFunction | None = None,
-        loc: float | Tensor = 0,
-        scale: float | Tensor = 1,
     ):
         super().__init__(n_tasks, input_dim, hidden_dim, n_layers, dropout, activation, criterion)
 
-        self.register_buffer("loc", torch.tensor(loc).view(1, -1))
-        self.register_buffer("scale", torch.tensor(scale).view(1, -1))
-
     def forward(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z)
-
-        return self.scale * Y + self.loc
+        return super().forward(Z)
 
     def train_step(self, Z: Tensor) -> Tensor:
         return super().forward(Z)


### PR DESCRIPTION
## Description
Currently, the losses of training and validation sets are calculated using the scaled values. Then, the scaler is appended to the `loc` and `scale` attribute under `RegressionFFN` to calculate the losses of the test set. This is quite crumblesome and requires the user to remember only scale the training and validation set, but not the test set. Moreover, it is not intuitive for the user to compare the losses from training, validation, and test set.

## Example / Current workflow
Currently the test set is not scaled,
```
if isinstance(readout_ffn, RegressionFFN):
    scaler = train_dset.normalize_targets()     
    val_dset.normalize_targets(scaler)
    logger.info(f"Train data: loc = {scaler.mean_}, scale = {scaler.scale_}")
```
and it relies on register butter carefully at the right place (after evaluation is done on the validation step) in order to evaluate the test set as unscaled values.
```
if test_loader is not None:
        if args.task_type == "regression":
            model.predictor.register_buffer("loc", torch.tensor(scaler.mean_).view(-1, 1))
            model.predictor.register_buffer("scale", torch.tensor(scaler.scale_).view(-1, 1))
        results = trainer.test(model, test_loader)[0]
        logger.info(f"Test results: {results}")
```

## Bugfix / Desired workflow
This PR removes the `loc` and `scale` attributes from `RegressionFFN` and makes the unscale step explicitly by

```
if args.task_type == "regression":
                    preds = output_scaler.inverse_transform(preds)
```

This output scaler is saved to the model file.

## Relevant issues
https://github.com/chemprop/chemprop/issues/512

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
