### PR TITLE
Update pyproject.toml to exclude tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,6 @@ addopts = "--cov chemprop"
 profile = "black"
 line_length = 100
 force_sort_within_sections = true
+
+[tool.setuptools.packages.find]
+exclude = ["examples", "docs", "test_cli_classification_mol", "test_cli_classification_mol_multiclass", "test_cli_regression_mol", "test_cli_regression_mol+mol", "test_cli_regression_mol_multitask", "test_cli_regression_rxn", "test_cli_regression_rxn+mol", "tests"]


### PR DESCRIPTION
## Description
Fix `pyproject.toml` to exclude tests from being installed


## Relevant issues
See related [issue](https://github.com/chemprop/chemprop/issues/1056)

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
