### PR TITLE
Add meaningful warming for warm up epoch search space

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -238,6 +238,7 @@ def process_hpopt_args(args: Namespace) -> Namespace:
 
 def build_search_space(search_parameters: list[str], train_epochs: int) -> dict:
     if "warmup_epochs" in search_parameters and SEARCH_SPACE.get("warmup_epochs", None) is None:
+        assert train_epochs >= 6, "Training epochs must be at least 6 to perform hyperparameter optimization for warmup_epochs."
         SEARCH_SPACE["warmup_epochs"] = tune.qrandint(lower=1, upper=train_epochs // 2, q=1)
 
     return {param: SEARCH_SPACE[param] for param in search_parameters}

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -238,7 +238,9 @@ def process_hpopt_args(args: Namespace) -> Namespace:
 
 def build_search_space(search_parameters: list[str], train_epochs: int) -> dict:
     if "warmup_epochs" in search_parameters and SEARCH_SPACE.get("warmup_epochs", None) is None:
-        assert train_epochs >= 6, "Training epochs must be at least 6 to perform hyperparameter optimization for warmup_epochs."
+        assert (
+            train_epochs >= 6
+        ), "Training epochs must be at least 6 to perform hyperparameter optimization for warmup_epochs."
         SEARCH_SPACE["warmup_epochs"] = tune.qrandint(lower=1, upper=train_epochs // 2, q=1)
 
     return {param: SEARCH_SPACE[param] for param in search_parameters}


### PR DESCRIPTION
## Description
Currently, if a user uses `epoch <= 6` to test hyperparameter optimization that includes warm up epoch, it would fail with the following error message that is not easy to understand. I added a meaning error message.

```
Traceback (most recent call last):
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/bin/chemprop", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/hwpang/Projects/chemprop_v2_dev/chemprop/chemprop/cli/main.py", line 80, in main
    func(args)
  File "/home/hwpang/Projects/chemprop_v2_dev/chemprop/chemprop/cli/hpopt.py", line 107, in func
    main(args)
  File "/home/hwpang/Projects/chemprop_v2_dev/chemprop/chemprop/cli/hpopt.py", line 430, in main
    results = tune_model(
              ^^^^^^^^^^^
  File "/home/hwpang/Projects/chemprop_v2_dev/chemprop/chemprop/cli/hpopt.py", line 377, in tune_model
    return tuner.fit()
           ^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/tuner.py", line 379, in fit
    return self._local_tuner.fit()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/impl/tuner_internal.py", line 477, in fit
    analysis = self._fit_internal(trainable, param_space)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/impl/tuner_internal.py", line 596, in _fit_internal
    analysis = run(
               ^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/tune.py", line 841, in run
    if config and not searcher_set_search_props(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/search/util.py", line 19, in _set_search_properties_backwards_compatible
    return set_search_properties_func(metric, mode, config, **spec)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/search/search_generator.py", line 63, in set_search_properties
    return _set_search_properties_backwards_compatible(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/search/util.py", line 19, in _set_search_properties_backwards_compatible
    return set_search_properties_func(metric, mode, config, **spec)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/search/hyperopt/hyperopt_search.py", line 284, in set_search_properties
    space = self.convert_search_space(config)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/search/hyperopt/hyperopt_search.py", line 549, in convert_search_space
    value = resolve_value(par, domain)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/ray/tune/search/hyperopt/hyperopt_search.py", line 515, in resolve_value
    hpo.hp.quniform(
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/hyperopt/pyll_utils.py", line 18, in wrapper
    return f(label, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/hyperopt/pyll_utils.py", line 33, in wrapper
    raise ValueError(
ValueError: low should be less than high: 1 is not smaller than 1
```

## Example / Current workflow


## Bugfix / Desired workflow


## Questions

## Relevant issues

## Checklist
- [x] linted with flake8?
