### PR TITLE
Make fingerprint CLI consistent with predict CLI

### DIFF
--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -8,11 +8,7 @@ import pandas as pd
 import torch
 
 from chemprop import data
-from chemprop.cli.common import (
-    add_common_args,
-    process_common_args,
-    validate_common_args,
-)
+from chemprop.cli.common import add_common_args, process_common_args, validate_common_args
 from chemprop.cli.predict import find_models
 from chemprop.cli.utils import Subcommand, build_data_from_files, make_dataset
 from chemprop.featurizers import MoleculeFeaturizerRegistry

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -8,7 +8,12 @@ import pandas as pd
 import torch
 
 from chemprop import data
-from chemprop.cli.common import add_common_args, process_common_args, validate_common_args
+from chemprop.cli.common import (
+    add_common_args,
+    process_common_args,
+    validate_common_args,
+)
+from chemprop.cli.predict import find_models
 from chemprop.cli.utils import Subcommand, build_data_from_files, make_dataset
 from chemprop.featurizers import MoleculeFeaturizerRegistry
 from chemprop.models import load_model
@@ -44,7 +49,8 @@ class FingerprintSubcommand(Subcommand):
             "--model-path",
             required=True,
             type=Path,
-            help="Path to either a single pretrained model checkpoint (.ckpt) or single pretrained model file (.pt) or to a directory that contains these files. If a directory, will recursively search and predict on all found models.",
+            nargs="+",
+            help="Location of checkpoint(s) or model file(s) to use for prediction. It can be a path to either a single pretrained model checkpoint (.ckpt) or single pretrained model file (.pt), a directory that contains these files, or a list of path(s) and directory(s). If a directory, will recursively search and predict on all found (.pt) models.",
         )
         parser.add_argument(
             "--ffn-block-index",
@@ -76,13 +82,6 @@ def process_fingerprint_args(args: Namespace) -> Namespace:
             argument=None, message=f"Output must be a CSV or NPZ file. Got '{args.output}'."
         )
     return args
-
-
-def find_models(model_path: Path):
-    if model_path.suffix in [".ckpt", ".pt"]:
-        return [model_path]
-    elif model_path.is_dir():
-        return list(model_path.rglob("*.ckpt")) + list(model_path.rglob("*.pt"))
 
 
 def make_fingerprint_for_model(
@@ -184,7 +183,7 @@ def main(args):
     multicomponent = n_components > 1
 
     for i, model_path in enumerate(find_models(args.model_paths)):
-        logger.info(f"Fingerprints with model at '{model_path}'")
+        logger.info(f"Fingerprints with model {i} at '{model_path}'")
         output_path = args.output.parent / f"{args.output.stem}_{i}{args.output.suffix}"
         make_fingerprint_for_model(args, model_path, multicomponent, output_path)
 

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -9,7 +9,12 @@ import pandas as pd
 import torch
 
 from chemprop import data
-from chemprop.cli.common import add_common_args, process_common_args, validate_common_args
+from chemprop.cli.common import (
+    add_common_args,
+    find_models,
+    process_common_args,
+    validate_common_args,
+)
 from chemprop.cli.utils import Subcommand, build_data_from_files, make_dataset
 from chemprop.models import load_model
 from chemprop.nn.loss import LossFunctionRegistry

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -9,12 +9,7 @@ import pandas as pd
 import torch
 
 from chemprop import data
-from chemprop.cli.common import (
-    add_common_args,
-    find_models,
-    process_common_args,
-    validate_common_args,
-)
+from chemprop.cli.common import add_common_args, process_common_args, validate_common_args
 from chemprop.cli.utils import Subcommand, build_data_from_files, make_dataset
 from chemprop.models import load_model
 from chemprop.nn.loss import LossFunctionRegistry


### PR DESCRIPTION
## Description
Recently we have merged in https://github.com/chemprop/chemprop/pull/731, which changes the behavior of `--model-path` in predict.py to be the following

- It can take multiple locations of model (.pt) files and (.ckpt) checkpoints
- If a directory is given, search for all (.pt) models using the `find_models` helper function

The fingerprint.py has a same argument `--model-path` and a duplicate `find_models` helper function.

Instead of maintaining two functions doing the same thing, I move the `find_models` helper function into common.py. Both predict and fingerprint now use the same helper function code.

I change the `--model-path` in fingerprint.py to behave the same as predict.py, and change the help string to reflect the new behavior.

I also added the index corresponding to the model path to make bookkeeping easier for the user.

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
