### PR TITLE
change installed torch version on windows actions again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             python=${{ matrix.python-version }}
       - name: Change Torch Version on Windows
         if: matrix.os == 'windows-latest'
-        run: pip install 'torch!=2.4.0'
+        run: pip install 'torch!=2.4.0,!=2.4.1'
       - name: Install dependencies
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
## Description
@jonwzheng pointed out the CI is failing since yesterday. https://github.com/chemprop/chemprop/actions/runs/10716656341/job/29714670717

@JacksonBurns fixed the same issue in #971 by restricting the torch version

@shihchengli also suggests setting `USE_LIBUV` to `0`, or find a way to install PyTorch with `libuv` support on Windows.

Lets see if restricting the torch version works to start.
