### PR TITLE
Fix hyperparameter predictorbase

### DIFF
--- a/chemprop/nn/predictors.py
+++ b/chemprop/nn/predictors.py
@@ -131,8 +131,6 @@ class _FFNPredictorBase(Predictor, HyperparametersMixin):
         )
         self.output_transform = output_transform if output_transform is not None else nn.Identity()
 
-        self.output_transform = output_transform if output_transform is not None else nn.Identity()
-
     @property
     def input_dim(self) -> int:
         return self.ffn.input_dim

--- a/chemprop/nn/predictors.py
+++ b/chemprop/nn/predictors.py
@@ -119,7 +119,7 @@ class _FFNPredictorBase(Predictor, HyperparametersMixin):
         output_transform: UnscaleTransform | None = None,
     ):
         super().__init__()
-        self.save_hyperparameters()
+        self.save_hyperparameters(ignore=["criterion", "output_transform"])
         self.hparams["cls"] = self.__class__
 
         self.ffn = MLP.build(
@@ -129,7 +129,6 @@ class _FFNPredictorBase(Predictor, HyperparametersMixin):
         self.criterion = criterion or Factory.build(
             self._T_default_criterion, task_weights=task_weights, threshold=threshold
         )
-
         self.output_transform = output_transform if output_transform is not None else nn.Identity()
 
         self.output_transform = output_transform if output_transform is not None else nn.Identity()


### PR DESCRIPTION
## Description
This PR fixes warnings from lightning, caused by setting parameters.  
(Also removes a duplicate line)


## Example / Current workflow
```python
from chemprop.nn.predictors import BinaryClassificationFFN
from chemprop.nn.loss import BCELoss
from torch import nn

BinaryClassificationFFN(criterion=BCELoss(), output_transform=nn.Identity())

>> /my_python_path/lib/python3.11/site-packages/lightning/pytorch/utilities/parsing.py:199: Attribute 'criterion' is an instance of `nn.Module` and is already saved during checkpointing. It is recommended to ignore them using `self.save_hyperparameters(ignore=['criterion'])`.
>> /my_python_path/lib/python3.11/site-packages/lightning/pytorch/utilities/parsing.py:199: Attribute 'output_transform' is an instance of `nn.Module` and is already saved during checkpointing. It is recommended to ignore them using `self.save_hyperparameters(ignore=['output_transform'])`
```

## Bugfix / Desired workflow
See PR
