### PR TITLE
V2: Debug and add tests for various aggregation methods

### DIFF
--- a/chemprop/nn/agg.py
+++ b/chemprop/nn/agg.py
@@ -102,7 +102,7 @@ class NormAggregation(SumAggregation):
         self.hparams["norm"] = norm
 
     def forward(self, H: Tensor, batch: Tensor) -> Tensor:
-        return super().forward(H, batch, self.dim) / self.norm
+        return super().forward(H, batch) / self.norm
 
 
 class AttentiveAggregation(Aggregation):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,10 +10,10 @@ warnings.filterwarnings("ignore", module=r"lightning.*", append=True)
 
 @pytest.fixture(scope="session")
 def mpnn(request):
-    agg = nn.SumAggregation()
+    message_passing, agg = request.param
     ffn = nn.RegressionFFN()
 
-    return models.MPNN(request.param, agg, ffn, True)
+    return models.MPNN(message_passing, agg, ffn, True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_regression_mol.py
+++ b/tests/integration/test_regression_mol.py
@@ -11,7 +11,13 @@ from chemprop.data import MoleculeDatapoint, MoleculeDataset, collate_batch
 
 pytestmark = [
     pytest.mark.parametrize(
-        "mpnn", [nn.BondMessagePassing(), nn.AtomMessagePassing()], indirect=True
+        "mpnn",
+        [
+            (nn.BondMessagePassing(), nn.MeanAggregation()),
+            (nn.AtomMessagePassing(), nn.SumAggregation()),
+            (nn.BondMessagePassing(), nn.NormAggregation()),
+        ],
+        indirect=True,
     ),
     pytest.mark.integration,
 ]

--- a/tests/integration/test_regression_rxn.py
+++ b/tests/integration/test_regression_rxn.py
@@ -12,7 +12,11 @@ from chemprop.featurizers import CondensedGraphOfReactionFeaturizer
 
 SHAPE = CondensedGraphOfReactionFeaturizer().shape
 pytestmark = pytest.mark.parametrize(
-    "mpnn", [nn.BondMessagePassing(*SHAPE), nn.AtomMessagePassing(*SHAPE)], indirect=True
+    "mpnn", [
+            (nn.BondMessagePassing(*SHAPE), nn.MeanAggregation()),
+            (nn.AtomMessagePassing(*SHAPE), nn.SumAggregation()),
+            (nn.BondMessagePassing(*SHAPE), nn.NormAggregation()),
+        ], indirect=True
 )
 
 


### PR DESCRIPTION
## Description
https://github.com/chemprop/chemprop/issues/705 ran into error when using the norm aggregation. Currently we only test sum aggregation in the integration test. I add tests for other aggregation methods.

## Example / Current workflow
The error is from the forward function of norm aggregation. An extra `self.dim` is passed in, which is not necessary.

```
@AggregationRegistry.register("norm")
class NormAggregation(SumAggregation):
    r"""Sum the graph-level representation and divide by a normalization constant:

    .. math::
        \mathbf h = \frac{1}{c} \sum_{v \in V} \mathbf h_v
    """

    def __init__(self, dim: int = 0, *args, norm: float = 100, **kwargs):
        super().__init__(dim, **kwargs)

        self.norm = norm
        self.hparams["norm"] = norm

    def forward(self, H: Tensor, batch: Tensor) -> Tensor:
        return super().forward(H, batch, self.dim) / self.norm
```

The test didn't catch this because we currently only test for the `SumAggregation`

```
@pytest.fixture(scope="session")
def mpnn(request):
    agg = nn.SumAggregation()
    ffn = nn.RegressionFFN()

    return models.MPNN(request.param, agg, ffn, True)
```

## Bugfix / Desired workflow
I remove the extra self.dim:

```
    def forward(self, H: Tensor, batch: Tensor) -> Tensor:
        return super().forward(H, batch) / self.norm
```

I modify the integration test to be

```
@pytest.fixture(scope="session")
def mpnn(request):
    message_passing, agg = request.param
    ffn = nn.RegressionFFN()

    return models.MPNN(message_passing, agg, ffn, True)
```

with the request being

```
pytestmark = [
    pytest.mark.parametrize(
        "mpnn",
        [
            (nn.BondMessagePassing(), nn.MeanAggregation()),
            (nn.AtomMessagePassing(), nn.SumAggregation()),
            (nn.BondMessagePassing(), nn.NormAggregation()),
        ],
        indirect=True,
    ),
    pytest.mark.integration,
]
```

## Relevant issues
https://github.com/chemprop/chemprop/issues/705

## Checklist
- [ ] linted with flake8?
- [x] (if appropriate) unit tests added?
