### PR TITLE
Add simple cache to CLI

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -306,6 +306,11 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         nargs="+",
         help="Name of the columns to ignore when :code:`target_columns` is not provided.",
     )
+    train_data_args.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Whether to not cache the featurized :code:`MolGraph`s at the beginning of training.",
+    )
     # TODO: Add in v2.1
     # train_data_args.add_argument(
     #     "--spectra-phase-mask-path",
@@ -974,6 +979,10 @@ def main(args):
             output_transform = UnscaleTransform.from_standard_scaler(output_scaler)
         else:
             output_transform = None
+
+        if not args.no_cache:
+            train_dset.cache = True
+            val_dset.cache = True
 
         train_loader = build_dataloader(
             train_dset, args.batch_size, args.num_workers, seed=args.data_seed


### PR DESCRIPTION
We want to have caching in the CLI as it speeds up training. I decided to always have caching on as the default with the option to turn it off. This is because in my tests with 1 M datapoints, the cached Molgraphs only took on the order of 10 GB of memory. I figure if someone is trying to train on 1M datapoints, they probably have that much memory to spare. 

I don't cache the test set as it is only used once so the MolGraphs only need to be calculated once and caching doesn't help with that. 

My tests:
```
from rdkit import Chem
from chemprop import data

mol = Chem.MolFromSmiles("CC1(C(N2C(S1)C(C2=O)NC(=O)CC3=CC=CC=C3)C(=O)O)C") # Penicillin
datapoints = [data.MoleculeDatapoint(mol) for _ in range(1_000_000)]
dataset = data.MoleculeDataset(datapoints)
dataset.cache = True
```

I found making 1M datapoints took about half a gig. Then caching added about 10 gigabytes. I also estimated the size of a single MolGraph:
```
from sys import getsizeof
from chemprop import featurizers
feat = featurizers.SimpleMoleculeMolGraphFeaturizer()
mg = feat(mol)
(getsizeof(mg.V)
+ getsizeof(mg.E)
+ getsizeof(mg.edge_index)
+ getsizeof(mg.rev_edge_index)
+ getsizeof(mg))
```

This gives 13992 bytes. So 1M penicillin MolGraphs would be about 14 GB which is in the same order of magnitude.

As I side note, I found that after setting the cache `dataset.cache = True`, trying to clear the cache `dataset.cache = False` only reduced the memory by 1G instead of 10G, so we may not be clearing the cache correctly. This can be looked into later. 

Closes #792