### PR TITLE
v2: restrict docutils to version < 0.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 [project.optional-dependencies]
 hpopt = ["ray[tune]", "hyperopt"]
 dev = ["black == 23.*", "bumpversion", "autopep8", "flake8", "pytest", "pytest-cov"]
-docs = ["nbsphinx", "sphinx", "sphinx-argparse", "sphinx-autobuild", "sphinx-autoapi", "sphinxcontrib-bibtex", "sphinx-book-theme","nbsphinx-link","ipykernel"]
+docs = ["nbsphinx", "sphinx", "sphinx-argparse", "sphinx-autobuild", "sphinx-autoapi", "sphinxcontrib-bibtex", "sphinx-book-theme", "nbsphinx-link", "ipykernel", "docutils < 0.21"]
 test = ["pytest >= 6.2", "pytest-cov"]
 notebooks = ["ipykernel"]
 


### PR DESCRIPTION
## Description
@shihchengli identified in #825 that the reason our readthedocs build is failing is due to a change in `docutils`, which is a dependency of `sphinx`. Restricting the version to below 0.21 should fix this issue.