### PR TITLE
V2: Convert from float64 to float32

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -752,8 +752,12 @@ def train_model(args, train_loader, val_loader, test_loader, output_dir, scaler,
 
         if test_loader is not None:
             if args.task_type == "regression":
-                model.predictor.register_buffer("loc", torch.tensor(scaler.mean_).view(1, -1))
-                model.predictor.register_buffer("scale", torch.tensor(scaler.scale_).view(1, -1))
+                model.predictor.register_buffer(
+                    "loc", torch.tensor(scaler.mean_).view(1, -1).float()
+                )
+                model.predictor.register_buffer(
+                    "scale", torch.tensor(scaler.scale_).view(1, -1).float()
+                )
             results = trainer.test(model, test_loader)[0]
             logger.info(f"Test results: {results}")
 

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -51,14 +51,14 @@ def parse_csv(
         target_cols = list(set(df.columns) - set(input_cols) - set(ignore_cols or []))
 
     Y = df[target_cols]
-    weights = None if weight_col is None else df[weight_col].astype(np.float32).to_numpy()
+    weights = None if weight_col is None else df[weight_col].to_numpy(np.single)
 
     if bounded:
         lt_mask = Y.applymap(lambda x: "<" in x).to_numpy()
         gt_mask = Y.applymap(lambda x: ">" in x).to_numpy()
-        Y = Y.applymap(lambda x: x.strip("<").strip(">")).astype(np.float32).to_numpy()
+        Y = Y.applymap(lambda x: x.strip("<").strip(">")).to_numpy(np.single)
     else:
-        Y = Y.astype(np.float32).to_numpy()
+        Y = Y.to_numpy(np.single)
         lt_mask = None
         gt_mask = None
 

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -51,14 +51,14 @@ def parse_csv(
         target_cols = list(set(df.columns) - set(input_cols) - set(ignore_cols or []))
 
     Y = df[target_cols]
-    weights = None if weight_col is None else df[weight_col].to_numpy()
+    weights = None if weight_col is None else df[weight_col].astype(np.float32).to_numpy()
 
     if bounded:
         lt_mask = Y.applymap(lambda x: "<" in x).to_numpy()
         gt_mask = Y.applymap(lambda x: ">" in x).to_numpy()
-        Y = Y.applymap(lambda x: x.strip("<").strip(">")).astype(float).to_numpy()
+        Y = Y.applymap(lambda x: x.strip("<").strip(">")).astype(np.float32).to_numpy()
     else:
-        Y = Y.to_numpy()
+        Y = Y.astype(np.float32).to_numpy()
         lt_mask = None
         gt_mask = None
 
@@ -148,7 +148,7 @@ def make_datapoints(
     else:
         N = len(smiss)
 
-    weights = np.ones(N) if weights is None else weights
+    weights = np.ones(N, dtype=np.float32) if weights is None else weights
     gt_mask = [None] * N if gt_mask is None else gt_mask
     lt_mask = [None] * N if lt_mask is None else lt_mask
 

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -148,7 +148,7 @@ def make_datapoints(
     else:
         N = len(smiss)
 
-    weights = np.ones(N, dtype=np.float32) if weights is None else weights
+    weights = np.ones(N, dtype=np.single) if weights is None else weights
     gt_mask = [None] * N if gt_mask is None else gt_mask
     lt_mask = [None] * N if lt_mask is None else lt_mask
 

--- a/chemprop/data/collate.py
+++ b/chemprop/data/collate.py
@@ -88,7 +88,7 @@ def collate_batch(batch: Iterable[Datum]) -> TrainingBatch:
         None if V_ds[0] is None else torch.from_numpy(np.concatenate(V_ds)).float(),
         None if x_ds[0] is None else torch.from_numpy(np.array(x_ds)).float(),
         None if ys[0] is None else torch.from_numpy(np.array(ys)).float(),
-        torch.tensor(weights).unsqueeze(1),
+        torch.tensor(weights, dtype=torch.float).unsqueeze(1),
         None if lt_masks[0] is None else torch.from_numpy(np.array(lt_masks)),
         None if gt_masks[0] is None else torch.from_numpy(np.array(gt_masks)),
     )

--- a/chemprop/featurizers/molgraph/molecule.py
+++ b/chemprop/featurizers/molgraph/molecule.py
@@ -79,7 +79,7 @@ class SimpleMoleculeMolGraphFeaturizer(_MolGraphFeaturizerMixin, GraphFeaturizer
                 x_e = self.bond_featurizer(bond)
                 if bond_features_extra is not None:
                     x_e = np.concatenate(
-                        (x_e, bond_features_extra[bond.GetIdx()]), dtype=np.float32
+                        (x_e, bond_features_extra[bond.GetIdx()]), dtype=np.single
                     )
 
                 E[i : i + 2] = x_e

--- a/chemprop/featurizers/molgraph/molecule.py
+++ b/chemprop/featurizers/molgraph/molecule.py
@@ -60,9 +60,9 @@ class SimpleMoleculeMolGraphFeaturizer(_MolGraphFeaturizerMixin, GraphFeaturizer
             )
 
         if n_atoms == 0:
-            V = np.zeros((1, self.atom_fdim)).astype(np.float32)
+            V = np.zeros((1, self.atom_fdim), dtype=np.single)
         else:
-            V = np.array([self.atom_featurizer(a) for a in mol.GetAtoms()]).astype(np.float32)
+            V = np.array([self.atom_featurizer(a) for a in mol.GetAtoms()], dtype=np.single)
         E = np.empty((2 * n_bonds, self.bond_fdim))
         edge_index = [[], []]
 

--- a/chemprop/featurizers/molgraph/molecule.py
+++ b/chemprop/featurizers/molgraph/molecule.py
@@ -78,9 +78,7 @@ class SimpleMoleculeMolGraphFeaturizer(_MolGraphFeaturizerMixin, GraphFeaturizer
 
                 x_e = self.bond_featurizer(bond)
                 if bond_features_extra is not None:
-                    x_e = np.concatenate(
-                        (x_e, bond_features_extra[bond.GetIdx()]), dtype=np.single
-                    )
+                    x_e = np.concatenate((x_e, bond_features_extra[bond.GetIdx()]), dtype=np.single)
 
                 E[i : i + 2] = x_e
 

--- a/chemprop/featurizers/molgraph/molecule.py
+++ b/chemprop/featurizers/molgraph/molecule.py
@@ -60,9 +60,9 @@ class SimpleMoleculeMolGraphFeaturizer(_MolGraphFeaturizerMixin, GraphFeaturizer
             )
 
         if n_atoms == 0:
-            V = np.zeros((1, self.atom_fdim))
+            V = np.zeros((1, self.atom_fdim)).astype(np.float32)
         else:
-            V = np.array([self.atom_featurizer(a) for a in mol.GetAtoms()])
+            V = np.array([self.atom_featurizer(a) for a in mol.GetAtoms()]).astype(np.float32)
         E = np.empty((2 * n_bonds, self.bond_fdim))
         edge_index = [[], []]
 
@@ -78,7 +78,9 @@ class SimpleMoleculeMolGraphFeaturizer(_MolGraphFeaturizerMixin, GraphFeaturizer
 
                 x_e = self.bond_featurizer(bond)
                 if bond_features_extra is not None:
-                    x_e = np.concatenate((x_e, bond_features_extra[bond.GetIdx()]))
+                    x_e = np.concatenate(
+                        (x_e, bond_features_extra[bond.GetIdx()]), dtype=np.float32
+                    )
 
                 E[i : i + 2] = x_e
 


### PR DESCRIPTION
## Description
MPS framework doesn't support float64. Some attributes in a datapoint are saved as float64. Converting them to float32 can solve this issue.

## Relevant issues
#711 

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
