### PR TITLE
Save individual and average predictions into different files

### DIFF
--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -40,6 +40,7 @@ class FingerprintSubcommand(Subcommand):
             help="Path to which predictions will be saved. If the file extension is .npz, they will be saved as a npz file, respectively. Otherwise, will save predictions as a CSV. The index of the model will be appended to the filename's stem. By default, predictions will be saved to the same location as '--test-path' with '_fps' appended, i.e., 'PATH/TO/TEST_PATH_fps_0.csv'.",
         )
         parser.add_argument(
+            "--model-paths",
             "--model-path",
             required=True,
             type=Path,
@@ -182,7 +183,7 @@ def main(args):
 
     multicomponent = n_components > 1
 
-    for i, model_path in enumerate(find_models(args.model_path)):
+    for i, model_path in enumerate(find_models(args.model_paths)):
         logger.info(f"Fingerprints with model at '{model_path}'")
         output_path = args.output.parent / f"{args.output.stem}_{i}{args.output.suffix}"
         make_fingerprint_for_model(args, model_path, multicomponent, output_path)

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -338,7 +338,7 @@ def main(args):
 
     multicomponent = n_components > 1
 
-    model_paths = find_models(args.model_path)
+    model_paths = find_models(args.model_paths)
 
     make_prediction_for_models(args, model_paths, multicomponent, output_path=args.output)
 

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -48,7 +48,7 @@ def add_predict_args(parser: ArgumentParser) -> ArgumentParser:
         "--output",
         "--preds-path",
         type=Path,
-        help="Path to which predictions will be saved. If the file extension is .pkl, will be saved as a pickle file. Otherwise, will save predictions as a CSV. The index of the model will be appended to the filename's stem. By default, predictions will be saved to the same location as '--test-path' with '_preds' appended, i.e., 'PATH/TO/TEST_PATH_preds.csv'.",
+        help="Path to which predictions will be saved. If the file extension is .pkl, will be saved as a pickle file. Otherwise, will save predictions as a CSV. If multiple models are used to make predictions, the average predictions will be saved in the file, and another file ending in '_individual' with the same file extension will save the predictions for each individual model, with the column names being the target names appended with the model index (e.g., '_model_<index>').",
     )
     parser.add_argument(
         "--drop-extra-columns",

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -56,8 +56,8 @@ def add_predict_args(parser: ArgumentParser) -> ArgumentParser:
         help="Whether to drop all columns from the test data file besides the SMILES columns and the new prediction columns.",
     )
     parser.add_argument(
-        "--model-path",
         "--model-paths",
+        "--model-path",
         required=True,
         type=Path,
         nargs="+",

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -2,6 +2,7 @@ from argparse import ArgumentError, ArgumentParser, Namespace
 import logging
 from pathlib import Path
 import sys
+from typing import Iterator
 
 from lightning import pytorch as pl
 import pandas as pd
@@ -185,16 +186,14 @@ def find_models(model_paths: list[Path]):
 
 
 def make_prediction_for_model(
-    args: Namespace, model_path: Path, multicomponent: bool, output_path: Path
+    args: Namespace, model_paths: Iterator[Path], multicomponent: bool, output_path: Path
 ):
-    model = load_model(model_path, multicomponent)
-
+    model = load_model(model_paths[0], multicomponent)
     bounded = any(
         isinstance(model.criterion, LossFunctionRegistry[loss_function])
         for loss_function in LossFunctionRegistry.keys()
         if "bounded" in loss_function
     )
-
     format_kwargs = dict(
         no_header_row=args.no_header_row,
         smiles_cols=args.smiles_columns,
@@ -252,27 +251,36 @@ def make_prediction_for_model(
     # else:
     #     cal_loader = None
 
-    logger.info(model)
+    individual_preds = []
+    for model_path in model_paths:
+        logger.info(f"Predicting with model at '{model_path}'")
 
-    trainer = pl.Trainer(
-        logger=False, enable_progress_bar=True, accelerator=args.accelerator, devices=args.devices
-    )
+        model = load_model(model_path, multicomponent)
 
-    predss = trainer.predict(model, test_loader)
+        logger.info(model)
 
-    # TODO: add uncertainty and calibration
-    # if cal_dset is not None:
-    #     if args.task_type == "regression":
-    #         model.loc, model.scale = float(scaler.mean_), float(scaler.scale_)
-    #     predss_cal = trainer.predict(model, cal_loader)[0]
+        trainer = pl.Trainer(
+            logger=False,
+            enable_progress_bar=True,
+            accelerator=args.accelerator,
+            devices=args.devices,
+        )
 
-    # TODO: might want to write a shared function for this as train.py might also want to do this.
-    df_test = pd.read_csv(args.test_path)
-    preds = torch.concat(predss, 0)
+        predss = trainer.predict(model, test_loader)
 
-    if isinstance(model.predictor, MulticlassClassificationFFN):
-        preds = torch.argmax(preds, dim=-1)
+        # TODO: add uncertainty and calibration
+        # if cal_dset is not None:
+        #     if args.task_type == "regression":
+        #         model.loc, model.scale = float(scaler.mean_), float(scaler.scale_)
+        #     predss_cal = trainer.predict(model, cal_loader)[0]
 
+        # TODO: might want to write a shared function for this as train.py might also want to do this.
+        preds = torch.concat(predss, 0)
+        if isinstance(model.predictor, MulticlassClassificationFFN):
+            preds = torch.argmax(preds, dim=-1)
+        individual_preds.append(preds)
+
+    average_preds = torch.mean(torch.stack(individual_preds), dim=0)
     if args.target_columns is not None:
         assert (
             len(args.target_columns) == model.n_tasks
@@ -283,13 +291,33 @@ def make_prediction_for_model(
             f"pred_{i}" for i in range(preds.shape[1])
         ]  # TODO: need to improve this for cases like multi-task MVE and multi-task multiclass
 
-    df_test[target_columns] = preds
+    df_test = pd.read_csv(args.test_path)
+    df_test[target_columns] = average_preds
     if output_path.suffix == ".pkl":
         df_test = df_test.reset_index(drop=True)
         df_test.to_pickle(output_path)
     else:
         df_test.to_csv(output_path, index=False)
     logger.info(f"Predictions saved to '{output_path}'")
+
+    if len(model_paths) > 1:
+        individual_preds = torch.concat(individual_preds, 1)
+        target_columns = [
+            f"{col}_model_{i}" for i in range(len(model_paths)) for col in target_columns
+        ]
+
+        df_test = pd.read_csv(args.test_path)
+        df_test[target_columns] = individual_preds
+
+        output_path = output_path.parent / Path(
+            str(args.output.stem) + "_individual" + str(output_path.suffix)
+        )
+        if output_path.suffix == ".pkl":
+            df_test = df_test.reset_index(drop=True)
+            df_test.to_pickle(output_path)
+        else:
+            df_test.to_csv(output_path, index=False)
+        logger.info(f"Individual predictions saved to '{output_path}'")
 
 
 def main(args):
@@ -307,12 +335,7 @@ def main(args):
 
     model_paths = find_models(args.model_path)
 
-    for i, model_path in enumerate(model_paths):
-        logger.info(f"Predicting with model at '{model_path}'")
-        output_path = args.output.parent / Path(
-            str(args.output.stem) + f"_{i}" + str(args.output.suffix)
-        )
-        make_prediction_for_model(args, model_path, multicomponent, output_path)
+    make_prediction_for_model(args, model_paths, multicomponent, output_path=args.output)
 
 
 if __name__ == "__main__":

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -280,7 +280,7 @@ def make_prediction_for_model(
             preds = torch.argmax(preds, dim=-1)
         individual_preds.append(preds)
 
-    average_preds = torch.mean(torch.stack(individual_preds), dim=0)
+    average_preds = torch.mean(torch.stack(individual_preds).float(), dim=0)
     if args.target_columns is not None:
         assert (
             len(args.target_columns) == model.n_tasks

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -48,7 +48,7 @@ def add_predict_args(parser: ArgumentParser) -> ArgumentParser:
         "--output",
         "--preds-path",
         type=Path,
-        help="Path to which predictions will be saved. If the file extension is .pkl, will be saved as a pickle file. Otherwise, will save predictions as a CSV. The index of the model will be appended to the filename's stem. By default, predictions will be saved to the same location as '--test-path' with '_preds' appended, i.e., 'PATH/TO/TEST_PATH_preds_0.csv'.",
+        help="Path to which predictions will be saved. If the file extension is .pkl, will be saved as a pickle file. Otherwise, will save predictions as a CSV. The index of the model will be appended to the filename's stem. By default, predictions will be saved to the same location as '--test-path' with '_preds' appended, i.e., 'PATH/TO/TEST_PATH_preds.csv'.",
     )
     parser.add_argument(
         "--drop-extra-columns",

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -57,6 +57,7 @@ def add_predict_args(parser: ArgumentParser) -> ArgumentParser:
     )
     parser.add_argument(
         "--model-path",
+        "--model-paths",
         required=True,
         type=Path,
         nargs="+",

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -185,7 +185,7 @@ def find_models(model_paths: list[Path]):
     return collected_model_paths
 
 
-def make_prediction_for_model(
+def make_prediction_for_models(
     args: Namespace, model_paths: Iterator[Path], multicomponent: bool, output_path: Path
 ):
     model = load_model(model_paths[0], multicomponent)
@@ -335,7 +335,7 @@ def main(args):
 
     model_paths = find_models(args.model_path)
 
-    make_prediction_for_model(args, model_paths, multicomponent, output_path=args.output)
+    make_prediction_for_models(args, model_paths, multicomponent, output_path=args.output)
 
 
 if __name__ == "__main__":

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -318,6 +318,10 @@ def make_prediction_for_models(
         else:
             df_test.to_csv(output_path, index=False)
         logger.info(f"Individual predictions saved to '{output_path}'")
+        for i, model_path in enumerate(model_paths):
+            logger.info(
+                f"Results from model path {model_path} are saved under the column name ending with 'model_{i}'"
+            )
 
 
 def main(args):

--- a/tests/cli/test_cli_classification_mol.py
+++ b/tests/cli/test_cli_classification_mol.py
@@ -145,7 +145,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         m.setattr("sys.argv", args)
         main()
 
-    assert (tmp_path / "preds_0.csv").exists()
+    assert (tmp_path / "preds.csv").exists()
 
 
 @pytest.mark.parametrize("ffn_block_index", ["0", "1"])

--- a/tests/cli/test_cli_classification_mol.py
+++ b/tests/cli/test_cli_classification_mol.py
@@ -137,6 +137,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         data_path,
         "--model-path",
         model_path,
+        model_path,
         "--output",
         str(tmp_path / "preds.csv"),
     ]
@@ -146,6 +147,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         main()
 
     assert (tmp_path / "preds.csv").exists()
+    assert (tmp_path / "preds_individual.csv").exists()
 
 
 @pytest.mark.parametrize("ffn_block_index", ["0", "1"])

--- a/tests/cli/test_cli_classification_mol_multiclass.py
+++ b/tests/cli/test_cli_classification_mol_multiclass.py
@@ -140,7 +140,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         m.setattr("sys.argv", args)
         main()
 
-    assert (tmp_path / "preds_0.csv").exists()
+    assert (tmp_path / "preds.csv").exists()
 
 
 @pytest.mark.parametrize("ffn_block_index", ["0", "1"])

--- a/tests/cli/test_cli_classification_mol_multiclass.py
+++ b/tests/cli/test_cli_classification_mol_multiclass.py
@@ -132,6 +132,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         data_path,
         "--model-path",
         model_path,
+        model_path,
         "--output",
         str(tmp_path / "preds.csv"),
     ]
@@ -141,6 +142,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         main()
 
     assert (tmp_path / "preds.csv").exists()
+    assert (tmp_path / "preds_individual.csv").exists()
 
 
 @pytest.mark.parametrize("ffn_block_index", ["0", "1"])

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -267,6 +267,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         input_path,
         "--model-path",
         model_path,
+        model_path,
         "--output",
         str(tmp_path / "preds.csv"),
     ]
@@ -276,6 +277,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         main()
 
     assert (tmp_path / "preds.csv").exists()
+    assert (tmp_path / "preds_individual.csv").exists()
 
 
 @pytest.mark.parametrize("ffn_block_index", ["0", "1"])

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -275,7 +275,7 @@ def test_predict_output_structure(monkeypatch, data_path, model_path, tmp_path):
         m.setattr("sys.argv", args)
         main()
 
-    assert (tmp_path / "preds_0.csv").exists()
+    assert (tmp_path / "preds.csv").exists()
 
 
 @pytest.mark.parametrize("ffn_block_index", ["0", "1"])


### PR DESCRIPTION
## Description
The predictions of each model in a directory are currently saved as separate files and are not automatically averaged. This PR puts the average results into a single file. In the case of ensemble models, the individual predictions for each file will be saved into another file with the file name ending in `_individual.csv` or `_individual.pkl`. The column name would be `{target_name}_model_{ind}`. For example, if you train a model on target U0 with two ensembles, the column names would be U0_model_0 and U0_model_1. In addition to saving predictions to two files, this PR also changes the previous behavior of loading the test dataset for each model to only loading it once and using this dataloader for all the models.

## Questions
As mentioned in #890, the current target names are not saved in the model file. Without providing them via `--target-columns`, the current column names default to `prop_{i}`, which should be addressed in another PR.

## Relevant issues
#719

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
