### PR TITLE
Add `--show-individual-scores` CLI flag

### DIFF
--- a/tests/cli/test_cli_classification_mol.py
+++ b/tests/cli/test_cli_classification_mol.py
@@ -36,6 +36,7 @@ def test_train_quick(monkeypatch, data_path):
         "accuracy",
         "f1",
         "roc",
+        "--show-individual-scores",
     ]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_classification_mol_multiclass.py
+++ b/tests/cli/test_cli_classification_mol_multiclass.py
@@ -31,6 +31,7 @@ def test_train_quick(monkeypatch, data_path):
         "0",
         "--task-type",
         "multiclass",
+        "--show-individual-scores",
     ]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -59,6 +59,7 @@ def test_train_quick(monkeypatch, data_path):
         *bond_feat_path_0,
         "--atom-descriptors-path",
         *atom_desc_path_1,
+        "--show-individual-scores",
     ]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -38,7 +38,17 @@ def config_path(data_dir):
 def test_train_quick(monkeypatch, data_path):
     input_path, *_ = data_path
 
-    args = ["chemprop", "train", "-i", input_path, "--epochs", "1", "--num-workers", "0"]
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--epochs",
+        "1",
+        "--num-workers",
+        "0",
+        "--show-individual-scores",
+    ]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)

--- a/tests/cli/test_cli_regression_mol_multitask.py
+++ b/tests/cli/test_cli_regression_mol_multitask.py
@@ -19,7 +19,17 @@ def model_path(data_dir):
 
 
 def test_train_quick(monkeypatch, data_path):
-    args = ["chemprop", "train", "-i", data_path, "--epochs", "1", "--num-workers", "0"]
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        data_path,
+        "--epochs",
+        "1",
+        "--num-workers",
+        "0",
+        "--show-individual-scores",
+    ]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)

--- a/tests/cli/test_cli_regression_rxn+mol.py
+++ b/tests/cli/test_cli_regression_rxn+mol.py
@@ -55,6 +55,7 @@ def test_train_quick(monkeypatch, data_path):
         *bond_features_path,
         "--atom-descriptors-path",
         *atom_descriptors_path,
+        "--show-individual-scores",
     ]
 
     with monkeypatch.context() as m:

--- a/tests/cli/test_cli_regression_rxn.py
+++ b/tests/cli/test_cli_regression_rxn.py
@@ -35,6 +35,7 @@ def test_train_quick(monkeypatch, data_path):
         "0",
         "--descriptors-path",
         descriptors_path,
+        "--show-individual-scores",
     ]
 
     with monkeypatch.context() as m:


### PR DESCRIPTION
## Description
Add `--show-individual-scores` so all scores for individual targets will be shown.

## Example / Current workflow
Run this CLI
```
chemprop train \
-i data/regression/mol/mol.csv \
--epochs 1 \
--task-type regression \
--ensemble-size 2 \
--show-individual-scores
```

You will see individual scores for each target after each model training is finished.
```
INFO:__main__:Entire Test Set results:
INFO:__main__:entire_test/mse: 1.035393409031115
INFO:__main__:Entire Test Set individual results:
INFO:__main__:entire_test/lipo/mse: 1.035393409031115
```

## Relevant issues
#719

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
