### PR TITLE
Avoid scrambling target column name order

### DIFF
--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -49,13 +49,14 @@ def parse_csv(
         input_cols = [df.columns[0]]
 
     if target_cols is None:
-        target_cols = list(
-            set(df.columns)
-            - set(input_cols)
-            - set(ignore_cols or [])
-            - set(splits_col or [])
-            - set(weight_col or [])
-        )
+       target_cols = list(
+           i
+           for i in df.columns
+           if i
+           not in set(
+               input_cols + (ignore_cols or []) + (splits_col or []) + (weight_col or [])
+           )
+       )
 
     Y = df[target_cols]
     weights = None if weight_col is None else df[weight_col].to_numpy(np.single)

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -50,9 +50,9 @@ def parse_csv(
 
     if target_cols is None:
         target_cols = list(
-            i
-            for i in df.columns
-            if i
+            column
+            for column in df.columns
+            if column
             not in set(input_cols + (ignore_cols or []) + (splits_col or []) + (weight_col or []))
         )
 

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -49,14 +49,12 @@ def parse_csv(
         input_cols = [df.columns[0]]
 
     if target_cols is None:
-       target_cols = list(
-           i
-           for i in df.columns
-           if i
-           not in set(
-               input_cols + (ignore_cols or []) + (splits_col or []) + (weight_col or [])
-           )
-       )
+        target_cols = list(
+            i
+            for i in df.columns
+            if i
+            not in set(input_cols + (ignore_cols or []) + (splits_col or []) + (weight_col or []))
+        )
 
     Y = df[target_cols]
     weights = None if weight_col is None else df[weight_col].to_numpy(np.single)

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -93,11 +93,10 @@ def get_column_names(
 
     if target_cols is None:
         target_cols = list(
-            set(df.columns)
-            - set(input_cols)
-            - set(ignore_cols or [])
-            - set(splits_col or [])
-            - set(weight_col or [])
+            column
+            for column in df.columns
+            if column
+            not in set(input_cols + (ignore_cols or []) + (splits_col or []) + (weight_col or []))
         )
 
     return input_cols + target_cols


### PR DESCRIPTION
Partially addresses https://github.com/chemprop/chemprop/issues/890

All this does is remove use of `set` to avoid scrambling order of target columns.
