### PR TITLE
Add floor to spectral targets for positive targets

### DIFF
--- a/chemprop/nn/loss.py
+++ b/chemprop/nn/loss.py
@@ -311,7 +311,7 @@ class MulticlassDirichletLoss(DirichletMixin, LossFunction):
 
 @LossFunctionRegistry.register("sid")
 class SIDLoss(LossFunction):
-    def __init__(self, task_weights: ArrayLike = 1.0, threshold: float | None = None):
+    def __init__(self, task_weights: ArrayLike = 1.0, threshold: float | None = 1e-8):
         super().__init__(task_weights)
 
         self.threshold = threshold
@@ -319,6 +319,7 @@ class SIDLoss(LossFunction):
     def _calc_unreduced_loss(self, preds: Tensor, targets: Tensor, mask: Tensor, *args) -> Tensor:
         if self.threshold is not None:
             preds = preds.clamp(min=self.threshold)
+            targets = targets.clamp(min=self.threshold)
 
         preds_norm = preds / (preds * mask).sum(1, keepdim=True)
 
@@ -333,7 +334,7 @@ class SIDLoss(LossFunction):
 
 @LossFunctionRegistry.register(["earthmovers", "wasserstein"])
 class WassersteinLoss(LossFunction):
-    def __init__(self, task_weights: ArrayLike = 1.0, threshold: float | None = None):
+    def __init__(self, task_weights: ArrayLike = 1.0, threshold: float | None = 1e-8):
         super().__init__(task_weights)
 
         self.threshold = threshold
@@ -341,6 +342,7 @@ class WassersteinLoss(LossFunction):
     def _calc_unreduced_loss(self, preds: Tensor, targets: Tensor, mask: Tensor, *args) -> Tensor:
         if self.threshold is not None:
             preds = preds.clamp(min=self.threshold)
+            targets = targets.clamp(min=self.threshold)
 
         preds_norm = preds / (preds * mask).sum(1, keepdim=True)
 

--- a/tests/unit/test_loss_functions.py
+++ b/tests/unit/test_loss_functions.py
@@ -436,7 +436,7 @@ def test_MulticlassMCC(
             torch.ones([2], dtype=torch.bool),
             torch.ones([2], dtype=torch.bool),
             0.5,
-            torch.tensor(0.033673, dtype=torch.float),
+            torch.tensor(0.021015, dtype=torch.float),
         ),
     ],
 )
@@ -486,7 +486,7 @@ def test_SID(
             torch.zeros([2, 4], dtype=torch.bool),
             torch.zeros([2, 4], dtype=torch.bool),
             0.3,
-            torch.tensor(0.501984, dtype=torch.float),
+            torch.tensor(0.611706, dtype=torch.float),
         ),
     ],
 )


### PR DESCRIPTION
I changed the expected value for SID and Wasserstein for one of the tests because I don't think `threshold` was implemented correctly. 

The spectra need to only have positive values, which is ensured by using `exp()` on the predictions, but for targets, the user should be able to supply a `threshold` that is a min value for the targets which in v1 defaulted to `1e-8`. See the v1 [README](https://github.com/chemprop/chemprop/blob/02c760216ec03488b69b41abe184589b9c996d74/README.md?plain=1#L333) and this [line](https://github.com/chemprop/chemprop/blob/02c760216ec03488b69b41abe184589b9c996d74/chemprop/train/run_training.py#L188) of code. We still need to make this available to CLI users, not sure if that is in the scope of this PR 

Partly address #1008. It doesn't sum normalize the targets.