### PR TITLE
Minor: Fix frzn-ffn-layers description and update doc for transfer learning

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -107,13 +107,13 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     transfer_args = parser.add_argument_group("transfer learning args")
     transfer_args.add_argument(
         "--model-frzn",
-        help="Path to model checkpoint file to be loaded for overwriting and freezing weights",
+        help="Path to model checkpoint file to be loaded for overwriting and freezing weights. By default, all MPNN weights are frozen with this option.",
     )
     transfer_args.add_argument(
         "--frzn-ffn-layers",
         type=int,
         default=0,
-        help="Freeze the first n layers (default is 0, no layers frozen) of the FFN from the checkpoint model (specified by ``model-frzn``). This option also freezes all MPNN weights.",
+        help="Freeze the first ``n`` layers of the FFN from the checkpoint model (specified by ``model-frzn``).",
     )
     # transfer_args.add_argument(
     #     "--freeze-first-only",

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -113,7 +113,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         "--frzn-ffn-layers",
         type=int,
         default=0,
-        help="Overwrites weights for the first n layers of the ffn from checkpoint model (specified ``model-frzn``), where n is specified in the input (also automatically freezes mpnn weights)",
+        help="Freeze the first n layers (default is 0, no layers frozen) of the FFN from the checkpoint model (specified by ``model-frzn``). This option also freezes all MPNN weights.",
     )
     # transfer_args.add_argument(
     #     "--freeze-first-only",

--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -162,8 +162,8 @@ The following evaluation metrics are supported during training:
 Advanced Training Methods
 -------------------------
 
-Pretraining
-^^^^^^^^^^^
+Pretraining and Transfer Learning
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. An existing model, for example from training on a larger, lower quality dataset, can be used for parameter-initialization of a new model by providing a checkpoint of the existing model using either:
 
@@ -171,9 +171,9 @@ Pretraining
 ..  * :code:`--checkpoint-path <path>` Path to a model checkpoint file (:code:`.pt` file).
 .. when training the new model. The model architecture of the new model should resemble the architecture of the old model - otherwise some or all parameters might not be loaded correctly. Please note that the old model is only used to initialize the parameters of the new model, but all parameters remain trainable (no frozen layers). Depending on the quality of the old model, the new model might only need a few epochs to train.
 
-It is possible to freeze the weights of a loaded model during training, such as for transfer learning applications. To do so, specify :code:`--model-frzn <path>` where :code:`<path>` refers to a model's checkpoint file that will be used to overwrite and freeze the model weights. The following flags may be used:
+It is possible to freeze the weights of a loaded Chemprop model during training, such as for transfer learning applications. To do so, you first need to load a pre-trained model by specifying its checkpoint file using :code:--model-frzn <path>, where :code:<path> points to the checkpoint file location. After loading the model, you can control how the weights are frozen during training.
 
- * :code:`--frzn-ffn-layers <n>` Overwrites weights for the first n layers of the FFN from the checkpoint (default 0)  
+For example, you can use the :code:--frzn-ffn-layers <n> flag to freeze the weights of the first (right after MPNN) n layers of the FFN from the checkpoint. The remaining layers of the FFN will remain trainable. Additionally, this option automatically freezes all weights in the MPNN. By default, :code:n is set to 0, meaning all FFN layers are trainable unless specified otherwise.
 
 .. _train-on-reactions:
 

--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -171,9 +171,7 @@ Pretraining and Transfer Learning
 ..  * :code:`--checkpoint-path <path>` Path to a model checkpoint file (:code:`.pt` file).
 .. when training the new model. The model architecture of the new model should resemble the architecture of the old model - otherwise some or all parameters might not be loaded correctly. Please note that the old model is only used to initialize the parameters of the new model, but all parameters remain trainable (no frozen layers). Depending on the quality of the old model, the new model might only need a few epochs to train.
 
-It is possible to freeze the weights of a loaded Chemprop model during training, such as for transfer learning applications. To do so, you first need to load a pre-trained model by specifying its checkpoint file using :code:--model-frzn <path>, where :code:<path> points to the checkpoint file location. After loading the model, you can control how the weights are frozen during training.
-
-For example, you can use the :code:--frzn-ffn-layers <n> flag to freeze the weights of the first (right after MPNN) n layers of the FFN from the checkpoint. The remaining layers of the FFN will remain trainable. Additionally, this option automatically freezes all weights in the MPNN. By default, :code:n is set to 0, meaning all FFN layers are trainable unless specified otherwise.
+It is possible to freeze the weights of a loaded Chemprop model during training, such as for transfer learning applications. To do so, you first need to load a pre-trained model by specifying its checkpoint file using :code:`--model-frzn <path>`, where :code:`<path>` points to the checkpoint file location. After loading the model, the MPNN weights are automatically frozen. You can control how the weights are frozen in the FFN layers by using :code:`--frzn-ffn-layers <n>` flag, where the :code:`n` is the first n layers are frozen in the FFN layers. By default, :code:`n` is set to 0, meaning all FFN layers are trainable unless specified otherwise.
 
 .. _train-on-reactions:
 


### PR DESCRIPTION
## Description
The description of training flag `--frzn-ffn-layers` 

https://github.com/chemprop/chemprop/blob/590c32cf14df93bf964d3dac367b202628dd90ea/chemprop/cli/train.py#L112-L117

is incorrect because its actual (and desired) behavior is **freezing** the weights in the first n layers of FFN, instead of **overwritting** them as evident by the following code:

https://github.com/chemprop/chemprop/blob/590c32cf14df93bf964d3dac367b202628dd90ea/chemprop/cli/train.py#L784-L786

Thus, the implementation of `--frzn-ffn-layers` is correct but the description has a typo. This PR fixed this typo. In addition, the corresponding part of the documentation is updated to reflect this change and made more clear.



