### PR TITLE
make LookupAction work with ConfigArgParse

### DIFF
--- a/chemprop/cli/utils/actions.py
+++ b/chemprop/cli/utils/actions.py
@@ -1,9 +1,9 @@
-from argparse import Action, ArgumentParser, Namespace
-from typing import Any, Mapping, Sequence
+from argparse import _StoreAction
+from typing import Any, Mapping
 
 
 def LookupAction(obj: Mapping[str, Any]):
-    class LookupAction_(Action):
+    class LookupAction_(_StoreAction):
         def __init__(self, option_strings, dest, default=None, choices=None, **kwargs):
             if default not in obj.keys() and default is not None:
                 raise ValueError(
@@ -15,14 +15,5 @@ def LookupAction(obj: Mapping[str, Any]):
             kwargs["default"] = default
 
             super().__init__(option_strings, dest, **kwargs)
-
-        def __call__(
-            self,
-            parser: ArgumentParser,
-            namespace: Namespace,
-            values: str | Sequence[Any] | None,
-            option_string: str | None = None,
-        ):
-            setattr(namespace, self.dest, values)
 
     return LookupAction_


### PR DESCRIPTION
We use [ConfigArgParse](https://pypi.org/project/ConfigArgParse/) to have easy config file support. But when we try to use our `LookupAction` and `nargs='+'` we have an error.

## Example
`chemprop train --config-path config.toml`
```
$ cat config.toml
data-path = tests/data/classification/mol.csv
metrics = [mse, rmse]
features-generators = [morgan_count, morgan_binary]
```

## Error
```
usage: chemprop train [-h] [--logfile [LOGFILE]] [-v] [-s SMILES_COLUMNS [SMILES_COLUMNS ...]]
                      [-r REACTION_COLUMNS [REACTION_COLUMNS ...]] [--no-header-row] [-n NUM_WORKERS] [-b BATCH_SIZE]
...
                      [--pytorch-seed PYTORCH_SEED]
chemprop train: error: metrics can't be set to a list '['mae', 'rmse']' unless its action type is changed to 'append' or nargs is set to '*', '+', or > 1
```

## Background
LookupAction does two things:
1. enforce the default value (`.add_argument(..., default="hello")`) is a valid option to use later in `MoleculeFeaturizerRegistry[features_generator]`.
2. auto populate the choices(`.add_argument(..., choices=["a","b"])`) with the options in `MoleculeFeaturizerRegistry`

## Solution
After a bit of hunting I found the problem is that ConfigArgParse [checks](https://github.com/bw2/ConfigArgParse/blob/ee77f44d03415f2afe73c82096bae2293db29a3b/configargparse.py#L1148) if `isinstance(action, argparse._StoreAction)`. _StoreAction is the default if you don't specify an action and all it does is check that `nargs != 0` and then stores the argument value `setattr(namespace, self.dest, values)`. 

Our `LookupAction_` class also does `setattr(namespace, self.dest, values)`, and while it doesn't explicitly require `nargs != 0`, that isn't something we would do. So our `LookupAction_` looks like `_StoreAction` but isn't an instance of it because we inherit from the base class `Action` (as is recommended for custom actions). If we inherit from `_StoreAction` instead, the error goes away. 

## Questions
Is is okay to inherit from the  `_StoreAction`? It is marked as private "_" which I guess means argparse could change its behavior. But also it is the [default](https://github.com/python/cpython/blob/4055577221f5f52af329e87f31d81bb8fb02c504/Lib/argparse.py#L1326) action, so I don't see them changing it anytime soon. 

Other thoughts:
ConfigArgParse says it works up through python 3.11, but not 3.12. That may be an issue because we say that Chemprop mostly works on 3.12. I haven't check if ConfigArgParse is compatible with 3.12 though it might be.