### PR TITLE
don't save Modules in hparams

### DIFF
--- a/chemprop/nn/__init__.py
+++ b/chemprop/nn/__init__.py
@@ -66,7 +66,7 @@ from .predictors import (
     RegressionFFN,
     SpectralFFN,
 )
-from .transforms import UnscaleTransform
+from .transforms import GraphTransform, ScaleTransform, UnscaleTransform
 from .utils import Activation
 
 __all__ = [
@@ -129,5 +129,7 @@ __all__ = [
     "MulticlassDirichletFFN",
     "SpectralFFN",
     "Activation",
+    "GraphTransform",
+    "ScaleTransform",
     "UnscaleTransform",
 ]

--- a/chemprop/nn/message_passing/base.py
+++ b/chemprop/nn/message_passing/base.py
@@ -61,7 +61,7 @@ class _MessagePassingBase(MessagePassing, HyperparametersMixin):
         # layers_per_message: int = 1,
     ):
         super().__init__()
-        self.save_hyperparameters()
+        self.save_hyperparameters(ignore=["V_d_transform", "graph_transform"])
         self.hparams["cls"] = self.__class__
 
         self.W_i, self.W_h, self.W_o, self.W_d = self.setup(d_v, d_e, d_h, d_vd, bias)

--- a/chemprop/nn/predictors.py
+++ b/chemprop/nn/predictors.py
@@ -128,9 +128,7 @@ class _FFNPredictorBase(Predictor, HyperparametersMixin):
         self.criterion = criterion or Factory.build(
             self._T_default_criterion, task_weights=task_weights, threshold=threshold
         )
-        self.hparams["criterion"] = self.criterion
         self.output_transform = output_transform if output_transform is not None else nn.Identity()
-        self.hparams["output_transform"] = self.output_transform
 
     @property
     def input_dim(self) -> int:

--- a/chemprop/nn/transforms.py
+++ b/chemprop/nn/transforms.py
@@ -43,7 +43,9 @@ class UnscaleTransform(_ScaleTransformMixin):
 
 
 class GraphTransform(nn.Module):
-    def __init__(self, V_transform: ScaleTransform, E_transform: ScaleTransform):
+    def __init__(
+        self, V_transform: ScaleTransform | nn.Identity, E_transform: ScaleTransform | nn.Identity
+    ):
         super().__init__()
 
         self.V_transform = V_transform

--- a/tests/unit/utils/test_save_load_mol.py
+++ b/tests/unit/utils/test_save_load_mol.py
@@ -3,11 +3,22 @@ from pathlib import Path
 from lightning import pytorch as pl
 import numpy as np
 import pytest
+import torch
+from torch.nn import Identity
 from torch.utils.data import DataLoader
 
 from chemprop.data import MoleculeDatapoint, MoleculeDataset, collate_batch
 from chemprop.models import MPNN
-from chemprop.models.utils import save_model
+from chemprop.models.utils import load_model, save_model
+from chemprop.nn import (
+    BondMessagePassing,
+    GraphTransform,
+    MSELoss,
+    NormAggregation,
+    RegressionFFN,
+    ScaleTransform,
+    UnscaleTransform,
+)
 
 
 @pytest.fixture
@@ -84,3 +95,35 @@ def test_checkpoint_roundtrip(checkpoint_path, model_path, trainer, test_loader)
     ys_from_file = np.vstack(predss_from_file)
 
     assert np.allclose(ys_from_file, ys_from_checkpoint, atol=1e-6)
+
+
+def test_scalers_roundtrip(tmp_path):
+    E_f_transform = ScaleTransform(mean=[0.0, 1.0], scale=[2.0, 3.0])
+    graph_transform = GraphTransform(V_transform=Identity(), E_transform=E_f_transform)
+    V_d_transform = ScaleTransform(mean=[4.0, 5.0], scale=[6.0, 7.0])
+    mp = BondMessagePassing(graph_transform=graph_transform, V_d_transform=V_d_transform)
+
+    output_transform = UnscaleTransform(mean=[8.0, 9.0], scale=[10.0, 11.0])
+    criterion = MSELoss(task_weights=[12.0])
+    ffn = RegressionFFN(output_transform=output_transform, criterion=criterion)
+
+    X_d_transform = ScaleTransform(mean=[13.0, 14.0], scale=[15.0, 16.0])
+    original = MPNN(mp, NormAggregation(), ffn, X_d_transform=X_d_transform)
+
+    save_model(tmp_path / "model.pt", original)
+    loaded = load_model(tmp_path / "model.pt", multicomponent=False)
+
+    assert torch.equal(
+        original.message_passing.V_d_transform.mean, loaded.message_passing.V_d_transform.mean
+    )
+    assert torch.equal(
+        original.message_passing.graph_transform.E_transform.mean,
+        loaded.message_passing.graph_transform.E_transform.mean,
+    )
+    assert torch.equal(
+        original.predictor.criterion.task_weights, loaded.predictor.criterion.task_weights
+    )
+    assert torch.equal(
+        original.predictor.output_transform.mean, loaded.predictor.output_transform.mean
+    )
+    assert torch.equal(original.X_d_transform.mean, loaded.X_d_transform.mean)


### PR DESCRIPTION
## Description
Related to #898, this PR address the fact that we double save `nn.Modules` in both the `hparams` and in the `state_dict`. This PR follows David's idea [here](https://github.com/chemprop/chemprop/pull/898#issuecomment-2158733975). 

The main downside to this PR is a lot more code is required to implement this versus continuing to double save. The main upside is that model files will be a little smaller. 

## Other notes
`metrics` in `MPNN` is a list of `Modules` so the whole list is pickled and unpickled to save and load. This is different than all the other Modules like `criterion` which are rebuilt each time a model is loaded. 

The default `task_weights` for `criterion` is an array, so I don't need to check if there are `task_weights` in the `state_dict`. For the other cases, the default is `None`/`Identity` so in those cases, I need to check if their are corresponding parameters in the `state_dict` and if so build a `Module` with zeros. 

While working on this PR, I found that for multicomponent message passing, if a single block is shared between two components, the weights for that block appear twice in the `state_dict`. I don't know if the weights just have two key values, or if they are truly saved twice in the model file. Not sure if this is something we should try to change. 
