### PR TITLE
add ModelCheckpointing to training.ipynb so best model is used automatically

### DIFF
--- a/examples/training.ipynb
+++ b/examples/training.ipynb
@@ -16,7 +16,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 19,
+            "execution_count": 52,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -24,8 +24,9 @@
                 "from pathlib import Path\n",
                 "\n",
                 "from lightning import pytorch as pl\n",
+                "from lightning.pytorch.callbacks import ModelCheckpoint\n",
                 "\n",
-                "from chemprop import data, featurizers, models, nn"
+                "from chemprop import data, featurizers, models, nn\n"
             ]
         },
         {
@@ -37,7 +38,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 20,
+            "execution_count": 53,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -57,7 +58,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 21,
+            "execution_count": 54,
             "metadata": {},
             "outputs": [
                 {
@@ -163,7 +164,7 @@
                             "[100 rows x 2 columns]"
                         ]
                     },
-                    "execution_count": 21,
+                    "execution_count": 54,
                     "metadata": {},
                     "output_type": "execute_result"
                 }
@@ -182,7 +183,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 22,
+            "execution_count": 55,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -192,7 +193,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 23,
+            "execution_count": 56,
             "metadata": {},
             "outputs": [
                 {
@@ -206,7 +207,7 @@
                             "      dtype=object)"
                         ]
                     },
-                    "execution_count": 23,
+                    "execution_count": 56,
                     "metadata": {},
                     "output_type": "execute_result"
                 }
@@ -217,7 +218,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 24,
+            "execution_count": 57,
             "metadata": {},
             "outputs": [
                 {
@@ -230,7 +231,7 @@
                             "       [ 3.1 ]])"
                         ]
                     },
-                    "execution_count": 24,
+                    "execution_count": 57,
                     "metadata": {},
                     "output_type": "execute_result"
                 }
@@ -248,7 +249,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 25,
+            "execution_count": 58,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -264,7 +265,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 26,
+            "execution_count": 59,
             "metadata": {},
             "outputs": [
                 {
@@ -279,7 +280,7 @@
                             " 'KMEANS']"
                         ]
                     },
-                    "execution_count": 26,
+                    "execution_count": 59,
                     "metadata": {},
                     "output_type": "execute_result"
                 }
