### PR TITLE
Add CLI transition guide link to RTD

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ This website contains documentation for Chemprop, a PyTorch-based framework for 
 To get started with Chemprop, check out the :ref:`quickstart` page, and for more detailed information, see the :ref:`installation`, :ref:`tutorial`, and :ref:`notebooks` pages.
 
 .. note::
-    Chemprop recently underwent a ground-up rewrite and new major release (v2.0.0). A helpful transition guide from Chemprop v1 to v2 can be found [here](https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml). This includes a side-by-side comparison of CLI argument options, a list of which arguments will be implemented in later versions of v2, and a list of changes to default hyperparameters.
+    Chemprop recently underwent a ground-up rewrite and new major release (v2.0.0). A helpful transition guide from Chemprop v1 to v2 can be found `here <https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml>`_. This includes a side-by-side comparison of CLI argument options, a list of which arguments will be implemented in later versions of v2, and a list of changes to default hyperparameters.
 
 If you use Chemprop to train or develop a model in your own work, we would appreciate if you cite the following papers:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,9 @@ This website contains documentation for Chemprop, a PyTorch-based framework for 
 
 To get started with Chemprop, check out the :ref:`quickstart` page, and for more detailed information, see the :ref:`installation`, :ref:`tutorial`, and :ref:`notebooks` pages.
 
+.. note::
+    Chemprop recently underwent a ground-up rewrite and new major release (v2.0.0). A helpful transition guide from Chemprop v1 to v2 can be found [here](https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml). This includes a side-by-side comparison of CLI argument options, a list of which arguments will be implemented in later versions of v2, and a list of changes to default hyperparameters.
+
 If you use Chemprop to train or develop a model in your own work, we would appreciate if you cite the following papers:
 
 .. footbibliography::

--- a/docs/source/tutorial/cli/index.rst
+++ b/docs/source/tutorial/cli/index.rst
@@ -3,6 +3,9 @@
 Command Line Tutorial
 =====================
 
+.. note::
+    Chemprop recently underwent a ground-up rewrite and new major release (v2.0.0). A helpful transition guide from Chemprop v1 to v2 can be found [here](https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml). This includes a side-by-side comparison of CLI argument options, a list of which arguments will be implemented in later versions of v2, and a list of changes to default hyperparameters.
+
 Chemprop may be invoked from the command line using the following command:
 
 .. code-block::

--- a/docs/source/tutorial/cli/index.rst
+++ b/docs/source/tutorial/cli/index.rst
@@ -4,7 +4,7 @@ Command Line Tutorial
 =====================
 
 .. note::
-    Chemprop recently underwent a ground-up rewrite and new major release (v2.0.0). A helpful transition guide from Chemprop v1 to v2 can be found [here](https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml). This includes a side-by-side comparison of CLI argument options, a list of which arguments will be implemented in later versions of v2, and a list of changes to default hyperparameters.
+    Chemprop recently underwent a ground-up rewrite and new major release (v2.0.0). A helpful transition guide from Chemprop v1 to v2 can be found `here <https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml>`_. This includes a side-by-side comparison of CLI argument options, a list of which arguments will be implemented in later versions of v2, and a list of changes to default hyperparameters.
 
 Chemprop may be invoked from the command line using the following command:
 


### PR DESCRIPTION
## Description
We have a CLI transition guide spreadsheet for v2 that we've linked in the README and release notes, but this should also be added to the Read the Docs for better visibility.
