### PR TITLE
Remove Ray zombie processes

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -28,6 +28,7 @@ from chemprop.nn.transforms import UnscaleTransform
 NO_RAY = False
 DEFAULT_SEARCH_SPACE = {}
 try:
+    import ray
     from ray import tune
     from ray.train import CheckpointConfig, RunConfig, ScalingConfig
     from ray.train.lightning import (
@@ -417,6 +418,8 @@ def main(args: Namespace):
     logger.info(f"Saving hyperparameter optimization results: {result_df}")
 
     result_df.to_csv(args.hpopt_save_dir / "all_progress.csv", index=False)
+
+    ray.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
As described in #835, Ray sometimes leaves zombie processes running after HPO finishes. @JacksonBurns found that this is apparently a longstanding issue with Ray, as it has already been discussed [here](https://github.com/ray-project/ray/issues/12337). I have tested with adding [ray.shutdown](https://docs.ray.io/en/latest/ray-core/api/doc/ray.shutdown.html) at the end of HPO, and all the zombie processes are killed successfully.

## Relevant issues
#835 
