### PR TITLE
Pass kwargs through to DataLoader in MolGraphDataLoader

### DIFF
--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -149,9 +149,7 @@ def make_fingerprint_for_model(
     if V_d_scaler is not None:
         test_dset.normalize_inputs("V_d", V_d_scaler)
 
-    test_loader = data.build_dataloader(
-        test_dset, args.batch_size, args.num_workers, shuffle=False
-    )
+    test_loader = data.build_dataloader(test_dset, args.batch_size, args.num_workers, shuffle=False)
 
     logger.info(model)
 

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -149,7 +149,7 @@ def make_fingerprint_for_model(
     if V_d_scaler is not None:
         test_dset.normalize_inputs("V_d", V_d_scaler)
 
-    test_loader = data.MolGraphDataLoader(
+    test_loader = data.build_dataloader(
         test_dset, args.batch_size, args.num_workers, shuffle=False
     )
 

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -250,10 +250,10 @@ def update_args_with_config(args: Namespace, config: dict) -> Namespace:
 def train_model(config, args, train_dset, val_dset, logger):
     update_args_with_config(args, config)
 
-    train_loader = MolGraphDataLoader(
+    train_loader = build_dataloader(
         train_dset, args.batch_size, args.num_workers, seed=args.data_seed
     )
-    val_loader = MolGraphDataLoader(val_dset, args.batch_size, args.num_workers, shuffle=False)
+    val_loader = build_dataloader(val_dset, args.batch_size, args.num_workers, shuffle=False)
 
     seed = args.pytorch_seed if args.pytorch_seed is not None else torch.seed()
 

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -20,7 +20,7 @@ from chemprop.cli.train import (
     validate_train_args,
 )
 from chemprop.cli.utils.command import Subcommand
-from chemprop.data import MolGraphDataLoader
+from chemprop.data import build_dataloader
 from chemprop.nn import AggregationRegistry
 from chemprop.nn.utils import Activation
 
@@ -373,10 +373,10 @@ def main(args: Namespace):
     else:
         scaler = None
 
-    train_loader = MolGraphDataLoader(
+    train_loader = build_dataloader(
         train_dset, args.batch_size, args.num_workers, seed=args.data_seed
     )
-    val_loader = MolGraphDataLoader(val_dset, args.batch_size, args.num_workers, shuffle=False)
+    val_loader = build_dataloader(val_dset, args.batch_size, args.num_workers, shuffle=False)
 
     seed = args.pytorch_seed if args.pytorch_seed is not None else torch.seed()
 

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -257,9 +257,7 @@ def make_prediction_for_model(
     # else:
     #     cal_data = None
 
-    test_loader = data.build_dataloader(
-        test_dset, args.batch_size, args.num_workers, shuffle=False
-    )
+    test_loader = data.build_dataloader(test_dset, args.batch_size, args.num_workers, shuffle=False)
     # TODO: add uncertainty and calibration
     # if cal_data is not None:
     #     cal_dset = make_dataset(cal_data, bond_messages, args.rxn_mode)

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -257,13 +257,13 @@ def make_prediction_for_model(
     # else:
     #     cal_data = None
 
-    test_loader = data.MolGraphDataLoader(
+    test_loader = data.build_dataloader(
         test_dset, args.batch_size, args.num_workers, shuffle=False
     )
     # TODO: add uncertainty and calibration
     # if cal_data is not None:
     #     cal_dset = make_dataset(cal_data, bond_messages, args.rxn_mode)
-    #     cal_loader = data.MolGraphDataLoader(cal_dset, args.batch_size, args.num_workers, shuffle=False)
+    #     cal_loader = data.build_dataloader(cal_dset, args.batch_size, args.num_workers, shuffle=False)
     # else:
     #     cal_loader = None
 

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -12,7 +12,7 @@ from lightning.pytorch.callbacks import ModelCheckpoint, EarlyStopping
 import torch
 
 from chemprop.data import (
-    MolGraphDataLoader,
+    build_dataloader,
     MolGraphDataset,
     MulticomponentDataset,
     MoleculeDataset,
@@ -442,7 +442,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         "--data-seed",
         type=int,
         default=0,
-        help="Random seed to use when splitting data into train/val/test sets. When :code`num_folds > 1`, the first fold uses this seed and all subsequent folds add 1 to the seed. Also used for shuffling data in :code:`MolGraphDataLoader` when :code:`shuffle` is True.",
+        help="Random seed to use when splitting data into train/val/test sets. When :code`num_folds > 1`, the first fold uses this seed and all subsequent folds add 1 to the seed. Also used for shuffling data in :code:`build_dataloader` when :code:`shuffle` is True.",
     )
 
     parser.add_argument(
@@ -912,12 +912,12 @@ def main(args):
         else:
             scaler = None
 
-        train_loader = MolGraphDataLoader(
+        train_loader = build_dataloader(
             train_dset, args.batch_size, args.num_workers, seed=args.data_seed
         )
-        val_loader = MolGraphDataLoader(val_dset, args.batch_size, args.num_workers, shuffle=False)
+        val_loader = build_dataloader(val_dset, args.batch_size, args.num_workers, shuffle=False)
         if test_dset is not None:
-            test_loader = MolGraphDataLoader(
+            test_loader = build_dataloader(
                 test_dset, args.batch_size, args.num_workers, shuffle=False
             )
         else:

--- a/chemprop/data/__init__.py
+++ b/chemprop/data/__init__.py
@@ -1,5 +1,5 @@
 from .collate import BatchMolGraph, TrainingBatch, collate_batch, collate_multicomponent
-from .dataloader import MolGraphDataLoader
+from .dataloader import build_dataloader
 from .datapoints import MoleculeDatapoint, ReactionDatapoint
 from .datasets import (
     MoleculeDataset,
@@ -17,7 +17,7 @@ __all__ = [
     "TrainingBatch",
     "collate_batch",
     "collate_multicomponent",
-    "MolGraphDataLoader",
+    "build_dataloader",
     "MoleculeDatapoint",
     "ReactionDatapoint",
     "MoleculeDataset",

--- a/chemprop/data/dataloader.py
+++ b/chemprop/data/dataloader.py
@@ -7,16 +7,23 @@ from chemprop.data.datasets import MoleculeDataset, MulticomponentDataset, React
 from chemprop.data.samplers import ClassBalanceSampler, SeededSampler
 
 
-class MolGraphDataLoader(DataLoader):
-    """A :class:`MolGraphDataLoader` is a :obj:`~torch.utils.data.DataLoader` for
-    :class:`MolGraphDataset`\s
+def MolGraphDataLoader(
+    dataset: MoleculeDataset | ReactionDataset | MulticomponentDataset,
+    batch_size: int = 50,
+    num_workers: int = 0,
+    class_balance: bool = False,
+    seed: int | None = None,
+    shuffle: bool = True,
+    **kwargs,
+):
+    """Return a :obj:`~torch.utils.data.DataLoader` for :class:`MolGraphDataset`\s
 
     Parameters
     ----------
-    dataset : MoleculeDataset
-        The dataset containing the molecules to load.
+    dataset : MoleculeDataset | ReactionDataset | MulticomponentDataset
+        The dataset containing the molecules or reactions to load.
     batch_size : int, default=50
-        the batch size to load
+        the batch size to load.
     num_workers : int, default=0
         the number of workers used to build batches.
     class_balance : bool, default=False
@@ -24,58 +31,39 @@ class MolGraphDataLoader(DataLoader):
         molecules). Class balance is only available for single task classification datasets. Set
         shuffle to True in order to get a random subset of the larger class.
     seed : int, default=None
-        the random seed to use for shuffling (only used when `shuffle` is `True`)
+        the random seed to use for shuffling (only used when `shuffle` is `True`).
     shuffle : bool, default=False
-        whether to shuffle the data during sampling
+        whether to shuffle the data during sampling.
     """
 
-    def __init__(
-        self,
-        dataset: MoleculeDataset | ReactionDataset | MulticomponentDataset,
-        batch_size: int = 50,
-        num_workers: int = 0,
-        class_balance: bool = False,
-        seed: int | None = None,
-        shuffle: bool = True,
-        **kwargs,
-    ):
-        if "sampler" in kwargs:
-            sampler = kwargs.pop("sampler")
-        else:
-            if class_balance:
-                sampler = ClassBalanceSampler(dataset.Y, seed, shuffle)
-            elif shuffle and seed is not None:
-                sampler = SeededSampler(len(dataset), seed)
-            else:
-                sampler = None
+    if class_balance:
+        sampler = ClassBalanceSampler(dataset.Y, seed, shuffle)
+    elif shuffle and seed is not None:
+        sampler = SeededSampler(len(dataset), seed)
+    else:
+        sampler = None
 
-        if "collate_fn" in kwargs:
-            collate_fn = kwargs.pop("collate_fn")
-        else:
-            if isinstance(dataset, MulticomponentDataset):
-                collate_fn = collate_multicomponent
-            else:
-                collate_fn = collate_batch
+    if isinstance(dataset, MulticomponentDataset):
+        collate_fn = collate_multicomponent
+    else:
+        collate_fn = collate_batch
 
-        if "drop_last" in kwargs:
-            drop_last = kwargs.pop("drop_last")
-        else:
-            if len(dataset) % batch_size == 1:
-                warnings.warn(
-                    "Dropping last batch of size 1 to avoid issues with batch normalization "
-                    f"(dataset size = {len(dataset)}, batch_size = {batch_size})"
-                )
-                drop_last = True
-            else:
-                drop_last = False
-
-        super().__init__(
-            dataset,
-            batch_size,
-            sampler is None and shuffle,
-            sampler,
-            num_workers=num_workers,
-            collate_fn=collate_fn,
-            drop_last=drop_last,
-            **kwargs,
+    if len(dataset) % batch_size == 1:
+        warnings.warn(
+            f"Dropping last batch of size 1 to avoid issues with batch normalization \
+(dataset size = {len(dataset)}, batch_size = {batch_size})"
         )
+        drop_last = True
+    else:
+        drop_last = False
+
+    return DataLoader(
+        dataset,
+        batch_size,
+        sampler is None and shuffle,
+        sampler,
+        num_workers=num_workers,
+        collate_fn=collate_fn,
+        drop_last=drop_last,
+        **kwargs,
+    )

--- a/chemprop/data/dataloader.py
+++ b/chemprop/data/dataloader.py
@@ -7,7 +7,7 @@ from chemprop.data.datasets import MoleculeDataset, MulticomponentDataset, React
 from chemprop.data.samplers import ClassBalanceSampler, SeededSampler
 
 
-def MolGraphDataLoader(
+def build_dataloader(
     dataset: MoleculeDataset | ReactionDataset | MulticomponentDataset,
     batch_size: int = 50,
     num_workers: int = 0,

--- a/docs/source/tutorial/python/index.rst
+++ b/docs/source/tutorial/python/index.rst
@@ -48,7 +48,7 @@ Next, we load the data from a CSV file and split it into training, validation, a
   train_data, val_test_data = train_test_split(all_data, test_size=0.1)
   val_data, test_data = train_test_split(val_test_data, test_size=0.5)
 
-We then create :code:`MoleculeDataset` objects from the data and use them to create :code:`MolGraphDataLoader` objects, which are PyTorch :code:`DataLoader` objects that can be used to train the model.
+We then create :code:`MoleculeDataset` objects from the data and use them to create PyTorch :code:`DataLoader` objects that can be used to train the model.
 
 .. code-block::
 
@@ -59,9 +59,9 @@ We then create :code:`MoleculeDataset` objects from the data and use them to cre
   test_dset = data.MoleculeDataset(test_data, featurizer)
   test_dset.normalize_targets(scaler)
 
-  train_loader = data.MolGraphDataLoader(train_dset, num_workers=args.num_workers)
-  val_loader = data.MolGraphDataLoader(val_dset, num_workers=args.num_workers, shuffle=False)
-  test_loader = data.MolGraphDataLoader(test_dset, num_workers=args.num_workers, shuffle=False)
+  train_loader = data.build_dataloader(train_dset, num_workers=args.num_workers)
+  val_loader = data.build_dataloader(val_dset, num_workers=args.num_workers, shuffle=False)
+  test_loader = data.build_dataloader(test_dset, num_workers=args.num_workers, shuffle=False)
 
 Finally, we train the model and evaluate it on the test set.
 

--- a/examples/mpnn_fingerprints.ipynb
+++ b/examples/mpnn_fingerprints.ipynb
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "test_dset = data.MoleculeDataset(test_data, featurizer=featurizer)\n",
-    "test_loader = data.MolGraphDataLoader(test_dset, shuffle=False)"
+    "test_loader = data.build_dataloader(test_dset, shuffle=False)"
    ]
   },
   {

--- a/examples/predicting.ipynb
+++ b/examples/predicting.ipynb
@@ -293,7 +293,7 @@
             "source": [
                 "featurizer = featurizers.SimpleMoleculeMolGraphFeaturizer()\n",
                 "test_dset = data.MoleculeDataset(test_data, featurizer=featurizer)\n",
-                "test_loader = data.MolGraphDataLoader(test_dset, shuffle=False)"
+                "test_loader = data.build_dataloader(test_dset, shuffle=False)"
             ]
         },
         {

--- a/examples/predicting_regression_multicomponent.ipynb
+++ b/examples/predicting_regression_multicomponent.ipynb
@@ -336,7 +336,7 @@
             "outputs": [],
             "source": [
                 "test_mcdset = data.MulticomponentDataset(test_dsets)\n",
-                "test_loader = data.MolGraphDataLoader(test_mcdset, shuffle=False)"
+                "test_loader = data.build_dataloader(test_mcdset, shuffle=False)"
             ]
         },
         {

--- a/examples/predicting_regression_reaction.ipynb
+++ b/examples/predicting_regression_reaction.ipynb
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "test_dset = data.ReactionDataset(test_data, featurizer=featurizer)\n",
-    "test_loader = data.MolGraphDataLoader(test_dset, shuffle=False)"
+    "test_loader = data.build_dataloader(test_dset, shuffle=False)"
    ]
   },
   {

--- a/examples/training.ipynb
+++ b/examples/training.ipynb
@@ -353,9 +353,9 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "train_loader = data.MolGraphDataLoader(train_dset, num_workers=num_workers)\n",
-                "val_loader = data.MolGraphDataLoader(val_dset, num_workers=num_workers, shuffle=False)\n",
-                "test_loader = data.MolGraphDataLoader(test_dset, num_workers=num_workers, shuffle=False)"
+                "train_loader = data.build_dataloader(train_dset, num_workers=num_workers)\n",
+                "val_loader = data.build_dataloader(val_dset, num_workers=num_workers, shuffle=False)\n",
+                "test_loader = data.build_dataloader(test_dset, num_workers=num_workers, shuffle=False)"
             ]
         },
         {

--- a/examples/training_regression_multicomponent.ipynb
+++ b/examples/training_regression_multicomponent.ipynb
@@ -350,9 +350,9 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "train_loader = data.MolGraphDataLoader(train_mcdset)\n",
-                "val_loader = data.MolGraphDataLoader(val_mcdset, shuffle=False)\n",
-                "test_loader = data.MolGraphDataLoader(test_mcdset, shuffle=False)"
+                "train_loader = data.build_dataloader(train_mcdset)\n",
+                "val_loader = data.build_dataloader(val_mcdset, shuffle=False)\n",
+                "test_loader = data.build_dataloader(test_mcdset, shuffle=False)"
             ]
         },
         {

--- a/examples/training_regression_reaction.ipynb
+++ b/examples/training_regression_reaction.ipynb
@@ -343,9 +343,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_loader = data.MolGraphDataLoader(train_dset, num_workers=num_workers)\n",
-    "val_loader = data.MolGraphDataLoader(val_dset, num_workers=num_workers, shuffle=False)\n",
-    "test_loader = data.MolGraphDataLoader(test_dset, num_workers=num_workers, shuffle=False)"
+    "train_loader = data.build_dataloader(train_dset, num_workers=num_workers)\n",
+    "val_loader = data.build_dataloader(val_dset, num_workers=num_workers, shuffle=False)\n",
+    "test_loader = data.build_dataloader(test_dset, num_workers=num_workers, shuffle=False)"
    ]
   },
   {

--- a/tests/unit/utils/test_converter.py
+++ b/tests/unit/utils/test_converter.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from lightning import pytorch as pl
 
-from chemprop.data.dataloader import MolGraphDataLoader
+from chemprop.data.dataloader import build_dataloader
 from chemprop.data.datapoints import MoleculeDatapoint
 from chemprop.data.datasets import MoleculeDataset
 from chemprop.featurizers.molgraph.molecule import SimpleMoleculeMolGraphFeaturizer
@@ -34,7 +34,7 @@ def example_model_v1_prediction(data_dir):
     test_data = [MoleculeDatapoint.from_smi(smi, None) for smi in smis]
     test_dset = MoleculeDataset(test_data, featurizer)
 
-    test_loader = MolGraphDataLoader(test_dset, shuffle=False)
+    test_loader = build_dataloader(test_dset, shuffle=False)
     return ys, test_loader
 
 

--- a/tests/unit/utils/test_converter.py
+++ b/tests/unit/utils/test_converter.py
@@ -34,7 +34,7 @@ def example_model_v1_prediction(data_dir):
     test_data = [MoleculeDatapoint.from_smi(smi, None) for smi in smis]
     test_dset = MoleculeDataset(test_data, featurizer)
 
-    test_loader = MolGraphDataLoader(test_dset)
+    test_loader = MolGraphDataLoader(test_dset, shuffle=False)
     return ys, test_loader
 
 


### PR DESCRIPTION
Currently `trainer.predict` uses a batch size of 1 when given a `MolGraphDataLoader`. Simple code to reproduce:
```
from lightning import pytorch as pl
from chemprop import nn
from chemprop.models import MPNN

mp = nn.BondMessagePassing()
agg = nn.MeanAggregation()
ffn = nn.RegressionFFN()
mpnn = MPNN(mp, agg, ffn)
trainer = pl.Trainer()

import torch
from chemprop.data import MoleculeDatapoint, MoleculeDataset, MolGraphDataLoader
from chemprop.featurizers import SimpleMoleculeMolGraphFeaturizer
fake_data = [MoleculeDatapoint.from_smi('C', torch.tensor([1])), MoleculeDatapoint.from_smi('C', torch.tensor([2]))]
featurizer = SimpleMoleculeMolGraphFeaturizer()
fake_dset = MoleculeDataset(fake_data, featurizer)
fake_loader = MolGraphDataLoader(fake_dset, shuffle=False)

trainer.test(mpnn, fake_loader)
trainer.predict(mpnn, fake_loader)
```

Also add `print(targets)`/`print(Y)` to MPNN like this:
```
    def _evaluate_batch(self, batch) -> list[Tensor]:
        bmg, V_d, X_d, targets, _, lt_mask, gt_mask = batch
        print(targets)
        mask = targets.isfinite()
        targets = targets.nan_to_num(nan=0.0)
        preds = self(bmg, V_d, X_d)

        return [
            metric(preds, targets, mask, None, None, lt_mask, gt_mask)
            for metric in self.metrics[:-1]
        ]

    def predict_step(self, batch: TrainingBatch, batch_idx: int, dataloader_idx: int = 0) -> Tensor:
        """Return the predictions of the input batch

        Parameters
        ----------
        batch : TrainingBatch
            the input batch

        Returns
        -------
        Tensor
            a tensor of varying shape depending on the task type:

            * regression/binary classification: ``n x (t * s)``, where ``n`` is the number of input
            molecules/reactions, ``t`` is the number of tasks, and ``s`` is the number of targets
            per task. The final dimension is flattened, so that the targets for each task are
            grouped. I.e., the first ``t`` elements are the first target for each task, the second
            ``t`` elements the second target, etc.
            * multiclass classification: ``n x t x c``, where ``c`` is the number of classes
        """
        bmg, X_vd, X_d, Y, *_ = batch
        print(Y)

        return self(bmg, X_vd, X_d)
```

You'll see `trainer.test` prints 
```
tensor([[1.],
        [2.]])
```
while `trainer.predict` prints
```
tensor([[1.]])
tensor([[2.]])
```

The batch size of 1 makes prediction slower so we want to fix it.

The problem has to do with `batch_sampler`. In `MolGraphDataLoader` we don't accept `batch_sampler` as an argument (except in **kwargs, which will be important), and we don't give a batch sampler to pytorch.DataLoader in the `super().__init__()`. This means pytorch will automaticaly make us a `SequentialSampler` (when shuffle=False like for a test_loader, see [here](https://github.com/pytorch/pytorch/blob/cc66c43d51e5cba234e1f84a1155c12ac4c86a3f/torch/utils/data/dataloader.py#L352)). 

During prediction, lightning [reconstructs](https://github.com/Lightning-AI/pytorch-lightning/blob/c235f20e7131af2c7be4cc9080d3c946d93d58ea/src/lightning/pytorch/utilities/data.py#L323) the data loader for us for their purposes (I think for distributed predicting). This means they turn the `SequentialSampler` from pytorch into a `_IndexBatchSamplerWrapper` (which I think keeps track of the original batch size) and gives that back to our data loader class to make a new loader. But `MolGraphDataLoader` doesn't take `batch_sampler` so it winds up in `**kwargs` which isn't used. 

For pytorch data loaders, the "batch_sampler option is mutually exclusive with batch_size, shuffle, sampler, and drop_last" [(link)](https://github.com/Lightning-AI/pytorch-lightning/blob/c235f20e7131af2c7be4cc9080d3c946d93d58ea/src/lightning/pytorch/utilities/data.py#L326) so lighting also turns these off by setting sampler to None, shuffle to False, drop_last to False, and importantly batch_size to 1. `MolGraphDataLoader` does take the batch_size argument so that gets passed through while the batch_sampler does not. 

The fix then is to pass `**kwargs` through to the super().__init(). But special consideration is needed as `sampler`, `collate_fn` and `drop_last` are created by `MolGraphDataLoader` so the values in `kwargs` would be duplicates. I added a check to pop them out of kwargs if they are given. Alternatively we could just delete them from kwargs as they are recreated by `MolGraphDataLoader`. 

Side note, `MolGraphDataLoader` gave us a bit of hassle here, so a question is if we want to remove it entirely. My vote is to keep it because it handles collate_fn and drop_last (for training with a batch norm layer), both of which, I wouldn't expect a basic user to know they need to handle. 

These changes made `trainer.predict` on my dataset of ~45,000 molecules go from taking 2 minutes to 7 seconds, the difference of using a batch size of 1 vs 50. 