### PR TITLE
Fix Failing CI for `torch==2.4.0` on Windows `ray[tune]` Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,6 @@ jobs:
       - name: Test with pytest
         shell: bash -l {0}
         run: |
-          # specifically disable running on GPU, otherwise Lightning will attempt to use the Apple GPU
-          # that the GitHub actions runners still have but are not allowed to actually use
           pytest -v tests
       - name: Test notebooks (excluding hpopting.ipynb)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
             channel_priority: flexible
           create-args: |
             python=${{ matrix.python-version }}
+      - name: Change Torch Version on Windows
+        if: matrix.os == 'windows-latest'
+        run: pip install 'torch!=2.4.0'
       - name: Install dependencies
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
## Description
Our CI is currently failing only on Windows during the Ray tests with this error:
```
2024-07-25 16:38:09,780	ERROR tune_controller.py:1331 -- Trial task failed for trial TorchTrainer_49485314
Traceback (most recent call last):
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\air\execution\_internal\event_manager.py", line 110, in resolve_future
    result = ray.get(future)
             ^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\worker.py", line 2656, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\worker.py", line 871, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(RuntimeError): ray::_Inner.train() (pid=5080, ip=127.0.0.1, actor_id=5226ecc2ec198a1c56e9[970](https://github.com/JacksonBurns/chemprop/actions/runs/10097911504/job/27923852431#step:6:971)101000000, repr=TorchTrainer)
  File "python\ray\_raylet.pyx", line 1901, in ray._raylet.execute_task
  File "python\ray\_raylet.pyx", line 1842, in ray._raylet.execute_task.function_executor
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\function_manager.py", line 691, in actor_method_executor
    return method(__ray_actor, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\util\tracing\tracing_helper.py", line 467, in _resume_span
    return method(self, *_args, **_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\tune\trainable\trainable.py", line 331, in train
    raise skipped from exception_cause(skipped)
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\air\_internal\util.py", line 98, in run
    self._ret = self._target(*self._args, **self._kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\tune\trainable\function_trainable.py", line 45, in <lambda>
    training_func=lambda: self._trainable_func(self.config),
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\util\tracing\tracing_helper.py", line 467, in _resume_span
    return method(self, *_args, **_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\train\base_trainer.py", line 799, in _trainable_func
    super()._trainable_func(self._merged_config)
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\tune\trainable\function_trainable.py", line 248, in _trainable_func
    output = fn()
             ^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\train\base_trainer.py", line 107, in _train_coordinator_fn
    trainer.training_loop()
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\train\data_parallel_trainer.py", line 458, in training_loop
    backend_executor.start()
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\train\_internal\backend_executor.py", line 195, in start
    self._backend.on_start(self.worker_group, self._backend_config)
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\train\torch\config.py", line 197, in on_start
    ray.get(setup_futures)
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\worker.py", line 2656, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\worker.py", line 871, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(RuntimeError): ray::_RayTrainWorker__execute._setup_torch_process_group() (pid=2532, ip=127.0.0.1, actor_id=ea033bd6a8de4c9eda3de9aa0[1000](https://github.com/JacksonBurns/chemprop/actions/runs/10097911504/job/27923852431#step:6:1001)000, repr=<ray.train._internal.worker_group.RayTrainWorker object at 0x000001638E37A210>)
  File "python\ray\_raylet.pyx", line 1901, in ray._raylet.execute_task
  File "python\ray\_raylet.pyx", line 1842, in ray._raylet.execute_task.function_executor
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\_private\function_manager.py", line 691, in actor_method_executor
    return method(__ray_actor, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\util\tracing\tracing_helper.py", line 467, in _resume_span
    return method(self, *_args, **_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\train\_internal\worker_group.py", line 33, in __execute
    raise skipped from exception_cause(skipped)
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\train\_internal\worker_group.py", line 30, in __execute
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\ray\train\torch\config.py", line 112, in _setup_torch_process_group
    dist.init_process_group(
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\torch\distributed\c10d_logger.py", line 79, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\torch\distributed\c10d_logger.py", line 93, in wrapper
    func_return = func(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\torch\distributed\distributed_c10d.py", line 1361, in init_process_group
    store, rank, world_size = next(rendezvous_iterator)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\torch\distributed\rendezvous.py", line 258, in _env_rendezvous_handler
    store = _create_c10d_store(master_addr, master_port, rank, world_size, timeout, use_libuv)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\micromamba\envs\temp\Lib\site-packages\torch\distributed\rendezvous.py", line 185, in _create_c10d_store
    return TCPStore(
           ^^^^^^^^^
RuntimeError: use_libuv was requested but PyTorch was build without libuv support
```

## Bugfix / Desired workflow
Latest version of PyTorch changed the communication backend for distributed, see https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html and https://pytorch.org/blog/pytorch2-4/

This fix just avoids that version.

## Questions
I have chosen to fix this by simply avoiding this new version of PyTorch on Windows in the actions runner, rather than the pyproject or somewhere else, since I think this will be resolved upstream eventually. We just want to be able to go back to merging PRs, and this fix is small, simple, and easily reverted once the actual cause is addressed.

