### PR TITLE
Add ray to tests on python 3 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,25 +85,19 @@ jobs:
         run: |
           python -m pip install nbmake
           python -m pip install ".[dev,docs,test]"
-      - name: Install hyperopt optional dependencies (Python 3.11 only)
-        if: ${{ matrix.python-version == '3.11' }} 
+      - name: Install hyperopt optional dependencies
         run: |
           python -m pip install ".[hpopt]"
       - name: Test with pytest
         shell: bash -l {0}
         run: |
           pytest -v tests
-      - name: Test notebooks (excluding hpopting.ipynb)
+      - name: Test notebooks 
         shell: bash -l {0}
         run: |
           python -m pip install matplotlib
-          pytest --no-cov -v --nbmake $(find examples -name '*.ipynb' ! -name 'hpopting.ipynb')
+          pytest --no-cov -v --nbmake $(find examples -name '*.ipynb')
           pytest --no-cov -v --nbmake $(find docs/source/tutorial/python -name "*.ipynb")
-      - name: Test hpopting.ipynb (Python 3.11 only)
-        if: ${{ matrix.python-version == '3.11' }}
-        shell: bash -l {0}
-        run: |
-          pytest --no-cov -v --nbmake examples/hpopting.ipynb
 
   conda-test:
     name: Execute Tests with Conda-based Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install nbmake
-          python -m pip install ".[dev,docs,test]"
-      - name: Install hyperopt optional dependencies
-        run: |
-          python -m pip install ".[hpopt]"
+          python -m pip install ".[dev,docs,test,hpopt]"
       - name: Test with pytest
         shell: bash -l {0}
         run: |

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -433,7 +433,7 @@ def tune_model(
 def main(args: Namespace):
     if NO_RAY:
         raise ImportError(
-            "Ray Tune requires ray to be installed. If you installed Chemprop from PyPI, make sure that your Python version is 3.11 and use 'pip install -U ray[tune]' to install ray. If you installed from source, use 'pip install -e .[hpopt]' in Chemprop folder to install all hpopt relevant packages."
+            "Ray Tune requires ray to be installed. If you installed Chemprop from PyPI, run 'pip install -U ray[tune]' to install ray. If you installed from source, use 'pip install -e .[hpopt]' in Chemprop folder to install all hpopt relevant packages."
         )
 
     if not ray.is_initialized():

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,7 +12,7 @@ Chemprop can either be installed from PyPI via pip_, from source (i.e., directly
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 
 .. note:: 
-    *Python 3.11 vs. 3.12:* Options 1, 2, and 4 below explicitly specify ``python=3.11``, but for most Chemprop functionality, you can choose to replace ``python=3.11`` with ``python=3.12`` in these commands. We test Chemprop on both versions in our CI. However, Ray Tune, which is an optional dependency that Chemprop relies on for hyperparameter optimization, is not yet compatible with ``python=3.12``.
+    *Python 3.11 vs. 3.12:* Options 1, 2, and 4 below explicitly specify ``python=3.11`` but you can choose to replace ``python=3.11`` with ``python=3.12`` in these commands. We test Chemprop on both versions in our CI.
 
 .. note:: 
     *CPU-only installation:* For the following options 1-3, if you do not have a GPU, you might need to manually install a CPU-only version of PyTorch. This should be handled automatically, but if you find that it is not, you should run the following command before installing Chemprop:

--- a/docs/source/tutorial/cli/hpopt.rst
+++ b/docs/source/tutorial/cli/hpopt.rst
@@ -4,7 +4,7 @@ Hyperparameter Optimization
 ============================
 
 .. note::
-    Chemprop relies on `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`_ for hyperparameter optimization, which is not yet compatible with python=3.12 and is an optional install. To install the required dependencies, make sure your Python version is 3.11 and run :code:`pip install -U ray[tune]` if installing with PyPI, or :code:`pip install -e .[hpopt]` if installing from source.
+    Chemprop relies on `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`_ for hyperparameter optimization which is an optional install. To install the required dependencies, run :code:`pip install -U ray[tune]` if installing with PyPI, or :code:`pip install -e .[hpopt]` if installing from source.
 
 Searching Hyperparameter Space
 --------------------------------


### PR DESCRIPTION
## Description
I think [ray](https://docs.ray.io/en/latest/ray-overview/installation.html) now supports python 3.12? 

If the tests run ray on 3.12, then I can also update the documentation to say this works.
