### PR TITLE
fix no-header-rows in predict command error

### DIFF
--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -292,7 +292,9 @@ def make_prediction_for_models(
             f"pred_{i}" for i in range(preds.shape[1])
         ]  # TODO: need to improve this for cases like multi-task MVE and multi-task multiclass
 
-    df_test = pd.read_csv(args.test_path, header=None if args.no_header_row else "infer", index_col=False)
+    df_test = pd.read_csv(
+        args.test_path, header=None if args.no_header_row else "infer", index_col=False
+    )
     df_test[target_columns] = average_preds
     if output_path.suffix == ".pkl":
         df_test = df_test.reset_index(drop=True)
@@ -307,7 +309,9 @@ def make_prediction_for_models(
             f"{col}_model_{i}" for i in range(len(model_paths)) for col in target_columns
         ]
 
-        df_test = pd.read_csv(args.test_path, header=None if args.no_header_row else "infer", index_col=False)
+        df_test = pd.read_csv(
+            args.test_path, header=None if args.no_header_row else "infer", index_col=False
+        )
         df_test[target_columns] = individual_preds
 
         output_path = output_path.parent / Path(

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -292,7 +292,7 @@ def make_prediction_for_models(
             f"pred_{i}" for i in range(preds.shape[1])
         ]  # TODO: need to improve this for cases like multi-task MVE and multi-task multiclass
 
-    df_test = pd.read_csv(args.test_path)
+    df_test = pd.read_csv(args.test_path, header=None if args.no_header_row else "infer", index_col=False)
     df_test[target_columns] = average_preds
     if output_path.suffix == ".pkl":
         df_test = df_test.reset_index(drop=True)
@@ -307,7 +307,7 @@ def make_prediction_for_models(
             f"{col}_model_{i}" for i in range(len(model_paths)) for col in target_columns
         ]
 
-        df_test = pd.read_csv(args.test_path)
+        df_test = pd.read_csv(args.test_path, header=None if args.no_header_row else "infer", index_col=False)
         df_test[target_columns] = individual_preds
 
         output_path = output_path.parent / Path(


### PR DESCRIPTION
## Description
`chemprop predict` command failed if `--no-header-fix` was used with the following error:

>   File "/Users/sunhwan/work/beren/misc/chemprop/chemprop/cli/predict.py", line 297, in make_prediction_for_models
>     df_test[target_columns] = average_preds
>     ~~~~~~~^^^^^^^^^^^^^^^^
>   File "/Users/sunhwan/miniforge3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4299, in __setitem__
>     self._setitem_array(key, value)
>   File "/Users/sunhwan/miniforge3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4355, in _setitem_array
>     return self._setitem_array(key, value)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/sunhwan/miniforge3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4350, in _setitem_array
>     self._iset_not_inplace(key, value)
>   File "/Users/sunhwan/miniforge3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4380, in _iset_not_inplace
>     self[col] = igetitem(value, i)
>     ~~~~^^^^^
>   File "/Users/sunhwan/miniforge3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4311, in __setitem__
>     self._set_item(key, value)
>   File "/Users/sunhwan/miniforge3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4524, in _set_item
>     value, refs = self._sanitize_column(value)
>                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/sunhwan/miniforge3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 5266, in _sanitize_column
>     com.require_length_match(value, self.index)
>   File "/Users/sunhwan/miniforge3/envs/chemprop/lib/python3.11/site-packages/pandas/core/common.py", line 573, in require_length_match
>     raise ValueError(
> ValueError: Length of values (5) does not match length of index (4)

## Example / Current workflow
To reproduce:
1. remove header from `tests/data/test_smiles.csv` file
2. run `chemprop predict --test-path tests/data/test_smiles.csv --model-path tests/data/example_model_v2_regression_mol.pt --no-header-row`
