### PR TITLE
Set Ray Train's trainer resources to 0

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -374,9 +374,7 @@ def tune_model(
         num_workers=args.raytune_num_workers,
         use_gpu=use_gpu,
         resources_per_worker=resources_per_worker,
-        trainer_resources={
-            "CPU": 0,
-        }
+        trainer_resources={"CPU": 0},
     )
 
     checkpoint_config = CheckpointConfig(

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -374,6 +374,9 @@ def tune_model(
         num_workers=args.raytune_num_workers,
         use_gpu=use_gpu,
         resources_per_worker=resources_per_worker,
+        trainer_resources={
+            "CPU": 0,
+        }
     )
 
     checkpoint_config = CheckpointConfig(


### PR DESCRIPTION
## Description
See ray's [documentation](https://docs.ray.io/en/latest/train/user-guides/using-gpus.html#trainer-resources) for details.

> This object often only manages lightweight communication between the training workers. You can still specify its resources, which can be useful if you implemented your own Trainer that does heavier processing.

> Per default, a trainer uses 1 CPU. If you have a cluster with 8 CPUs and want to start 4 training workers a 2 CPUs, this will not work, as the total number of required CPUs will be 9 (4 * 2 + 1). In that case, you can specify the trainer resources to use 0 CPUs:

Since Ray Train's Trainer only handles lightweight communication per the documentation, we can specify its resources to be 0 cpu.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
