### PR TITLE
Add pip setup step to environment.yml install instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -53,6 +53,7 @@ Option 3: Installing from source using environment.yml
     cd chemprop
     conda env create -f environment.yml
     conda activate chemprop
+    pip install -e .
 
 Option 4: Installing via Docker
 -------------------------------


### PR DESCRIPTION
## Description
The installation instructions for installing with conda environment.yml was missing a step in setting up the cli command support. This PR adds the `pip install -e .` step to the installation.
