### PR TITLE
fix the `uncal_vars` for atom/bond property prediction

### DIFF
--- a/chemprop/uncertainty/uncertainty_predictor.py
+++ b/chemprop/uncertainty/uncertainty_predictor.py
@@ -209,8 +209,9 @@ class NoUncertaintyPredictor(UncertaintyPredictor):
                 len(model.atom_targets),
                 len(model.bond_targets),
             )
-            uncal_vars = np.zeros_like(self.uncal_preds)
-            uncal_vars[:] = np.nan
+            uncal_vars = np.empty(len(sum_preds), dtype=object)
+            for i, pred in enumerate(sum_preds):
+                uncal_vars[i] = np.full(len(pred), np.nan)
             self.uncal_vars = reshape_values(
                 uncal_vars,
                 self.test_data,


### PR DESCRIPTION
## Description
The shape of `uncal_vars` should be the same as that of `sum_preds`. 

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
