### PR TITLE
Improve output transformation and prediction saving for `MveFFN` and `EvidentialFFN`

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -874,84 +874,84 @@ def train_model(
             elif isinstance(model.predictor, EvidentialFFN):
                 preds = np.split(preds, 4, axis=1)[0]
 
-            if isinstance(test_loader.dataset, MulticomponentDataset):
-                test_dset = test_loader.dataset.datasets[0]
-            else:
-                test_dset = test_loader.dataset
-            targets = test_dset.Y
-            mask = torch.from_numpy(np.isfinite(targets))
-            targets = np.nan_to_num(targets, nan=0.0)
-            lt_mask = (
-                torch.from_numpy(test_dset.lt_mask) if test_dset.lt_mask[0] is not None else None
+            evaluate_and_save_predictions(
+                preds, test_loader, model.metrics[:-1], model_output_dir, args
             )
-            gt_mask = (
-                torch.from_numpy(test_dset.gt_mask) if test_dset.gt_mask[0] is not None else None
-            )
-
-            columns = get_column_names(
-                args.data_path,
-                args.smiles_columns,
-                args.reaction_columns,
-                args.target_columns,
-                args.ignore_columns,
-                args.splits_column,
-                args.weight_column,
-                args.no_header_row,
-            )
-            input_cols = (args.smiles_columns or []) + (args.reaction_columns or [])
-            target_cols = columns[1:] if len(input_cols) == 0 else columns[len(input_cols) :]
-
-            individual_scores = dict()
-            for metric in model.metrics[:-1]:
-                individual_scores[metric.alias] = []
-                for i, col in enumerate(target_cols):
-                    if "multiclass" in args.task_type:
-                        preds_slice = torch.from_numpy(preds[:, i : i + 1, :])
-                        targets_slice = torch.from_numpy(targets[:, i : i + 1])
-                    else:
-                        preds_slice = torch.from_numpy(preds[:, i])
-                        targets_slice = torch.from_numpy(targets[:, i])
-                    preds_loss = metric(
-                        preds_slice,
-                        targets_slice,
-                        mask[:, i],
-                        None,
-                        lt_mask[:, i] if lt_mask is not None else None,
-                        gt_mask[:, i] if gt_mask is not None else None,
-                    )
-                    individual_scores[metric.alias].append(preds_loss)
-
-            logger.info("Entire Test Set results:")
-            for metric in model.metrics[:-1]:
-                avg_loss = sum(individual_scores[metric.alias]) / len(
-                    individual_scores[metric.alias]
-                )
-                logger.info(f"entire_test/{metric.alias}: {avg_loss}")
-
-            if args.show_individual_scores:
-                logger.info("Entire Test Set individual results:")
-                for metric in model.metrics[:-1]:
-                    for i, col in enumerate(target_cols):
-                        logger.info(
-                            f"entire_test/{col}/{metric.alias}: {individual_scores[metric.alias][i]}"
-                        )
-
-            names = test_loader.dataset.names
-            if isinstance(test_loader.dataset, MulticomponentDataset):
-                namess = list(zip(*names))
-            else:
-                namess = [names]
-            if "multiclass" in args.task_type:
-                df_preds = pd.DataFrame(list(zip(*namess, preds)), columns=columns)
-            else:
-                df_preds = pd.DataFrame(list(zip(*namess, *preds.T)), columns=columns)
-            df_preds.to_csv(model_output_dir / "test_predictions.csv", index=False)
 
         best_model_path = checkpointing.best_model_path
         model = model.__class__.load_from_checkpoint(best_model_path)
         p_model = model_output_dir / "best.pt"
         save_model(p_model, model)
         logger.info(f"Best model saved to '{p_model}'")
+
+
+def evaluate_and_save_predictions(preds, test_loader, metrics, model_output_dir, args):
+    if isinstance(test_loader.dataset, MulticomponentDataset):
+        test_dset = test_loader.dataset.datasets[0]
+    else:
+        test_dset = test_loader.dataset
+    targets = test_dset.Y
+    mask = torch.from_numpy(np.isfinite(targets))
+    targets = np.nan_to_num(targets, nan=0.0)
+    lt_mask = torch.from_numpy(test_dset.lt_mask) if test_dset.lt_mask[0] is not None else None
+    gt_mask = torch.from_numpy(test_dset.gt_mask) if test_dset.gt_mask[0] is not None else None
+
+    columns = get_column_names(
+        args.data_path,
+        args.smiles_columns,
+        args.reaction_columns,
+        args.target_columns,
+        args.ignore_columns,
+        args.splits_column,
+        args.weight_column,
+        args.no_header_row,
+    )
+    input_cols = (args.smiles_columns or []) + (args.reaction_columns or [])
+    target_cols = columns[1:] if len(input_cols) == 0 else columns[len(input_cols) :]
+
+    individual_scores = dict()
+    for metric in metrics:
+        individual_scores[metric.alias] = []
+        for i, col in enumerate(target_cols):
+            if "multiclass" in args.task_type:
+                preds_slice = torch.from_numpy(preds[:, i : i + 1, :])
+                targets_slice = torch.from_numpy(targets[:, i : i + 1])
+            else:
+                preds_slice = torch.from_numpy(preds[:, i])
+                targets_slice = torch.from_numpy(targets[:, i])
+            preds_loss = metric(
+                preds_slice,
+                targets_slice,
+                mask[:, i],
+                None,
+                lt_mask[:, i] if lt_mask is not None else None,
+                gt_mask[:, i] if gt_mask is not None else None,
+            )
+            individual_scores[metric.alias].append(preds_loss)
+
+    logger.info("Entire Test Set results:")
+    for metric in metrics:
+        avg_loss = sum(individual_scores[metric.alias]) / len(individual_scores[metric.alias])
+        logger.info(f"entire_test/{metric.alias}: {avg_loss}")
+
+    if args.show_individual_scores:
+        logger.info("Entire Test Set individual results:")
+        for metric in metrics:
+            for i, col in enumerate(target_cols):
+                logger.info(
+                    f"entire_test/{col}/{metric.alias}: {individual_scores[metric.alias][i]}"
+                )
+
+    names = test_loader.dataset.names
+    if isinstance(test_loader.dataset, MulticomponentDataset):
+        namess = list(zip(*names))
+    else:
+        namess = [names]
+    if "multiclass" in args.task_type:
+        df_preds = pd.DataFrame(list(zip(*namess, preds)), columns=columns)
+    else:
+        df_preds = pd.DataFrame(list(zip(*namess, *preds.T)), columns=columns)
+    df_preds.to_csv(model_output_dir / "test_predictions.csv", index=False)
 
 
 def main(args):

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -42,6 +42,7 @@ from chemprop.nn.message_passing import (
     BondMessagePassing,
     MulticomponentMessagePassing,
 )
+from chemprop.nn.predictors import EvidentialFFN, MveFFN
 from chemprop.nn.transforms import GraphTransform, ScaleTransform, UnscaleTransform
 from chemprop.nn.utils import Activation
 from chemprop.utils import Factory
@@ -866,7 +867,12 @@ def train_model(
                 predss = trainer.predict(model, dataloaders=test_loader)
             else:
                 predss = trainer.predict(dataloaders=test_loader)
+
             preds = torch.concat(predss, 0).numpy()
+            if isinstance(model.predictor, MveFFN):
+                preds = np.split(preds, 2, axis=1)[0]
+            elif isinstance(model.predictor, EvidentialFFN):
+                preds = np.split(preds, 4, axis=1)[0]
 
             if isinstance(test_loader.dataset, MulticomponentDataset):
                 test_dset = test_loader.dataset.datasets[0]

--- a/chemprop/nn/predictors.py
+++ b/chemprop/nn/predictors.py
@@ -147,7 +147,7 @@ class _FFNPredictorBase(Predictor, HyperparametersMixin):
         return self.output_dim // self.n_targets
 
     def forward(self, Z: Tensor) -> Tensor:
-        return self.output_transform(self.ffn(Z))
+        return self.ffn(Z)
 
     def encode(self, Z: Tensor, i: int) -> Tensor:
         return self.ffn[:i](Z)
@@ -159,8 +159,10 @@ class RegressionFFN(_FFNPredictorBase):
     _T_default_criterion = MSELoss
     _T_default_metric = MSEMetric
 
-    def train_step(self, Z: Tensor) -> Tensor:
-        return super().forward(Z)
+    def forward(self, Z: Tensor) -> Tensor:
+        return self.output_transform(self.ffn(Z))
+
+    train_step = forward
 
 
 @PredictorRegistry.register("regression-mve")
@@ -169,20 +171,16 @@ class MveFFN(RegressionFFN):
     _T_default_criterion = MVELoss
 
     def forward(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z)
-        mean, var = torch.chunk(Y, self.n_targets, 1)
-
-        mean = self.scale * mean + self.loc
-        var = var * self.scale**2
-
-        return torch.cat((mean, var), 1)
-
-    def train_step(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z)
+        Y = self.ffn(Z)
         mean, var = torch.chunk(Y, self.n_targets, 1)
         var = F.softplus(var)
 
+        mean = self.output_transform(mean)
+        var = self.output_transform.transform_variance(var)
+
         return torch.cat((mean, var), 1)
+
+    train_step = forward
 
 
 @PredictorRegistry.register("regression-evidential")
@@ -191,23 +189,18 @@ class EvidentialFFN(RegressionFFN):
     _T_default_criterion = EvidentialLoss
 
     def forward(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z)
+        Y = self.ffn(Z)
         mean, v, alpha, beta = torch.chunk(Y, self.n_targets, 1)
-
-        mean = self.scale * mean + self.loc
-        v = v * self.scale**2
-
-        return torch.cat((mean, v, alpha, beta), 1)
-
-    def train_step(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z)
-        mean, v, alpha, beta = torch.chunk(Y, self.n_targets, 1)
-
         v = F.softplus(v)
         alpha = F.softplus(alpha) + 1
         beta = F.softplus(beta)
 
+        mean = self.output_transform(mean)
+        beta = self.output_transform.transform_variance(beta)
+
         return torch.cat((mean, v, alpha, beta), 1)
+
+    train_step = forward
 
 
 class BinaryClassificationFFNBase(_FFNPredictorBase):

--- a/chemprop/nn/transforms.py
+++ b/chemprop/nn/transforms.py
@@ -41,6 +41,11 @@ class UnscaleTransform(_ScaleTransformMixin):
 
         return X * self.scale + self.mean
 
+    def transform_variance(self, var: Tensor) -> Tensor:
+        if self.training:
+            return var
+        return var * (self.scale**2)
+
 
 class GraphTransform(nn.Module):
     def __init__(self, V_transform: ScaleTransform, E_transform: ScaleTransform):


### PR DESCRIPTION
## Description
Currently, the `output_transform` is applied to every prediction targets for regression tasks. However, the variance for the MVE model and the $\lambda$, $\alpha$, and $\beta$ parameters for the evidential model should be treated differently. Thus, a `transform_variance` function is added to unscale the variance by $\text{scale}^2$. The output transformation is now handled by the `UnscaleTransform` object via PR #726, but the update of output transformation for `MveFFN` and `EvidentialFFN` was missed at that time, so this PR also fixes this. For saving the prediction results, I only save the predicted property values. The other parameters related to uncertainty calculations will be used in prediction CLI with uncertainty methods specified, which will be implemented in PR #937.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
