### PR TITLE
Add default task weights 

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -763,10 +763,7 @@ def build_model(
     else:
         criterion = None
     if args.metrics is not None:
-        metrics = [
-            Factory.build(MetricRegistry[metric], task_weights=torch.Tensor([1.0]))
-            for metric in args.metrics
-        ]
+        metrics = [Factory.build(MetricRegistry[metric]) for metric in args.metrics]
     else:
         metrics = None
 

--- a/chemprop/models/model.py
+++ b/chemprop/models/model.py
@@ -89,7 +89,7 @@ class MPNN(pl.LightningModule):
         self.metrics = (
             [*metrics, self.criterion]
             if metrics
-            else [self.predictor._T_default_metric(torch.Tensor([1])), self.criterion]
+            else [self.predictor._T_default_metric(), self.criterion]
         )
 
         self.warmup_epochs = warmup_epochs

--- a/chemprop/nn/loss.py
+++ b/chemprop/nn/loss.py
@@ -32,11 +32,11 @@ class LossFunction(nn.Module):
         """
         Parameters
         ----------
-        task_weights :  ArrayLike = 1.0
+        task_weights :  ArrayLike, default=1.0
             the per-task weights of shape `t` or `1 x t`. Defaults to all tasks having a weight of 1.
         """
         super().__init__()
-        task_weights = torch.as_tensor(task_weights, dtype=torch.float32).view(1, -1)
+        task_weights = torch.as_tensor(task_weights, dtype=torch.float).view(1, -1)
         self.register_buffer("task_weights", task_weights)
 
     def forward(
@@ -82,7 +82,7 @@ class LossFunction(nn.Module):
         """Calculate a tensor of shape `b x t` containing the unreduced loss values."""
 
     def extra_repr(self) -> str:
-        return f"task_weights={self.task_weights}"
+        return f"task_weights={self.task_weights.tolist()}"
 
 
 LossFunctionRegistry = ClassRegistry[LossFunction]()

--- a/chemprop/nn/loss.py
+++ b/chemprop/nn/loss.py
@@ -27,15 +27,19 @@ __all__ = [
 
 
 class LossFunction(nn.Module):
-    def __init__(self, task_weights: Tensor):
+    def __init__(self, task_weights: Tensor | None = None):
         """
         Parameters
         ----------
-        task_weights : Tensor
-            a tensor of shape `t` or `1 x t` containing the per-task weight.
+        task_weights : Tensor | None = None
+            a tensor of shape `t` or `1 x t` containing the per-task weight. If None, defaults to
+            all tasks having a weight of 1.
         """
         super().__init__()
-        task_weights = torch.as_tensor(task_weights, dtype=torch.float32).view(1, -1)
+        if task_weights is None:
+            task_weights = torch.ones(1).view(1, -1)
+        else:
+            task_weights = torch.as_tensor(task_weights, dtype=torch.float32).view(1, -1)
         self.register_buffer("task_weights", task_weights)
 
     def forward(
@@ -81,6 +85,8 @@ class LossFunction(nn.Module):
         """Calculate a tensor of shape `b x t` containing the unreduced loss values."""
 
     def extra_repr(self) -> str:
+        if self.task_weights == torch.ones(1).view(1, -1):
+            return ""
         return f"task_weights={self.task_weights.tolist()}"
 
 
@@ -252,7 +258,6 @@ class DirichletMixin:
     """
 
     def __init__(self, task_weights: Tensor | None = None, v_kl: float = 0.2):
-        task_weights = torch.tensor([1.0])
         super().__init__(task_weights)
         self.v_kl = v_kl
 

--- a/chemprop/nn/loss.py
+++ b/chemprop/nn/loss.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 import torch
 from torch import Tensor, nn
 from torch.nn import functional as F
+from numpy.typing import ArrayLike
 
 from chemprop.utils import ClassRegistry
 
@@ -27,19 +28,15 @@ __all__ = [
 
 
 class LossFunction(nn.Module):
-    def __init__(self, task_weights: Tensor | None = None):
+    def __init__(self, task_weights: ArrayLike = 1.0):
         """
         Parameters
         ----------
-        task_weights : Tensor | None = None
-            a tensor of shape `t` or `1 x t` containing the per-task weight. If None, defaults to
-            all tasks having a weight of 1.
+        task_weights :  ArrayLike = 1.0
+            the per-task weights of shape `t` or `1 x t`. Defaults to all tasks having a weight of 1.
         """
         super().__init__()
-        if task_weights is None:
-            task_weights = torch.ones(1).view(1, -1)
-        else:
-            task_weights = torch.as_tensor(task_weights, dtype=torch.float32).view(1, -1)
+        task_weights = torch.as_tensor(task_weights, dtype=torch.float32).view(1, -1)
         self.register_buffer("task_weights", task_weights)
 
     def forward(
@@ -85,9 +82,7 @@ class LossFunction(nn.Module):
         """Calculate a tensor of shape `b x t` containing the unreduced loss values."""
 
     def extra_repr(self) -> str:
-        if self.task_weights == torch.ones(1).view(1, -1):
-            return ""
-        return f"task_weights={self.task_weights.tolist()}"
+        return f"task_weights={self.task_weights}"
 
 
 LossFunctionRegistry = ClassRegistry[LossFunction]()

--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -45,8 +45,6 @@ __all__ = [
 
 class Metric(LossFunction):
     """
-    __init__(self, task_weights: ArrayLike = 1.0):
-
     Parameters
     ----------
     task_weights :  ArrayLike = 1.0

--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -44,6 +44,15 @@ __all__ = [
 
 
 class Metric(LossFunction):
+    """
+    __init__(self, task_weights: ArrayLike = 1.0):
+
+    Parameters
+    ----------
+    task_weights :  ArrayLike = 1.0
+        Ignored. Inherited from :class:`LossFunction`, but not used in :class:`Metric`.
+    """
+
     minimize: bool = True
 
     def forward(

--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -50,7 +50,8 @@ class Metric(LossFunction):
     Parameters
     ----------
     task_weights :  ArrayLike = 1.0
-        Ignored. Inherited from :class:`LossFunction`, but not used in :class:`Metric`.
+        .. important::
+            Ignored. Maintained for compatibility with :class:`~chemprop.nn.loss.LossFunction`
     """
 
     minimize: bool = True

--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -44,18 +44,6 @@ __all__ = [
 
 
 class Metric(LossFunction):
-    """
-    __init__(self, task_weights: Tensor):
-
-    Parameters
-    ----------
-    task_weights : Tensor
-        a tensor of shape `t` or `1 x t` containing the per-task weight.
-    .. note::
-        This class inherits from :class:`LossFunction`, which requires task_weights. These
-        task_weights are not used in Metric and can be set to any Tensor, e.g. tensor([1.])
-    """
-
     minimize: bool = True
 
     def forward(

--- a/chemprop/utils/v1_to_v2.py
+++ b/chemprop/utils/v1_to_v2.py
@@ -56,7 +56,7 @@ def convert_hyper_parameters_v1_to_v2(model_v1_dict: dict) -> dict:
 
     args_v1 = model_v1_dict["args"]
     hyper_parameters_v2["batch_norm"] = False
-    hyper_parameters_v2["metrics"] = [MetricRegistry[args_v1.metric]]
+    hyper_parameters_v2["metrics"] = [Factory.build(MetricRegistry[args_v1.metric])]
     hyper_parameters_v2["warmup_epochs"] = args_v1.warmup_epochs
     hyper_parameters_v2["init_lr"] = args_v1.init_lr
     hyper_parameters_v2["max_lr"] = args_v1.max_lr
@@ -117,7 +117,6 @@ def convert_hyper_parameters_v1_to_v2(model_v1_dict: dict) -> dict:
     )
 
     if args_v1.dataset_type == "regression":
-        print(model_v1_dict["data_scaler"]["means"])
         hyper_parameters_v2["predictor"]["output_transform"] = UnscaleTransform(
             model_v1_dict["data_scaler"]["means"], model_v1_dict["data_scaler"]["stds"]
         )


### PR DESCRIPTION
## Description
In #779 we moved task weights to be an attribute of LossFunction. This means it is also an attribute of Metric even though it isn't used. We will address this more thoroughly in v2.1, but requiring task weights when creating a metric will be confusing for users. I thought about it some more and feel task weight should also not be required for when making a loss function if all task weights should be one.

Before I didn't put default task weights of ones in the init for LossFunction because in the LossFunction we don't know how many tasks there will be. Compare to predictors.py that uses `torch.ones(n_tasks) to make a default task weights. But then I realized if we want all ones, we don't have to have the length right because it can be broadcasted. 

This PR allows for simple creation of metrics and loss functions if the task weights should be ones via `MSEMetric()`/`MSELoss()`. I chose to not include task weights in the repr string if it is a tensor of a single 1 as `None` is the real default and if `task_weights == torch.ones(1).view(1,-1)` that is just a way to get the calculations to work. 