### PR TITLE
Convert v1 models trained on GPU

### DIFF
--- a/chemprop/models/utils.py
+++ b/chemprop/models/utils.py
@@ -12,8 +12,8 @@ def save_model(path: PathLike, model: MPNN) -> None:
 
 def load_model(path: PathLike, multicomponent: bool) -> MPNN:
     if multicomponent:
-        model = MulticomponentMPNN.load_from_file(path, map_location=lambda storage, loc: storage)
+        model = MulticomponentMPNN.load_from_file(path, map_location=torch.device("cpu"))
     else:
-        model = MPNN.load_from_file(path, map_location=lambda storage, loc: storage)
+        model = MPNN.load_from_file(path, map_location=torch.device("cpu"))
 
     return model

--- a/chemprop/utils/v1_to_v2.py
+++ b/chemprop/utils/v1_to_v2.py
@@ -146,6 +146,6 @@ def convert_model_dict_v1_to_v2(model_v1_dict: dict) -> dict:
 def convert_model_file_v1_to_v2(model_v1_file: PathLike, model_v2_file: PathLike) -> None:
     """Converts a v1 model .pt file to a v2 model .ckpt file"""
 
-    model_v1_dict = torch.load(model_v1_file)
+    model_v1_dict = torch.load(model_v1_file, map_location=torch.device("cpu"))
     model_v2_dict = convert_model_dict_v1_to_v2(model_v1_dict)
     torch.save(model_v2_dict, model_v2_file)


### PR DESCRIPTION
Similar to #950, if a model is trained on a GPU, torch remembers that and when loading onto a cpu only machine, we need to tell it to load onto the CPU. 

Question: In #950 we used `map_location=lambda storage, loc: storage` instead of `map_location=torch.device("cpu")`. Should I do the same thing here?