### PR TITLE
Fix docs building by pinning sphinx-argparse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 [project.optional-dependencies]
 hpopt = ["ray[tune]", "hyperopt", "optuna"]
 dev = ["black == 23.*", "bumpversion", "autopep8", "flake8", "pytest", "pytest-cov", "isort"]
-docs = ["nbsphinx", "sphinx", "sphinx-argparse", "sphinx-autobuild", "sphinx-autoapi", "sphinxcontrib-bibtex", "sphinx-book-theme", "nbsphinx-link", "ipykernel", "docutils < 0.21", "readthedocs-sphinx-ext", "pandoc"]
+docs = ["nbsphinx", "sphinx", "sphinx-argparse != 0.5.0", "sphinx-autobuild", "sphinx-autoapi", "sphinxcontrib-bibtex", "sphinx-book-theme", "nbsphinx-link", "ipykernel", "docutils < 0.21", "readthedocs-sphinx-ext", "pandoc"]
 test = ["pytest >= 6.2", "pytest-cov"]
 notebooks = ["ipykernel"]
 


### PR DESCRIPTION
`sphinx-argparse` v0.5.0 has issues that cause it to fail (see https://github.com/sphinx-doc/sphinx-argparse/issues/56) while building docs. This PR forbids that version, and is aimed at avoiding readthedocs from failing while building (which is why other PRs have been failing the readthedocs test). 

I verified that this works locally.