### PR TITLE
fix dataloader batch size

### DIFF
--- a/chemprop/data/dataloader.py
+++ b/chemprop/data/dataloader.py
@@ -9,7 +9,7 @@ from chemprop.data.samplers import ClassBalanceSampler, SeededSampler
 
 def build_dataloader(
     dataset: MoleculeDataset | ReactionDataset | MulticomponentDataset,
-    batch_size: int = 50,
+    batch_size: int = 64,
     num_workers: int = 0,
     class_balance: bool = False,
     seed: int | None = None,
@@ -22,7 +22,7 @@ def build_dataloader(
     ----------
     dataset : MoleculeDataset | ReactionDataset | MulticomponentDataset
         The dataset containing the molecules or reactions to load.
-    batch_size : int, default=50
+    batch_size : int, default=64
         the batch size to load.
     num_workers : int, default=0
         the number of workers used to build batches.


### PR DESCRIPTION
We changed the default batch size in the CLI to 64 [here](https://github.com/chemprop/chemprop/blob/4bba6776e248fc4440a3c279aeb790d252fce818/chemprop/cli/common.py#L41), but we didn't change it in dataloaders.py