### PR TITLE
Fix load from checkpoint in python 3.12

### DIFF
--- a/chemprop/models/multi.py
+++ b/chemprop/models/multi.py
@@ -51,23 +51,6 @@ class MulticomponentMPNN(MPNN):
         return H if X_d is None else torch.cat((H, X_d), 1)
 
     @classmethod
-    def load_from_checkpoint(
-        cls, checkpoint_path, map_location=None, hparams_file=None, strict=True, **kwargs
-    ) -> MPNN:
-        hparams = torch.load(checkpoint_path)["hyper_parameters"]
-
-        mp_hparams = hparams["message_passing"]
-        mp_hparams["blocks"] = [
-            block_hparams.pop("cls")(**block_hparams) for block_hparams in mp_hparams["blocks"]
-        ]
-        message_passing = mp_hparams.pop("cls")(**mp_hparams)
-        kwargs["message_passing"] = message_passing
-
-        return super().load_from_checkpoint(
-            checkpoint_path, map_location, hparams_file, strict, **kwargs
-        )
-
-    @classmethod
     def load_from_file(cls, model_path, map_location=None, strict=True) -> MPNN:
         d = torch.load(model_path, map_location=map_location)
 

--- a/chemprop/models/multi.py
+++ b/chemprop/models/multi.py
@@ -51,6 +51,21 @@ class MulticomponentMPNN(MPNN):
         return H if X_d is None else torch.cat((H, X_d), 1)
 
     @classmethod
+    def load_submodules(cls, checkpoint_path, **kwargs):
+        hparams = torch.load(checkpoint_path)["hyper_parameters"]
+
+        hparams["message_passing"]["blocks"] = [
+            block_hparams.pop("cls")(**block_hparams)
+            for block_hparams in hparams["message_passing"]["blocks"]
+        ]
+        kwargs |= {
+            key: hparams[key].pop("cls")(**hparams[key])
+            for key in ("message_passing", "agg", "predictor")
+            if key not in kwargs
+        }
+        return kwargs
+
+    @classmethod
     def load_from_file(cls, model_path, map_location=None, strict=True) -> MPNN:
         d = torch.load(model_path, map_location=map_location)
 


