### PR TITLE
V2: Fix reaction scaling

### DIFF
--- a/chemprop/data/datasets.py
+++ b/chemprop/data/datasets.py
@@ -355,7 +355,7 @@ class ReactionDataset(_MolGraphDatasetMixin, MolGraphDataset):
         d = self.data[idx]
         mg = self.mg_cache[idx]
 
-        return Datum(mg, None, d.x_d, d.y, d.weight, d.lt_mask, d.gt_mask)
+        return Datum(mg, None, self.X_d[idx], self.Y[idx], d.weight, d.lt_mask, d.gt_mask)
 
     @property
     def smiles(self) -> list[tuple]:


### PR DESCRIPTION
## Description
@am2145 found that the reaction prediction gives unreasonable values during benchmarking. We reduce the problem down to something is wrong with the scaler. However, it doesn't affect the molecule prediction. We eventually found that it is because `__getitem__` is pulling the wrong values for reaction dataset.

## Example / Current workflow
n/a

## Bugfix / Desired workflow
We should get the inputs and the targets from the dataset, but not the datapoint raw values for training.

## Questions
n/a

## Relevant issues
n/a

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
