### PR TITLE
revise dockerfile for chempropv2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,7 @@
 # Good luck!
 
 # Parent Image
-FROM ubuntu:latest
-
-# 'Install' Bash shell
-RUN ln -snf /bin/bash /bin/sh
+FROM continuumio/miniconda3:latest
 
 # Install system dependencies
 #
@@ -46,15 +43,6 @@ RUN apt-get update && \
     libxrender1 && \
     apt-get autoremove -y && \
     apt-get clean -y
-
-# Install conda
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda && \
-    rm Miniconda3-latest-Linux-x86_64.sh
-ENV PATH="$PATH:/miniconda/bin"
-
-# Set Bash as the default shell for following commands
-SHELL ["/bin/bash", "-c"]
 
 WORKDIR /opt/chemprop
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,80 @@
+# Dockerfile
+#
+# Builds a Docker image containing Chemprop and its required dependencies.
+#
+# Build this image with:
+#  docker build .
+#
+# Run the built image with:
+#  docker run --name chemprop_container -it <IMAGE_ID>
+# where <IMAGE_ID> is shown from the output of the build command.
+#
+# Note:
+# This image only runs on CPU - we do not provide a GPU Dockerfile
+# because it is highly system-dependent and much harder than just installing
+# from source or manually installing inside a Docker container.
+# 
+# To disregard this advice and make this Dockerfilework for your GPU,
+# select a new parent image from:
+# https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags
+# and then update the installation steps to install the appropriate
+# versions of PyTorch:
+# https://pytorch.org/get-started/locally/
+# and PyTorch Scatter:
+# https://github.com/rusty1s/pytorch_scatter?tab=readme-ov-file#installation
+# based on your GPU version.
+#
+# We have absolutely no idea how to make the above work on AMD GPUs... ¯\_(ツ)_/¯
+# Good luck!
+
+# Parent Image
+FROM ubuntu:latest
+
+# 'Install' Bash shell
+RUN ln -snf /bin/bash /bin/sh
+
+# Install system dependencies
+#
+# List of deps and why they are needed:
+#  - git for downloading repository
+#  - wget for downloading conda install script
+#  - libxrender1 required by RDKit
+RUN apt-get update && \
+    apt-get install -y \
+    wget \
+    git \
+    libxrender1 && \
+    apt-get autoremove -y && \
+    apt-get clean -y
+
+# Install conda
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda && \
+    rm Miniconda3-latest-Linux-x86_64.sh
+ENV PATH="$PATH:/miniconda/bin"
+
+# Set Bash as the default shell for following commands
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /opt/chemprop
+
+# build the conda environment
+RUN conda create --name chemprop_env python=3.11* && \
+    conda clean --all --yes
+
+# This runs all subsequent commands inside the chemprop_env conda environment
+#
+# Analogous to just activating the environment, which we can't actually do here
+# since that requires running conda init and restarting the shell (not possible
+# in a Dockerfile build script)
+SHELL ["conda", "run", "--no-capture-output", "-n", "chemprop_env", "/bin/bash", "-c"]
+
+# Follow the installation instructions (but with fixed versions, for stability of this image) then clear the cache
+RUN python -m pip install torch==2.2.0 --index-url https://download.pytorch.org/whl/cpu && \
+    python -m pip install torch-scatter -f https://data.pyg.org/whl/torch-2.2.0+cpu.html && \
+    python -m pip install git+https://github.com/chemprop/chemprop.git@f39a672d003dd82f1fddff8009d98a0c4f21796b && \
+    python -m pip cache purge
+
+# when running this image, open an interactive bash terminal inside the conda environment
+RUN echo "source activate chemprop_env" > ~/.bashrc
+ENTRYPOINT ["/bin/bash", "--login"]

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,11 +3,11 @@
 Installation
 ============
 
-Chemprop can either be installed from PyPI via pip_, from source (i.e., directly from the `git repo`_), or from docker_. The PyPI version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
+Chemprop can either be installed from PyPI via pip_, from source (i.e., directly from the `git repo`_), or from `Docker`_. The PyPI version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
 
 .. _pip: https://pypi.org/project/chemprop/
 .. _git repo: https://github.com/chemprop/chemprop.git
-.. _docker: https://docker.com
+.. _`Docker`: https://www.docker.com/get-started/
 .. _conda: https://docs.conda.io/en/latest/conda.html
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 
@@ -57,7 +57,7 @@ Option 3: Installing via Docker
 -------------------------------
  
 Chemprop can also be installed with Docker, making it possible to isolate the Chemprop code and environment.
-To install and run Chemprop in a Docker container, first install Docker from docker_.
+To install and run Chemprop in a Docker container, first install `Docker`_.
 You may then either ``pull`` and use official Chemprop images or ``build`` the image yourself.
 
 .. note:: 
@@ -66,7 +66,6 @@ You may then either ``pull`` and use official Chemprop images or ``build`` the i
     Adding the ``--gpus all`` argument to ``docker run`` will then allow Chemprop to run on GPU from within the container.
     Users on other systems should install Chemprop from PyPI or source.
 
