### PR TITLE
Move ignore columns to common

### DIFF
--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -28,6 +28,11 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         action="store_true",
         help="If specified, the first row in the input CSV will not be used as column names.",
     )
+    data_args.add_argument(
+        "--ignore-columns",
+        nargs="+",
+        help="Name of the columns to ignore.",
+    )
 
     dataloader_args = parser.add_argument_group("Dataloader args")
     dataloader_args.add_argument(

--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -28,11 +28,7 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         action="store_true",
         help="If specified, the first row in the input CSV will not be used as column names.",
     )
-    data_args.add_argument(
-        "--ignore-columns",
-        nargs="+",
-        help="Name of the columns to ignore.",
-    )
+    data_args.add_argument("--ignore-columns", nargs="+", help="Name of the columns to ignore.")
 
     dataloader_args = parser.add_argument_group("Dataloader args")
     dataloader_args.add_argument(

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -286,11 +286,6 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         help="Name of the columns containing target values. By default, uses all columns except the SMILES column and the :code:`ignore_columns`.",
     )
     train_data_args.add_argument(
-        "--ignore-columns",
-        nargs="+",
-        help="Name of the columns to ignore when :code:`target_columns` is not provided.",
-    )
-    train_data_args.add_argument(
         "--no-cache",
         action="store_true",
         help="Whether to not cache the featurized :code:`MolGraph`s at the beginning of training.",


### PR DESCRIPTION
## Description
This PR moves the ignore columns to common.py as it is also desired for CLIs other than train.

## Example / Current workflow
Sometimes a test file can contain extra columns that are not relevant. Currently, this causes the prediction to fail if those extra columns contain a data type that is not numbers.

## Bugfix / Desired workflow
I move this argument into common.py so that other CLIs can also have access to it.

## Questions


## Relevant issues
https://github.com/chemprop/chemprop/issues/793

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