@@ -291,7 +292,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 27,
+            "execution_count": 60,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -311,7 +312,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 28,
+            "execution_count": 61,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -335,7 +336,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 29,
+            "execution_count": 62,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -363,7 +364,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 30,
+            "execution_count": 63,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -385,7 +386,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 31,
+            "execution_count": 64,
             "metadata": {},
             "outputs": [
                 {
@@ -406,7 +407,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 32,
+            "execution_count": 65,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -440,7 +441,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 33,
+            "execution_count": 66,
             "metadata": {},
             "outputs": [
                 {
@@ -466,27 +467,16 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 34,
+            "execution_count": 67,
             "metadata": {},
-            "outputs": [
-                {
-                    "name": "stderr",
-                    "output_type": "stream",
-                    "text": [
-                        "/home/hwpang/Projects/chemprop_v2_dev/chemprop/chemprop/nn/transforms.py:21: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
-                        "  self.register_buffer(\"mean\", torch.tensor(mean, dtype=torch.float).unsqueeze(0))\n",
-                        "/home/hwpang/Projects/chemprop_v2_dev/chemprop/chemprop/nn/transforms.py:22: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
-                        "  self.register_buffer(\"scale\", torch.tensor(scale, dtype=torch.float).unsqueeze(0))\n"
-                    ]
-                }
-            ],
+            "outputs": [],
             "source": [
                 "output_transform = nn.UnscaleTransform.from_standard_scaler(scaler)"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 35,
+            "execution_count": 68,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -505,7 +495,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 36,
+            "execution_count": 69,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -524,7 +514,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 37,
+            "execution_count": 70,
             "metadata": {},
             "outputs": [
                 {
@@ -539,10 +529,10 @@
                         "    'bounded-mse': <class 'chemprop.nn.metrics.BoundedMSEMetric'>,\n",
                         "    'bounded-rmse': <class 'chemprop.nn.metrics.BoundedRMSEMetric'>,\n",
                         "    'r2': <class 'chemprop.nn.metrics.R2Metric'>,\n",
-                        "    'roc': <class 'chemprop.nn.metrics.AUROCMetric'>,\n",
-                        "    'prc': <class 'chemprop.nn.metrics.AUPRCMetric'>,\n",
-                        "    'accuracy': <class 'chemprop.nn.metrics.AccuracyMetric'>,\n",
-                        "    'f1': <class 'chemprop.nn.metrics.F1Metric'>,\n",
+                        "    'roc': <class 'chemprop.nn.metrics.BinaryAUROCMetric'>,\n",
+                        "    'prc': <class 'chemprop.nn.metrics.BinaryAUPRCMetric'>,\n",
+                        "    'accuracy': <class 'chemprop.nn.metrics.BinaryAccuracyMetric'>,\n",
+                        "    'f1': <class 'chemprop.nn.metrics.BinaryF1Metric'>,\n",
                         "    'bce': <class 'chemprop.nn.metrics.BCEMetric'>,\n",
                         "    'ce': <class 'chemprop.nn.metrics.CrossEntropyMetric'>,\n",
                         "    'binary-mcc': <class 'chemprop.nn.metrics.BinaryMCCMetric'>,\n",
@@ -559,7 +549,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 38,
+            "execution_count": 71,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -575,7 +565,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 39,
+            "execution_count": 72,
             "metadata": {},
             "outputs": [
                 {
@@ -604,14 +594,14 @@
                             "        (2): Linear(in_features=300, out_features=1, bias=True)\n",
                             "      )\n",
                             "    )\n",
-                            "    (criterion): MSELoss()\n",
+                            "    (criterion): MSELoss(task_weights=[[1.0]])\n",
                             "    (output_transform): UnscaleTransform()\n",
                             "  )\n",
                             "  (X_d_transform): Identity()\n",
                             ")"
                         ]
                     },
-                    "execution_count": 39,
+                    "execution_count": 72,
                     "metadata": {},
                     "output_type": "execute_result"
                 }
@@ -631,14 +621,14 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 40,
+            "execution_count": 73,
             "metadata": {},
             "outputs": [
                 {
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python /home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/pyt ...\n",
+                        "/home/donera/mambaforge/envs/chemprop/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python /home/donera/mambaforge/envs/chemprop/lib/python3.11 ...\n",
                         "GPU available: True (cuda), used: True\n",
                         "TPU available: False, using: 0 TPU cores\n",
                         "IPU available: False, using: 0 IPUs\n",
@@ -647,6 +637,16 @@
                 }
             ],
             "source": [
+                "# Configure model checkpointing\n",
+                "checkpointing = ModelCheckpoint(\n",
+                "    \"checkpoints\",  # Directory where model checkpoints will be saved\n",
+                "    \"best-{epoch}-{val_loss:.2f}\",  # Filename format for checkpoints, including epoch and validation loss\n",
+                "    \"val_loss\",  # Metric used to select the best checkpoint (based on validation loss)\n",
+                "    mode=\"min\",  # Save the checkpoint with the lowest validation loss (minimization objective)\n",
+                "    save_last=True,  # Always save the most recent checkpoint, even if it's not the best\n",
+                ")\n",
+                "\n",
+                "\n",
                 "trainer = pl.Trainer(\n",
                 "    logger=False,\n",
                 "    enable_checkpointing=True, # Use `True` if you want to save model checkpoints. The checkpoints will be saved in the `checkpoints` folder.\n",
@@ -654,6 +654,7 @@
                 "    accelerator=\"auto\",\n",
                 "    devices=1,\n",
                 "    max_epochs=20, # number of epochs to train for\n",
+                "    callbacks=[checkpointing], # Use the configured checkpoint callback\n",
                 ")"
             ]
         },
@@ -666,19 +667,17 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 41,
+            "execution_count": 74,
             "metadata": {},
             "outputs": [
                 {
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/lightning/fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python /home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/pyt ...\n",
-                        "You are using a CUDA device ('NVIDIA GeForce RTX 4090') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
-                        "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/lightning/pytorch/callbacks/model_checkpoint.py:653: Checkpoint directory /home/hwpang/Projects/chemprop_v2_dev/chemprop/examples/checkpoints exists and is not empty.\n",
+                        "/home/donera/mambaforge/envs/chemprop/lib/python3.11/site-packages/lightning/pytorch/callbacks/model_checkpoint.py:653: Checkpoint directory /home/donera/snap/chemprop/examples/checkpoints exists and is not empty.\n",
                         "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0,1]\n",
                         "Loading `train_dataloader` to estimate number of stepping batches.\n",
-                        "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:441: The 'train_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=63` in the `DataLoader` to improve performance.\n",
+                        "/home/donera/mambaforge/envs/chemprop/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:441: The 'train_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=63` in the `DataLoader` to improve performance.\n",
                         "\n",
                         "  | Name            | Type               | Params\n",
                         "-------------------------------------------------------\n",
@@ -687,10 +686,9 @@
                         "2 | bn              | BatchNorm1d        | 600   \n",
                         "3 | predictor       | RegressionFFN      | 90.6 K\n",
                         "4 | X_d_transform   | Identity           | 0     \n",
-                        "  | other params    | n/a                | 1     \n",
                         "-------------------------------------------------------\n",
                         "318 K     Trainable params\n",
-                        "1         Non-trainable params\n",
+                        "0         Non-trainable params\n",
                         "318 K     Total params\n",
                         "1.276     Total estimated model params size (MB)\n"
                     ]
@@ -699,21 +697,21 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Sanity Checking DataLoader 0:   0%|          | 0/1 [00:00<?, ?it/s]"
+                        "                                                                            "
                     ]
                 },
                 {
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:441: The 'val_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=63` in the `DataLoader` to improve performance.\n"
+                        "/home/donera/mambaforge/envs/chemprop/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:441: The 'val_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=63` in the `DataLoader` to improve performance.\n"
                     ]
                 },
                 {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00, 33.35it/s, train_loss=0.026, val_loss=2.160] "
+                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00, 40.30it/s, train_loss=0.307, val_loss=0.854] "
                     ]
                 },
                 {
@@ -727,7 +725,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00, 29.84it/s, train_loss=0.026, val_loss=2.160]\n"
+                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00, 32.58it/s, train_loss=0.307, val_loss=0.854]\n"
                     ]
                 }
             ],