-.. _docker: https://www.docker.com/get-started/
 .. _`nvidia-container-toolkit`: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 
 Pull Official Images

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -57,12 +57,12 @@ Option 3: Installing via Docker
  
 Chemprop can also be installed with Docker, making it possible to isolate the Chemprop code and environment.
 To install and run Chemprop in a Docker container, first install Docker from docker_.
-You may then either `pull` and use official Chemprop images or `build` the image yourself.
+You may then either ``pull`` and use official Chemprop images or ``build`` the image yourself.
 
 .. note:: 
     The Chemprop Dockerfile runs only on CPU and does not support GPU acceleration.
     Linux users with NVIDIA GPUs may install the `nvidia-container-toolkit`_ from NVIDIA and modify the installation instructions in the Dockerfile to install versions of `torch` and `torch-scatter` which are compatible with your system's GPUs and drivers.
-    Adding the `--gpus all` argument to `docker run` will then allow Chemprop to run on GPU from within the container.
+    Adding the ``--gpus all`` argument to ``docker run`` will then allow Chemprop to run on GPU from within the container.
     Users on other systems should install Chemprop from PyPI or source.
 
 .. _docker: https://www.docker.com/get-started/
@@ -73,18 +73,25 @@ Pull Official Images
 
 .. code-block::
 
-    docker pull chemprop/chemprop:X.Y.X.rcN
-    docker run -it chemprop/chemprop:X.Y.X.rcN
+    docker pull chemprop/chemprop:X.Y.ZrcN
+    docker run -it chemprop/chemprop:X.Y.ZrcN
 
-Where `X`, `Y`, `Z`, and `N`, should be replaced with the version of Chemprop you wish to `pull`.
-Note that not all versions of Chemprop are available as pre-built images - see the `Docker Hub`_ page for a list of those that are available.
+Where `X`, `Y`, `Z`, and `N`, should be replaced with the version of Chemprop you wish to ``pull``.
+For example, to pull `chemprop-2.0.0rc1` run
+
+.. code-block::
+
+    docker pull chemprop/chemprop:2.0.0rc1
+
+Note that not all versions of Chemprop are available as pre-built images.
+Visit the `Docker Hub`_ page for a list of those that are available.
 
 .. _`Docker Hub`: https://hub.docker.com/repository/docker/chemprop/chemprop/general
 
 Build Image Locally
 +++++++++++++++++++
 
