### PR TITLE
Change the installed numpy version in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
 requires-python = ">=3.11"
 dependencies = [
     "lightning >= 2.0",
-    "numpy",
+    "numpy < 2.0.0",
     "pandas",
     "rdkit",
     "scikit-learn",


### PR DESCRIPTION
## Description
Scheduled CI run failed today (see [here](https://github.com/chemprop/chemprop/actions/runs/9544345920)). Thanks to @JacksonBurns for finding the reason. It is because NumPy just released v2, and RDKit doesn't support it yet. By changing the installed version in pyproject.toml to v1, the issue is resolved. When the other dependencies support NumPy v2, we can add it back then.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
