### PR TITLE
change aggregation default to norm

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -200,7 +200,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     mp_args.add_argument(
         "--aggregation",
         "--agg",
-        default="mean",
+        default="norm",
         action=LookupAction(AggregationRegistry),
         help="the aggregation mode to use during graph predictor",
     )


### PR DESCRIPTION
In the v1 to v2 [transition guide](https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml#), we note that the default aggregation type was changed from mean to norm. But looks like we didn't actually make that change...

I don't think there will be any side affects to changing this default. Previous model files will have "mean" saved as a hyperparameter. All of our benchmarking scripts already specify `--aggregation norm`. 