### PR TITLE
Tidy up float parameter default values

### DIFF
--- a/chemprop/data/datapoints.py
+++ b/chemprop/data/datapoints.py
@@ -17,7 +17,7 @@ class _DatapointMixin:
 
     y: np.ndarray | None = None
     """the targets for the molecule with unknown targets indicated by `nan`s"""
-    weight: float = 1.
+    weight: float = 1.0
     """the weight of this datapoint for the loss calculation."""
     gt_mask: np.ndarray | None = None
     """Indicates whether the targets are an inequality regression target of the form `<x`"""

--- a/chemprop/data/datapoints.py
+++ b/chemprop/data/datapoints.py
@@ -17,7 +17,7 @@ class _DatapointMixin:
 
     y: np.ndarray | None = None
     """the targets for the molecule with unknown targets indicated by `nan`s"""
-    weight: float = 1
+    weight: float = 1.
     """the weight of this datapoint for the loss calculation."""
     gt_mask: np.ndarray | None = None
     """Indicates whether the targets are an inequality regression target of the form `<x`"""

--- a/chemprop/nn/agg.py
+++ b/chemprop/nn/agg.py
@@ -103,7 +103,7 @@ class NormAggregation(SumAggregation):
         \mathbf h = \frac{1}{c} \sum_{v \in V} \mathbf h_v
     """
 
-    def __init__(self, dim: int = 0, *args, norm: float = 100, **kwargs):
+    def __init__(self, dim: int = 0, *args, norm: float = 100., **kwargs):
         super().__init__(dim, **kwargs)
 
         self.norm = norm

--- a/chemprop/nn/agg.py
+++ b/chemprop/nn/agg.py
@@ -103,7 +103,7 @@ class NormAggregation(SumAggregation):
         \mathbf h = \frac{1}{c} \sum_{v \in V} \mathbf h_v
     """
 
-    def __init__(self, dim: int = 0, *args, norm: float = 100., **kwargs):
+    def __init__(self, dim: int = 0, *args, norm: float = 100.0, **kwargs):
         super().__init__(dim, **kwargs)
 
         self.norm = norm

--- a/chemprop/nn/message_passing/base.py
+++ b/chemprop/nn/message_passing/base.py
@@ -30,7 +30,7 @@ class _MessagePassingBase(MessagePassing, HyperparametersMixin):
         the number of message passing iterations
     undirected : bool, default=False
         if `True`, pass messages on undirected edges
-    dropout : float, default=0
+    dropout : float, default=0.0
         the dropout probability
     activation : str, default="relu"
         the activation function to use
@@ -51,7 +51,7 @@ class _MessagePassingBase(MessagePassing, HyperparametersMixin):
         d_h: int = DEFAULT_HIDDEN_DIM,
         bias: bool = False,
         depth: int = 3,
-        dropout: float = 0,
+        dropout: float = 0.0,
         activation: str | Activation = Activation.RELU,
         undirected: bool = False,
         d_vd: int | None = None,

--- a/chemprop/nn/predictors.py
+++ b/chemprop/nn/predictors.py
@@ -83,7 +83,7 @@ class _FFNPredictorBase(Predictor, HyperparametersMixin):
         input_dim: int = DEFAULT_HIDDEN_DIM,
         hidden_dim: int = 300,
         n_layers: int = 1,
-        dropout: float = 0,
+        dropout: float = 0.0,
         activation: str = "relu",
         criterion: LossFunction | None = None,
     ):
@@ -130,7 +130,7 @@ class RegressionFFN(_FFNPredictorBase):
         input_dim: int = DEFAULT_HIDDEN_DIM,
         hidden_dim: int = 300,
         n_layers: int = 1,
-        dropout: float = 0,
+        dropout: float = 0.0,
         activation: str = "relu",
         criterion: LossFunction | None = None,
         loc: float | Tensor = 0.0,
@@ -256,7 +256,7 @@ class MulticlassClassificationFFN(_FFNPredictorBase):
         input_dim: int = DEFAULT_HIDDEN_DIM,
         hidden_dim: int = 300,
         n_layers: int = 1,
-        dropout: float = 0,
+        dropout: float = 0.0,
         activation: str = "relu",
         criterion: LossFunction | None = None,
     ):


### PR DESCRIPTION
## Description
This tiny PR addresses #686 and tidies up initialization of some previous arguments that are meant to be floats but were initialized as ints. Specifically, weight in `_DatapointMixin`, norm in `NormAggregation`, and dropout in both `predictor.py` and `base.py` had their default values updated to be floats. 

## Relevant issues
#686 

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
