### PR TITLE
Bug: Move `task_weights` to 'device' for MCC metrics

### DIFF
--- a/chemprop/nn/loss.py
+++ b/chemprop/nn/loss.py
@@ -188,7 +188,7 @@ class BinaryMCCLoss(LossFunction):
             preds = preds.sigmoid()
 
         L = self._calc_unreduced_loss(preds, targets.long(), mask, weights, *args)
-        L = L * self.task_weights
+        L = L * self.task_weights.to(preds.device)
 
         return L.mean()
 
@@ -219,7 +219,7 @@ class MulticlassMCCLoss(LossFunction):
             preds = preds.softmax(2)
 
         L = self._calc_unreduced_loss(preds, targets.long(), mask, weights, *args)
-        L = L * self.task_weights
+        L = L * self.task_weights.to(preds.device)
 
         return L.mean()
 


### PR DESCRIPTION
## Description
When running on a GPU, using MCC metrics such as `BinaryMCCMetric()` results in the following error: `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`

## Example / Current workflow
```
    188     preds = preds.sigmoid()
    190 L = self._calc_unreduced_loss(preds, targets.long(), mask, weights, *args)
--> 191 L = L * self.task_weights
    193 return L.mean()

RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

## Bugfix / Desired workflow
Retrieve the device information from `preds` and move the tensors to the device using the `to` method.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