-First follow the instructions in `Installing from Source` up to invoking `pip`, and then run the following:
+First follow the instructions in `Option 2: Installing from Source`_ up to invoking ``pip``, and then run the following:
 
 .. code-block::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ Chemprop can either be installed from PyPI via pip_ or from source (i.e., direct
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 
 .. note:: 
-    We also plan to make chemprop installable using `Docker` or using an `environment.yml` file with `conda` before the release of v2.0.0.
+    We also plan to make chemprop installable using an `environment.yml` file with `conda` before the release of v2.0.0.
 
 Start by setting up your virtual environment. We assume you are using ``conda`` or ``miniconda``, but you may adapt these steps use any virtual environment manager you like:
 
@@ -52,24 +52,41 @@ Option 2: Installing from source
     pip install torch-scatter
     pip install .
 
-.. Option 3: Installing via Docker
-.. -------------------------------
+Option 3: Installing via Docker
+-------------------------------
+ 
+Chemprop can also be installed with Docker, making it possible to isolate the Chemprop code and environment.
+To install and run Chemprop in a Docker container, first install Docker from docker_.
+You may then either `pull` and use official Chemprop images or `build` the image yourself.
 
-.. Chemprop can also be installed with Docker, making it possible to isolate the Chemprop code and environment. To install and run our code in a Docker container, first install docker from docker_. Then, run the following commands:
+.. note:: 
+    The Chemprop Dockerfile runs only on CPU and does not support GPU acceleration.
+    Linux users with NVIDIA GPUs may install the `nvidia-container-toolkit`_ from NVIDIA and modify the installation instructions in the Dockerfile to install versions of `torch` and `torch-scatter` which are compatible with your system's GPUs and drivers.
+    Adding the `--gpus all` argument to `docker run` will then allow Chemprop to run on GPU from within the container.
+    Users on other systems should install Chemprop from PyPI or source.
 
-.. .. code-block::
+.. _docker: https://www.docker.com/get-started/
+.. _`nvidia-container-toolkit`: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 
-..     git clone https://github.com/chemprop/chemprop.git
-..     cd chemprop
-..     git checkout v2/dev
-..     docker build --tag chemprop . --build-arg="CUDA=<cuda_arg>"
-..     docker run -it chemprop:latest
+Pull Official Images
+++++++++++++++++++++
 
+.. code-block::
 
-.. .. note:: 
-..     In the docker build line, replace ``<cuda_arg>`` with ``cpu``, ``cu118``, or ``cu121`` depending on your version of PyTorch. If experiencing permission errors, prepend ``sudo`` to the Docker commands.
+    docker pull chemprop/chemprop:X.Y.X.rcN
+    docker run -it chemprop/chemprop:X.Y.X.rcN
 
-..     You will need to run the last command with ``nvidia-docker`` if you are on a GPU machine in order to be able to access the GPUs. Alternatively, with ``docker >= 19.03``, you can specify the ``--gpus`` command line option instead.
+Where `X`, `Y`, `Z`, and `N`, should be replaced with the version of Chemprop you wish to `pull`.
+Note that not all versions of Chemprop are available as pre-built images - see the `Docker Hub`_ page for a list of those that are available.
 
-..     In addition, you will also need to ensure that the CUDA toolkit version in the Docker image is compatible with the CUDA driver on your host machine. Newer CUDA driver versions are backward-compatible with older CUDA toolkit versions. To set a specific CUDA toolkit version, add ``cudatoolkit=X.Y`` to ``environment.yml`` before building the Docker image.
+.. _`Docker Hub`: https://hub.docker.com/repository/docker/chemprop/chemprop/general
 
+Build Image Locally
++++++++++++++++++++
+
+First follow the instructions in `Installing from Source` up to invoking `pip`, and then run the following:
+
+.. code-block::
+
+    docker build --tag=chemprop .
+    docker run -it chemprop

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,11 +3,11 @@
 Installation
 ============
 
-Chemprop can either be installed from PyPI via pip_, from source (i.e., directly from the `git repo`_), or from docker_. The PyPI version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
+Chemprop can either be installed from PyPI via pip_, from source (i.e., directly from the `git repo`_), or from Docker_. The PyPI version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
 
 .. _pip: https://pypi.org/project/chemprop/
 .. _git repo: https://github.com/chemprop/chemprop.git
-.. _docker: https://docker.com
+.. _Docker: https://docker.com
 .. _conda: https://docs.conda.io/en/latest/conda.html
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ Chemprop can either be installed from PyPI via pip_ or from source (i.e., direct
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 
 .. note:: 
-    We also plan to make chemprop installable using an `environment.yml` file with `conda` before the release of v2.0.0.
+    We also plan to make chemprop installable using an ``environment.yml`` file with ``conda`` before the release of v2.0.0.
 
 Start by setting up your virtual environment. We assume you are using ``conda`` or ``miniconda``, but you may adapt these steps use any virtual environment manager you like:
 
@@ -76,8 +76,8 @@ Pull Official Images
     docker pull chemprop/chemprop:X.Y.ZrcN
     docker run -it chemprop/chemprop:X.Y.ZrcN
 
-Where `X`, `Y`, `Z`, and `N`, should be replaced with the version of Chemprop you wish to ``pull``.
-For example, to pull `chemprop-2.0.0rc1` run
+Where ``X``, ``Y``, ``Z``, and ``N``, should be replaced with the version of Chemprop you wish to ``pull``.
+For example, to pull ``chemprop-2.0.0rc1`` run
 
 .. code-block::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,10 +3,11 @@
 Installation
 ============
 
-Chemprop can either be installed from PyPI via pip_ or from source (i.e., directly from the `git repo`_). The PyPI version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
+Chemprop can either be installed from PyPi via pip_, from source (i.e., directly from the `git repo`_), or from docker_. The PyPi version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
 
 .. _pip: https://pypi.org/project/chemprop/
 .. _git repo: https://github.com/chemprop/chemprop.git
+.. _docker: https://docker.com
 .. _conda: https://docs.conda.io/en/latest/conda.html
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,11 +3,11 @@
 Installation
 ============
 
-Chemprop can either be installed from PyPI via pip_, from source (i.e., directly from the `git repo`_), or from Docker_. The PyPI version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
+Chemprop can either be installed from PyPI via pip_, from source (i.e., directly from the `git repo`_), or from docker_. The PyPI version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
 
 .. _pip: https://pypi.org/project/chemprop/
 .. _git repo: https://github.com/chemprop/chemprop.git
-.. _Docker: https://docker.com
+.. _docker: https://docker.com
 .. _conda: https://docs.conda.io/en/latest/conda.html
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-Chemprop can either be installed from PyPi via pip_, from source (i.e., directly from the `git repo`_), or from docker_. The PyPi version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
+Chemprop can either be installed from PyPI via pip_, from source (i.e., directly from the `git repo`_), or from docker_. The PyPI version includes a vast majority of Chemprop functionality, but some functionality is only accessible when installed from source. We recommend installing ``chemprop`` in a virtual environment (e.g., conda_ or miniconda_). The following sections assume you are using ``conda`` or ``miniconda``, but you can use any virtual environment manager you like.
 
 .. _pip: https://pypi.org/project/chemprop/
 .. _git repo: https://github.com/chemprop/chemprop.git


### PR DESCRIPTION
 - note that this is locked on a specific version of pytorch, pytorch scatter, and chemprop (down to the commit hash)
 - this only runs on CPU, but includes some minimal instructions to help people get going on GPU
 - tested locally by building, running, and then training a quick FreeSolv model without issue

I have also generally overhauled the Dockerfile based on how we distribute RMG-Py via Docker, see [that Dockerfile](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/main/Dockerfile), which has been working without issues for a while now.