### PR TITLE
Fixing small bug in hpopt for learning rate

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -252,10 +252,10 @@ def update_args_with_config(args: Namespace, config: dict) -> Namespace:
     for key, value in config.items():
         match key:
             case "final_lr_ratio":
-                setattr(args, "final_lr", value * args.max_lr)
+                setattr(args, "final_lr", value * config.get("max_lr", args.max_lr))
 
             case "init_lr_ratio":
-                setattr(args, "init_lr", value * args.max_lr)
+                setattr(args, "init_lr", value * config.get("max_lr", args.max_lr))
 
             case _:
                 assert key in args, f"Key: {key} not found in args."


### PR DESCRIPTION
…r (instead of default)

## Description
Addresses #912 

## Example / Current workflow
Currently, default max-lr used to calculate the init-lr and final-lr (from init-lr-ratio and final-lr-ratio). This is for the outputs in the best_cnfig.toml file.

## Bugfix / Desired workflow
Change the default value to the best value found using hpopt.

## Questions


## Relevant issues
#912 

## Checklist
