### PR TITLE
Test v2.1 dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, v2-1/dev]
   # run this in the morning on weekdays to catch dependency issues
   schedule:
     - cron: "0 8 * * 1-5"


### PR DESCRIPTION
We'd like to have a branch to collect our changes for v2.1 (API and default behavior changes). I'm adding this branch to our CI so it will be tested and make merging into main at the v2.1 release easier. 

@JacksonBurns Is this the right way to do this?