@@ -744,7 +742,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 42,
+            "execution_count": 75,
             "metadata": {},
             "outputs": [
                 {
@@ -752,38 +750,48 @@
                     "output_type": "stream",
                     "text": [
                         "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0,1]\n",
-                        "/home/hwpang/miniforge3/envs/chemprop_v2_dev/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:441: The 'test_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=63` in the `DataLoader` to improve performance.\n"
+                        "/home/donera/mambaforge/envs/chemprop/lib/python3.11/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:441: The 'test_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=63` in the `DataLoader` to improve performance.\n"
                     ]
                 },
                 {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Testing DataLoader 0: 100%|██████████| 1/1 [00:00<00:00, 238.52it/s]\n",
-                        "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n",
-                        "       Test metric             DataLoader 0\n",
-                        "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n",
-                        "        test/mae            0.6950093507766724\n",
-                        "        test/rmse           0.9511734247207642\n",
-                        "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n"
+                        "Testing DataLoader 0: 100%|██████████| 1/1 [00:00<00:00, 261.98it/s]\n"
                     ]
+                },
+                {
+                    "data": {
+                        "text/html": [
+                            "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+                            "┃<span style=\"font-weight: bold\">        Test metric        </span>┃<span style=\"font-weight: bold\">       DataLoader 0        </span>┃\n",
+                            "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+                            "│<span style=\"color: #008080; text-decoration-color: #008080\">  batch_averaged_test/mae  </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.7299395203590393     </span>│\n",
+                            "│<span style=\"color: #008080; text-decoration-color: #008080\"> batch_averaged_test/rmse  </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.9790006875991821     </span>│\n",
+                            "└───────────────────────────┴───────────────────────────┘\n",
+                            "</pre>\n"
+                        ],
+                        "text/plain": [
+                            "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+                            "┃\u001b[1m \u001b[0m\u001b[1m       Test metric       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      DataLoader 0       \u001b[0m\u001b[1m \u001b[0m┃\n",
+                            "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+                            "│\u001b[36m \u001b[0m\u001b[36m batch_averaged_test/mae \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.7299395203590393    \u001b[0m\u001b[35m \u001b[0m│\n",
+                            "│\u001b[36m \u001b[0m\u001b[36mbatch_averaged_test/rmse \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.9790006875991821    \u001b[0m\u001b[35m \u001b[0m│\n",
+                            "└───────────────────────────┴───────────────────────────┘\n"
+                        ]
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
                 }
             ],
             "source": [
-                "results = trainer.test(mpnn, test_loader)\n"
+                "results = trainer.test(dataloaders=test_loader)"
             ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": []
         }
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": "Python 3",
+            "display_name": "chemprop",
             "language": "python",
             "name": "python3"
         },
@@ -797,7 +805,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.11.8"
+            "version": "3.11.9"
         },
         "orig_nbformat": 4
     },


### PR DESCRIPTION
## Description
Addresses issue #820 (https://github.com/chemprop/chemprop/issues/820) 

## Example / Current workflow
Currently in `training.ipynb`
```
trainer.test(mpnn, test_loader)
```

## Bugfix / Desired workflow
Now in `training.ipynb`...
```
trainer.test(dataloaders = test_loader)
```
there is no need to specify the model because the model with the lowest validation loss (can change metric if desired) is automatically selected.

## Questions
If there are open questions about implementation strategy or scope of the PR, include them here

## Relevant issues
If appropriate, please tag them here and include a quick summary

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
