### PR TITLE
Fix `hpopting` Notebook and CLI for Windows

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -416,6 +416,7 @@ def tune_model(
         num_samples=args.raytune_num_samples,
         scheduler=scheduler,
         search_alg=search_alg,
+        trial_dirname_creator=lambda trial: str(trial.trial_id),
     )
 
     tuner = tune.Tuner(

--- a/examples/hpopting.ipynb
+++ b/examples/hpopting.ipynb
@@ -999,7 +999,7 @@
     "    num_samples=2, # number of trials to run\n",
     "    scheduler=scheduler,\n",
     "    search_alg=search_alg,\n",
-    "    trial_dirname_creator=lambda trial: str(trial.trial_id),  # shorten filepaths for Windows\n",
+    "    trial_dirname_creator=lambda trial: str(trial.trial_id), # shorten filepaths\n",
     "    \n",
     ")\n",
     "\n",

--- a/examples/hpopting.ipynb
+++ b/examples/hpopting.ipynb
@@ -999,6 +999,7 @@
     "    num_samples=2, # number of trials to run\n",
     "    scheduler=scheduler,\n",
     "    search_alg=search_alg,\n",
+    "    trial_dirname_creator=lambda trial: str(trial.trial_id),  # shorten filepaths for Windows\n",
     "    \n",
     ")\n",
     "\n",


### PR DESCRIPTION
Resolves #1033 - `ray` will make filepaths for saving intermediate results that are too long for Windows. This implements `ray`'s suggested fix, which is to pass a custom 'name-r' for the trials that makes them shorter.

@shihchengli please review