### PR TITLE
V2: Fix `save-smiles-splits` not working with rxn. columns as column header

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -565,11 +565,11 @@ def save_config(parser: ArgumentParser, args: Namespace, config_path: Path):
 def save_smiles_splits(args: Namespace, output_dir, train_dset, val_dset, test_dset):
     match (args.smiles_columns, args.reaction_columns):
         case [_, None]:
-            column_labels = args.smiles_columns
+            column_labels = deepcopy(args.smiles_columns)
         case [None, _]:
-            column_labels = args.reaction_columns
+            column_labels = deepcopy(args.reaction_columns)
         case _:
-            column_labels = args.smiles_columns
+            column_labels = deepcopy(args.smiles_columns)
             column_labels.extend(args.reaction_columns)
 
     train_smis = train_dset.smiles

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -582,7 +582,7 @@ def save_smiles_splits(args: Namespace, output_dir, train_dset, val_dset, test_d
 
     if test_dset is not None:
         test_smis = test_dset.smiles
-        df_test = pd.DataFrame(test_smis, columns=args.column_labels)
+        df_test = pd.DataFrame(test_smis, columns=column_labels)
         df_test.to_csv(output_dir / "test_smiles.csv", index=False)
 
 

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -563,14 +563,23 @@ def save_config(parser: ArgumentParser, args: Namespace, config_path: Path):
 
 
 def save_smiles_splits(args: Namespace, output_dir, train_dset, val_dset, test_dset):
+    match (args.smiles_columns, args.reaction_columns):
+        case [_, None]:
+            column_labels = args.smiles_columns
+        case [None, _]:
+            column_labels = args.reaction_columns
+        case _:
+            column_labels = args.smiles_columns
+            column_labels.extend(args.reaction_columns)
+
     train_smis = train_dset.smiles
-    df_train = pd.DataFrame(train_smis, columns=args.smiles_columns)
+    df_train = pd.DataFrame(train_smis, columns=column_labels)
     df_train.to_csv(output_dir / "train_smiles.csv", index=False)
 
     val_smis = val_dset.smiles
-    df_val = pd.DataFrame(val_smis, columns=args.smiles_columns)
+    df_val = pd.DataFrame(val_smis, columns=column_labels)
     df_val.to_csv(output_dir / "val_smiles.csv", index=False)
-
+    
     if test_dset is not None:
         test_smis = test_dset.smiles
         df_test = pd.DataFrame(test_smis, columns=args.smiles_columns)

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -572,16 +572,16 @@ def save_smiles_splits(args: Namespace, output_dir, train_dset, val_dset, test_d
             column_labels = deepcopy(args.smiles_columns)
             column_labels.extend(args.reaction_columns)
 
-    train_smis = train_dset.smiles
+    train_smis = train_dset.names
     df_train = pd.DataFrame(train_smis, columns=column_labels)
     df_train.to_csv(output_dir / "train_smiles.csv", index=False)
 
-    val_smis = val_dset.smiles
+    val_smis = val_dset.names
     df_val = pd.DataFrame(val_smis, columns=column_labels)
     df_val.to_csv(output_dir / "val_smiles.csv", index=False)
 
     if test_dset is not None:
-        test_smis = test_dset.smiles
+        test_smis = test_dset.names
         df_test = pd.DataFrame(test_smis, columns=column_labels)
         df_test.to_csv(output_dir / "test_smiles.csv", index=False)
 

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -579,7 +579,7 @@ def save_smiles_splits(args: Namespace, output_dir, train_dset, val_dset, test_d
     val_smis = val_dset.smiles
     df_val = pd.DataFrame(val_smis, columns=column_labels)
     df_val.to_csv(output_dir / "val_smiles.csv", index=False)
-    
+
     if test_dset is not None:
         test_smis = test_dset.smiles
         df_test = pd.DataFrame(test_smis, columns=args.smiles_columns)

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -582,7 +582,7 @@ def save_smiles_splits(args: Namespace, output_dir, train_dset, val_dset, test_d
 
     if test_dset is not None:
         test_smis = test_dset.smiles
-        df_test = pd.DataFrame(test_smis, columns=args.smiles_columns)
+        df_test = pd.DataFrame(test_smis, columns=args.column_labels)
         df_test.to_csv(output_dir / "test_smiles.csv", index=False)
 
 


### PR DESCRIPTION
## Description
Previously, including reaction smiles while enabling `save-smiles-splits` caused chemprop to crash. This is because sometimes reaction SMILES are used to describe datapoints instead of (or in addition to) molecular SMILES.

## Bugfix / Desired workflow
This changes the `columns` flag when constructing the DataFrame such that the column(s) passed is/are a smiles column, reaction column, or combination of both (depending on whichever ones are present).

## Questions / Outstanding issues
Previous question was addressed in latest commits.

## Relevant issues
#643 was the first to point this out

## Checklist
- [x] linted with flake8?
