### PR TITLE
Fix `BinaryDirichletFFN` and  `MulticlassDirichletFFN` predictors

### DIFF
--- a/chemprop/nn/predictors.py
+++ b/chemprop/nn/predictors.py
@@ -229,14 +229,17 @@ class BinaryDirichletFFN(BinaryClassificationFFNBase):
     _T_default_metric = BinaryAUROCMetric
 
     def forward(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z)
-        alpha, beta = torch.chunk(Y, self.n_targets, 1)
-        Y = beta / (alpha + beta)
+        Y = super().forward(Z).reshape(len(Z), -1, 2)
 
-        return Y.reshape(Y.shape[0], -1, 1)
+        alpha = F.softplus(Y) + 1
+
+        u = 2 / alpha.sum(-1)
+        Y = alpha / alpha.sum(-1, keepdim=True)
+
+        return torch.stack((Y[..., 1], u), dim=2)
 
     def train_step(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z)
+        Y = super().forward(Z).reshape(len(Z), -1, 2)
 
         return F.softplus(Y) + 1
 
@@ -294,18 +297,16 @@ class MulticlassDirichletFFN(MulticlassClassificationFFN):
     _T_default_metric = CrossEntropyMetric
 
     def forward(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z).reshape(len(Z), -1, self.n_classes)
+        Y = super().train_step(Z)
 
-        Y = Y.softmax(-1)
-        Y = F.softplus(Y) + 1
+        alpha = F.softplus(Y) + 1
 
-        alpha = Y
-        Y = Y / Y.sum(-1, keepdim=True)
+        Y = alpha / alpha.sum(-1, keepdim=True)
 
-        return torch.cat((Y, alpha), 1)
+        return Y
 
     def train_step(self, Z: Tensor) -> Tensor:
-        Y = super().forward(Z).reshape(len(Z), -1, self.n_classes)
+        Y = super().train_step(Z)
 
         return F.softplus(Y) + 1
 

--- a/tests/cli/test_cli_classification_mol.py
+++ b/tests/cli/test_cli_classification_mol.py
@@ -42,7 +42,6 @@ def test_train_quick(monkeypatch, data_path):
     task_types = ["classification", "classification-dirichlet"]
 
     for task_type in task_types:
-        print(f"Testing task type: {task_type}")
         args = base_args.copy()
 
         args += ["--task-type", task_type]

--- a/tests/cli/test_cli_classification_mol_multiclass.py
+++ b/tests/cli/test_cli_classification_mol_multiclass.py
@@ -20,7 +20,7 @@ def model_path(data_dir):
 
 
 def test_train_quick(monkeypatch, data_path):
-    args = [
+    base_args = [
         "chemprop",
         "train",
         "-i",
@@ -29,14 +29,21 @@ def test_train_quick(monkeypatch, data_path):
         "3",
         "--num-workers",
         "0",
-        "--task-type",
-        "multiclass",
         "--show-individual-scores",
+        "--accelerator",
+        "cpu",
     ]
 
-    with monkeypatch.context() as m:
-        m.setattr("sys.argv", args)
-        main()
+    task_types = ["multiclass", "multiclass-dirichlet"]
+
+    for task_type in task_types:
+        args = base_args.copy()
+
+        args += ["--task-type", task_type]
+
+        with monkeypatch.context() as m:
+            m.setattr("sys.argv", args)
+            main()
 
 
 def test_predict_quick(monkeypatch, data_path, model_path):


### PR DESCRIPTION
## Description
As identified in previous PR (https://github.com/chemprop/chemprop/pull/959#discussion_r1747656884), the predictors for `BinaryDirichletFFN` are not correct. Based on the original [paper](https://arxiv.org/abs/1806.01768), the logits should be passed into an activation function like `ReLU` to get non-negative output ($\alpha_i$). Here, we use `SoftPlus`. Then, the corresponding Dirichlet distribution has parameters:

$$ \alpha_i = f(\mathbf{x}_i \mid \Theta) + 1 $$

where $\Theta$ is the trained network. The probability of each class can be calculated as:

$$ \frac{\alpha_i}{\mathbf{S}} $$

where $\mathbf{S} = \sum_{i=1}^{K} \alpha_i$ and  $K$ is the number of class labels. The uncertainty can be calculated  as:

$$ \frac{K}{\mathbf{S}} $$


## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