### PR DESCRIPTION
This PR fixes an interesting error with our use of `save_hyperparameters()` that prevents loading checkpoint files in python 3.12. We have had discussion of this several places (#714 and #738). I learned a lot while debugging this and felt it was too long for a comment. So I opened this PR both to isolate the change to demonstraight it works and also to have the space to explain what is going on. I'd be also happy to include this change in the other PR and close this one. 

## The short version
When we call `save_hyperparameters()` in the `__init__` of our modules (e.g. `_MessagePassingBase`) lightning will "Recursively collects the arguments passed to the child constructors in the inheritance tree." It knows when to stop by looking for the absense of `__class__` in the local variables. It can do this because `super().__init__()` is required in the `__init__` of modules that inherit from `LightningModule` and this adds `__class__` to the local variables.  If our call to `__init__` originates in a scope that also has `__class__` (as is the case in `load_from_checkpoint()`) then lightning won't know where to stop. In python 3.11 we were okay because we instantiate the modules in `load_from_checkpoint()` *within a comprehension loop* which has its own scope. Python 3.12 speeded up comprehension by removing it creating its own scope. We can fix our use of `save_hyperparameters()` by instantiating the modules within a different scope that doesn't have `__class__`, done here by calling a helper function `load_submodules()`. 

## The longer version
### The error
A simple test reproduces the error:
```
from chemprop.models import MPNN
checkpoint_path = "tests/data/example_model_v2_regression_mol.ckpt"
model = MPNN.load_from_checkpoint(checkpoint_path)
```
The traceback shows the error originates in `lightning/pytorch/utilities/parsing.py` in `_get_init_args()`:
```
Traceback (most recent call last):
  File "---/simple_example.py", line 3, in <module>
    model = MPNN.load_from_checkpoint(checkpoint_path)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "---/mambaforge/envs/chemprop_3-12/lib/python3.12/site-packages/chemprop/models/model.py", line 230, in load_from_checkpoint
    key: hparams[key].pop("cls")(**hparams[key])
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "---/mambaforge/envs/chemprop_3-12/lib/python3.12/site-packages/chemprop/nn/message_passing/base.py", line 62, in __init__
    self.save_hyperparameters()
  File "---/mambaforge/envs/chemprop_3-12/lib/python3.12/site-packages/lightning/pytorch/core/mixins/hparams_mixin.py", line 130, in save_hyperparameters
    save_hyperparameters(self, *args, ignore=ignore, frame=frame, given_hparams=given_hparams)
  File "---/mambaforge/envs/chemprop_3-12/lib/python3.12/site-packages/lightning/pytorch/utilities/parsing.py", line 175, in save_hyperparameters
    for local_args in collect_init_args(frame, [], classes=(HyperparametersMixin,)):
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "---/mambaforge/envs/chemprop_3-12/lib/python3.12/site-packages/lightning/pytorch/utilities/parsing.py", line 139, in collect_init_args
    return collect_init_args(frame.f_back, path_args, inside=True, classes=classes)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "---/mambaforge/envs/chemprop_3-12/lib/python3.12/site-packages/lightning/pytorch/utilities/parsing.py", line 135, in collect_init_args
    local_self, local_args = _get_init_args(frame)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "---/mambaforge/envs/chemprop_3-12/lib/python3.12/site-packages/lightning/pytorch/utilities/parsing.py", line 101, in _get_init_args
    local_args = {k: local_vars[k] for k in init_parameters}
                     ~~~~~~~~~~^^^
KeyError: 'self'
```
### The stack frame
The error occurs because lightning looks through the local variable (`local_vars`) to pick out what parameters are needed to re-initalize the module later (i.e. the hyperparameters), but the some are missing, specifically 'self' the module object that is currently being created. We see in `_get_init_args()` that `local_vars` comes from `_, _, _, local_vars = inspect.getargvalues(frame)`. The frame here is part of the stack frame which is like an onion, whose layers keep track of the scopes (local variables) of the various function calls. [(Potentially helpful reference)](https://stackoverflow.com/questions/40641615/what-is-the-difference-between-a-frame-and-object-and-when-should-i-modify-one) When the code hits an error, I think the stack trace comes from following the stack frame back out to where we started. Side note that `init_parameters` comes from inspecting the signature of the `__init__` of the class `init_parameters = inspect.signature(cls.__init__).parameters`.
### Recursion
Why does the frame not have the variables that `__init__` needs? `_get_init_args()` is called by `collect_init_args()` which says it `"Recursively collects the arguments passed to the child constructors in the inheritance tree."` Part of this function checks if `__class__` is in the local_vars and if it is, it will call `collect_init_args()` again but with `frame.f_back` as the new frame. (Side note: it also checks if class in the current frame inherits from `HyperparametersMixin`, but I don't think that is relavent to our error.) What `frame.f_back` does is gets the frame one up in the stack. So `collect_init_args()` will continue back up the stack until it hits a frame that doesn't have `__class__`. 
### Inspecting the frames
The initial frame that gets given to `collect_init_args()` is generated in the call to `save_hyperparameters()` in the module `__init__`. I'll use `_MessagePassingBase` as an example. When `self.save_hyperparameters()` is called python goes into `lightning.pytorch.core.mixins.hparams_mixin` which defines `save_hyperparameters()`. This internally calls a different `save_hyperparameters()` that is in `lightning.pytorch.utilities.parsing`. The call looks like `save_hyperparameters(self, *args, ignore=ignore, frame=frame, given_hparams=given_hparams)` where `frame` comes from the couple lines above `current_frame = inspect.currentframe()`, `frame = current_frame.f_back`. `save_hyperparameters()` gets the current frame, but really we want the frame of the function that called `save_hyperparameters()` which is `__init__` so it uses `f_back`. This means it is sufficient to look at the stack frame in `__init__` to figure out what is going on. Adding a block of code before `self.save_hyperparameters()`  in `_MessagePassingBase` will show us the variable names that are defined in each frame's scope. 
```
    super().__init__()
    import inspect
    frame = inspect.currentframe()
    while True:
        _, _, _, local_vars = inspect.getargvalues(frame)
        print(local_vars.keys())
        if '__class__' in local_vars.keys():
	    print('__class__:', local_vars['__class__']) 
	frame = frame.f_back
    return
    self.save_hyperparameters()
```
### Python 3.12
Running the simple test example from earlier gives a stack trace of:
```
dict_keys(['self', 'd_v', 'd_e', 'd_h', 'bias', 'depth', 'dropout', 'activation', 'undirected', 'd_vd', 'inspect', 'frame', '__class__'])
__class__: <class 'chemprop.nn.message_passing.base._MessagePassingBase'>
dict_keys(['cls', 'checkpoint_path', 'map_location', 'hparams_file', 'strict', 'kwargs', 'hparams', 'key', '__class__'])
__class__: <class 'chemprop.models.model.MPNN'>
dict_keys(['__name__', '__doc__', '__package__', '__loader__', '__spec__', '__annotations__', '__builtins__', '__file__', '__cached__', 'MPNN', 'checkpoint_path'])
```
The first dict_keys line is the variables that were available inside `__init__`. This makes sense because those variables are either arguments to the function (`d_v`, `d_vd`, etc.) or are created in init (`import inspect`, `frame = ...`).  The second dict_keys line comes from `load_from_checkpoint()` in `MPNN` in `model.py` and the third comes from the test example's script file.
So when `save_hyperparameters()` runs it first tries to save the arguments for the first line (`d_v`, etc.) for `<class 'chemprop.nn.message_passing.base._MessagePassingBase'>`. Then it sees that the function call before also has `__class__` so it tries to save what it needs to init a `<class 'chemprop.models.model.MPNN'>` by starting with `self` but that wasn't given in our function call because it was `load_from_checkpoint()` not `__init__`. 
### Python 3.11
If I run the same simple text example in python 3.11 the stack trace is instead:
```
dict_keys(['self', 'd_v', 'd_e', 'd_h', 'bias', 'depth', 'dropout', 'activation', 'undirected', 'd_vd', 'inspect', 'frame', '__class__'])
__class__: <class 'chemprop.nn.message_passing.base._MessagePassingBase'>
dict_keys(['.0', 'key', 'hparams', 'kwargs'])
dict_keys(['cls', 'checkpoint_path', 'map_location', 'hparams_file', 'strict', 'kwargs', 'hparams', '__class__'])
__class__: <class 'chemprop.models.model.MPNN'>
dict_keys(['__name__', '__doc__', '__package__', '__loader__', '__spec__', '__annotations__', '__builtins__', '__file__', '__cached__', 'MPNN', 'checkpoint_path'])
```
This is the same as before but there is an extra line. This line come from the dictionary comprehension used to loop through the three submodules that need to be instantiated. 
```
kwargs |= {
            key: hparams[key].pop("cls")(**hparams[key])
            for key in ("message_passing", "agg", "predictor")
            if key not in kwargs
        }
```
In this case after saving the hyperparameters for `<class 'chemprop.nn.message_passing.base._MessagePassingBase'>`, it sees the next function call doesn't have `__class__` and correctly terminates.
### What changed in 3.12
PEP 709 changed comprehensions to be [inline](https://docs.python.org/3/whatsnew/3.12.html#whatsnew312-pep709). This means "there is no longer a separate frame for the comprehension in tracebacks". 
### Solution
A simple solution is to add another function call between `load_from_checkpoint()` and calling `__init__` of the modules. The current implementation gives:
```
dict_keys(['self', 'd_v', 'd_e', 'd_h', 'bias', 'depth', 'dropout', 'activation', 'undirected', 'd_vd', 'inspect', 'frame', '__class__'])
__class__: <class 'chemprop.nn.message_passing.base._MessagePassingBase'>
dict_keys(['checkpoint_path', 'kwargs', 'hparams', 'key'])
dict_keys(['cls', 'checkpoint_path', 'map_location', 'hparams_file', 'strict', 'kwargs', '__class__'])
__class__: <class 'chemprop.models.model.MPNN'>
dict_keys(['__name__', '__doc__', '__package__', '__loader__', '__spec__', '__annotations__', '__builtins__', '__file__', '__cached__', 'MPNN', 'checkpoint_path'])
```
### Where does `__class__` come from?
As I tried to debug this, I wondered why `load_from_file()` works just fine while `load_from_checkpoint()` didn't. The stack for `load_from_file()` in the current v2/dev with python 3.12 gives:
```
dict_keys(['self', 'd_v', 'd_e', 'd_h', 'bias', 'depth', 'dropout', 'activation', 'undirected', 'd_vd', 'inspect', 'frame', '__class__'])
__class__: <class 'chemprop.nn.message_passing.base._MessagePassingBase'>
dict_keys(['cls', 'model_path', 'map_location', 'strict', 'd', 'hparams', 'state_dict', 'key', 'hparam_kwargs', 'hparam_cls'])
dict_keys(['__name__', '__doc__', '__package__', '__loader__', '__spec__', '__annotations__', '__builtins__', '__file__', '__cached__', 'MPNN', 'checkpoint_path'])
```
The second dict_keys line comes from `load_from_file()` but doesn't have `__class__`. I learned [here](https://stackoverflow.com/questions/43644444/how-is-the-class-cell-value-set-in-class-methods) that `__class__` gets added to the local vars when `super()` is called. `load_from_checkpoint()` has a call to `super()` while `load_from_file()` doesn't. 

(Side note: apparently `super()` doesn't even need to be called, just present. Consider this example where `super()` is not reachable.)
```
class MyClass():
    def f(self):
        import inspect
        frame = inspect.currentframe()
        _, _, _, local_vars = inspect.getargvalues(frame)
        print(local_vars.keys())
        return
	print("hi")
        super()
        

temp = MyClass()
temp.f()
>>> dict_keys(['self', 'inspect', 'frame', '__class__'])
```

## Implementation and Questions
I decided to only have one `load_submodules()` shared between `MPNN` and `MulticomponentMPNN`. This was to keep things simple, but then requires checking for `"blocks" in hparams["message_passing"]` in the function in `MPNN` which is a multicomponent only idea. Alternatively we could be more explicit that `load_submodules()` is for both `MPNN` and `MulticomponentMPNN` by putting it in a separate file. I couldn't put it in `models/utils.py` though because this file imports from `MPNN`. 

Both MPNN and MulticomponentMPNN have their own `load_from_file()` method. These could be condensed into a single function by checking for `"blocks" in hparams["message_passing"]` in the same way that I did with `load_from_checkpoint()`. Do we want to do this? If we do, there is also the question if we want `load_from_file()` to call on `load_submodules()` instead of using its current `for key in` loop. 
