### PR TITLE
clean up column names

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -843,6 +843,8 @@ def train_model(args, train_loader, val_loader, test_loader, output_dir, scaler,
                     args.reaction_columns,
                     args.target_columns,
                     args.ignore_columns,
+                    args.splits_column,
+                    args.weight_column,
                     args.no_header_row,
                 )
                 names = test_loader.dataset.names

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -50,7 +50,11 @@ def parse_csv(
 
     if target_cols is None:
         target_cols = list(
-            set(df.columns) - set(input_cols) - set(ignore_cols or []) - set(splits_col or [])
+            set(df.columns)
+            - set(input_cols)
+            - set(ignore_cols or [])
+            - set(splits_col or [])
+            - set(weight_col or [])
         )
 
     Y = df[target_cols]
@@ -74,9 +78,14 @@ def get_column_names(
     rxn_cols: Sequence[str] | None,
     target_cols: Sequence[str] | None,
     ignore_cols: Sequence[str] | None,
+    splits_col: str | None,
+    weight_col: str | None,
     no_header_row: bool = False,
 ):
     df = pd.read_csv(path, header=None if no_header_row else "infer", index_col=False)
+
+    if no_header_row:
+        return ["SMILES"] + ["pred_" + str(i) for i in range((len(df.columns) - 1))]
 
     input_cols = []
 
@@ -86,20 +95,18 @@ def get_column_names(
         input_cols.extend(rxn_cols)
 
     if len(input_cols) == 0:
-        if no_header_row:
-            input_cols = ["SMILES"]
-        else:
-            input_cols = [df.columns[0]]
+        input_cols = [df.columns[0]]
 
     if target_cols is None:
-        if no_header_row:
-            ignore_len = len(ignore_cols) if ignore_cols else 0
-            ["pred_" + str(i) for i in range((len(df.columns) - len(input_cols) - ignore_len))]
-        else:
-            target_cols = list(set(df.columns) - set(input_cols) - set(ignore_cols or []))
+        target_cols = list(
+            set(df.columns)
+            - set(input_cols)
+            - set(ignore_cols or [])
+            - set(splits_col or [])
+            - set(weight_col or [])
+        )
 
-    cols = input_cols + target_cols
-    return cols
+    return input_cols + target_cols
 
 
 def make_datapoints(

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -87,12 +87,7 @@ def get_column_names(
     if no_header_row:
         return ["SMILES"] + ["pred_" + str(i) for i in range((len(df.columns) - 1))]
 
-    input_cols = []
-
-    if smiles_cols is not None:
-        input_cols.extend(smiles_cols)
-    if rxn_cols is not None:
-        input_cols.extend(rxn_cols)
+    input_cols = (smiles_cols or []) + (rxn_cols or [])
 
     if len(input_cols) == 0:
         input_cols = [df.columns[0]]

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -220,6 +220,7 @@ def test_train_csv_splits(monkeypatch, data_dir, tmp_path):
         "0",
         "--save-dir",
         str(tmp_path),
+        "--save-preds",
     ]
 
     with monkeypatch.context() as m:


### PR DESCRIPTION
I introduced a bug where having a splits column wasn't accounted for in get column names. I also saw it was missing the weights column so added that. And generally tried to make the code more concise. Note that if there is no header row, it doesn't make sense to use any of the column CLI args (--smiles-columns, etc.) because there are no headers to reference.