### PR TITLE
disable libuv with env var rather than avoiding latest torch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ concurrency:
   group: actions-id-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  USE_LIBUV: 0  # libuv doesn't work on GitHub actions Windows runner
+
 jobs:
   build:
     name: Check Build
@@ -77,9 +80,6 @@ jobs:
             channel_priority: flexible
           create-args: |
             python=${{ matrix.python-version }}
-      - name: Change Torch Version on Windows
-        if: matrix.os == 'windows-latest'
-        run: pip install 'torch!=2.4.0,!=2.4.1,!=2.5.0'
       - name: Install dependencies
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
trying to avoid the continual small patches:
 - https://github.com/chemprop/chemprop/pull/1062
 - https://github.com/chemprop/chemprop/pull/1016
 - https://github.com/chemprop/chemprop/pull/971

based on this part of pytorch docs: https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html#exit-route-3-set-environment-variable-use-libuv-to-0 which was also recommend above in one of these PRs
 

Just a draft for now - want to see if this works.
