### PR TITLE
[v1]: Add Docker Image Building Action and Official Images to DockerHub

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,4 +86,31 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
           verbose: true
-      
+  
+  build-and-push-docker:
+    # shamelessly copied from:
+    # https://github.com/ReactionMechanismGenerator/RMG-Py/blob/bfaee1cad9909a17103a8e6ef9a22569c475964c/.github/workflows/CI.yml#L359C1-L386C54
+    # which is also shamelessly copied from somewhere
+    needs: build
+    runs-on: ubuntu-latest
+    # ensure we only run on pushes to main of chemprop (i.e. not forks, dev branches, etc.)
+    if: github.ref == 'refs/heads/main' && github.repository == 'chemprop/chemprop'
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          # repository secretes managed by the maintainers
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: chemprop/chemprop:latest

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Run this command to download and run a given release version of Chemprop:
 where `X.Y.Z` is the version you want to download, i.e. `1.7.0`.
 
 > [!NOTE]
-> Not all versions of Chemprop are available from DockerHub - see the [DockerHub](https://hub.docker.com/repository/docker/chemprop/chemprop/general) page for a complete list of those available.
+> Not all versions of Chemprop are available from DockerHub - see the [DockerHub](https://hub.docker.com/r/chemprop/chemprop/tags) page for a complete list of those available.
 
 DockerHub also has a `latest` tag - this is _not_ the latest release of Chemprop, but rather the latest version of `master` which is _not necessarily fit for deployment_.
 Use this tag only for development or if you need to access a feature which has not yet been formally released!

--- a/README.md
+++ b/README.md
@@ -126,20 +126,39 @@ Then proceed to either option below to complete the installation. If installing 
 
 ### Docker
 
-Chemprop can also be installed with Docker. Docker makes it possible to isolate the Chemprop code and environment. To install and run our code in a Docker container, follow these steps:
+Chemprop can also be installed with Docker.
+Docker makes it possible to isolate the Chemprop code and environment.
+You can either pull a pre-built image or build it locally.
+
+Note that regardless of installation method you will need to run the `docker run` command with the `--gpus` command line flag to access GPUs on your machine.
+
+In addition, you will also need to ensure that the CUDA toolkit version in the Docker image is compatible with the CUDA driver on your host machine.
+Newer CUDA driver versions are backward-compatible with older CUDA toolkit versions.
+To set a specific CUDA toolkit version, add `cudatoolkit=X.Y` to `environment.yml` before building the Docker image.
+
+#### Pull Pre-Built
+
+Run this command to download and run a given release version of Chemprop:
+
+`docker run -it chemprop/chemprop:X.Y.X`
+
+where `X.Y.Z` is the version you want to download, i.e. `1.7.0`.
+
+> [!NOTE]
+> Not all versions of Chemprop are available from DockerHub - see the [DockerHub](https://hub.docker.com/repository/docker/chemprop/chemprop/general) page for a complete list of those available.
+
+DockerHub also has a `latest` tag - this is _not_ the latest release of Chemprop, but rather the latest version of `master` which is _not necessarily fit for deployment_.
+Use this tag only for development or if you need to access a feature which has not yet been formally released!
+
+#### Local Build
+
+To install and run our code in a Docker container, follow these steps:
 
 1. `git clone https://github.com/chemprop/chemprop.git`
 2. `cd chemprop`
 3. Install Docker from [https://docs.docker.com/install/](https://docs.docker.com/install/)
 4. `docker build -t chemprop .`
 5. `docker run -it chemprop:latest`
-
-Note that you will need to run the latter command with nvidia-docker if you are on a GPU machine in order to be able to access the GPUs.
-Alternatively, with Docker 19.03+, you can specify the `--gpus` command line option instead.
-
-In addition, you will also need to ensure that the CUDA toolkit version in the Docker image is compatible with the CUDA driver on your host machine.
-Newer CUDA driver versions are backward-compatible with older CUDA toolkit versions.
-To set a specific CUDA toolkit version, add `cudatoolkit=X.Y` to `environment.yml` before building the Docker image.
 
 ## Known Issues
 


### PR DESCRIPTION
## Description
Replaces #715 - official Chemprop Docker images will now be available at DockerHub.

## Example / Current workflow
Current readme only describes how to build locally.

## Bugfix / Desired workflow
I have pushed the latest tag to DockerHub and will start working backwards building and pushing some previous versions as well.

In the future, the added action will automatically build images based on `master`, and we can manually tag them with release numbers as we do formal releases.
