### PR TITLE
Cleanup the uncertainty modules

### DIFF
--- a/chemprop/uncertainty/__init__.py
+++ b/chemprop/uncertainty/__init__.py
@@ -30,7 +30,7 @@ from .evaluator import (
     SpearmanEvaluator,
     UncertaintyEvaluatorRegistry,
 )
-from .predictor import (
+from .predictor import (  # RoundRobinSpectraPredictor,
     ClassificationDirichletPredictor,
     DropoutPredictor,
     EnsemblePredictor,
@@ -41,7 +41,6 @@ from .predictor import (
     MVEPredictor,
     NoUncertaintyPredictor,
     QuantileRegressionPredictor,
-    RoundRobinSpectraPredictor,
     UncertaintyPredictor,
     UncertaintyPredictorRegistry,
 )
@@ -87,7 +86,7 @@ __all__ = [
     "MVEPredictor",
     "NoUncertaintyPredictor",
     "QuantileRegressionPredictor",
-    "RoundRobinSpectraPredictor",
+    # "RoundRobinSpectraPredictor",
     "UncertaintyPredictor",
     "UncertaintyPredictorRegistry",
 ]

--- a/chemprop/uncertainty/__init__.py
+++ b/chemprop/uncertainty/__init__.py
@@ -32,7 +32,6 @@ from .evaluator import (
 )
 from .predictor import (
     ClassificationDirichletPredictor,
-    ClassPredictor,
     DropoutPredictor,
     EnsemblePredictor,
     EvidentialAleatoricPredictor,
@@ -78,7 +77,6 @@ __all__ = [
     "SpearmanEvaluator",
     "UncertaintyEvaluator",
     "UncertaintyEvaluatorRegistry",
-    "ClassPredictor",
     "ClassificationDirichletPredictor",
     "MulticlassDirichletPredictor",
     "DropoutPredictor",

--- a/chemprop/uncertainty/__init__.py
+++ b/chemprop/uncertainty/__init__.py
@@ -32,6 +32,7 @@ from .evaluator import (
 )
 from .predictor import (  # RoundRobinSpectraPredictor,
     ClassificationDirichletPredictor,
+    ClassPredictor,
     DropoutPredictor,
     EnsemblePredictor,
     EvidentialAleatoricPredictor,
@@ -77,6 +78,7 @@ __all__ = [
     "UncertaintyEvaluator",
     "UncertaintyEvaluatorRegistry",
     "ClassificationDirichletPredictor",
+    "ClassPredictor",
     "MulticlassDirichletPredictor",
     "DropoutPredictor",
     "EnsemblePredictor",

--- a/chemprop/uncertainty/calibrator.py
+++ b/chemprop/uncertainty/calibrator.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 import logging
 import math
 from typing import Self
-import warnings
 
 import numpy as np
 from scipy.optimize import fmin
@@ -285,8 +284,9 @@ class RegressionConformalCalibrator(RegressionCalibrator):
                 q_level = math.ceil((num_data + 1) * (1 - self.alpha)) / num_data
             else:
                 q_level = 1
-                warnings.warn(
-                    "The error rate (i.e., alpha) is smaller than 1 / (number of data + 1), so the 1 - alpha quantile is set to 1, but this only ensures that the coverage is trivially satisfied."
+                logger.warning(
+                    "The error rate (i.e., `alpha`) is smaller than `1 / (number of data + 1)`, so the `1 - alpha` quantile is set to 1, "
+                    "but this only ensures that the coverage is trivially satisfied."
                 )
             qhat = torch.quantile(calibration_scores, q_level, interpolation="higher")
             self.qhats.append(qhat)
@@ -627,8 +627,9 @@ class MulticlassConformalCalibrator(MulticlassClassificationCalibrator):
                 q_level = math.ceil((num_data + 1) * (1 - self.alpha)) / num_data
             else:
                 q_level = 1
-                warnings.warn(
-                    "`alpha` is smaller than `1 / (number of data + 1)`, so the `1 - alpha` quantile is set to 1, but this only ensures that the coverage is trivially satisfied."
+                logger.warning(
+                    "`alpha` is smaller than `1 / (number of data + 1)`, so the `1 - alpha` quantile is set to 1, "
+                    "but this only ensures that the coverage is trivially satisfied."
                 )
             qhat = torch.quantile(scores_j, q_level, interpolation="higher")
             self.qhats.append(qhat)

--- a/chemprop/uncertainty/calibrator.py
+++ b/chemprop/uncertainty/calibrator.py
@@ -83,7 +83,8 @@ class ZScalingCalibrator(RegressionCalibrator):
 
     References
     ----------
-    .. [levi2022] Levi, D.; Gispan, L.; Giladi, N.; Fetaya, E. "Evaluating and Calibrating Uncertainty Prediction in Regression Tasks." Sensors, 2022, 22(15), 5540. https://www.mdpi.com/1424-8220/22/15/5540.
+    .. [levi2022] Levi, D.; Gispan, L.; Giladi, N.; Fetaya, E. "Evaluating and Calibrating Uncertainty Prediction in
+        Regression Tasks." Sensors, 2022, 22(15), 5540. https://www.mdpi.com/1424-8220/22/15/5540
     """
 
     def fit(self, preds: Tensor, uncs: Tensor, targets: Tensor, mask: Tensor) -> Self:
@@ -124,7 +125,8 @@ class ZelikmanCalibrator(RegressionCalibrator):
 
     References
     ----------
-    .. [zelikman2020] Zelikman, E.; Healy, C.; Zhou, S.; Avati, A. "CRUDE: calibrating regression uncertainty distributions empirically." arXiv preprint arXiv:2005.12496. https://doi.org/10.48550/arXiv.2005.12496.
+    .. [zelikman2020] Zelikman, E.; Healy, C.; Zhou, S.; Avati, A. "CRUDE: calibrating regression uncertainty distributions
+        empirically." arXiv preprint arXiv:2005.12496. https://doi.org/10.48550/arXiv.2005.12496
     """
 
     def __init__(self, p: float):
@@ -160,7 +162,9 @@ class MVEWeightingCalibrator(RegressionCalibrator):
 
     References
     ----------
-    .. [wang2021] Wang, D.; Yu, J.; Chen, L.; Li, X.; Jiang, H.; Chen, K.; Zheng, M.; Luo, X. "A hybrid framework for improving uncertainty quantification in deep learning-based QSAR regression modeling." J. Cheminform., 2021, 13, 1-17. https://doi.org/10.1186/s13321-021-00551-x.
+    .. [wang2021] Wang, D.; Yu, J.; Chen, L.; Li, X.; Jiang, H.; Chen, K.; Zheng, M.; Luo, X. "A hybrid framework
+        for improving uncertainty quantification in deep learning-based QSAR regression modeling." J. Cheminform.,
+        2021, 13, 1-17. https://doi.org/10.1186/s13321-021-00551-x
     """
 
     def fit(self, preds: Tensor, uncs: Tensor, targets: Tensor, mask: Tensor) -> Self:
@@ -225,7 +229,7 @@ class MVEWeightingCalibrator(RegressionCalibrator):
 @UncertaintyCalibratorRegistry.register("conformal-regression")
 class RegressionConformalCalibrator(RegressionCalibrator):
     r"""Conformalize quantiles to make the interval :math:`[\hat{t}_{\alpha/2}(x),\hat{t}_{1-\alpha/2}(x)]` to have
-    approximately :math:`1-\alpha` coverage. [1]_
+    approximately :math:`1-\alpha` coverage. [angelopoulos2021]_
 
     .. math::
         s(x, y) &= \max \left\{ \hat{t}_{\alpha/2}(x) - y, y - \hat{t}_{1-\alpha/2}(x) \right\}
@@ -252,7 +256,7 @@ class RegressionConformalCalibrator(RegressionCalibrator):
 
     References
     ----------
-    .. [1] Angelopoulos, A.N.; Bates, S.; "A Gentle Introduction to Conformal Prediction and Distribution-Free
+    .. [angelopoulos2021] Angelopoulos, A.N.; Bates, S.; "A Gentle Introduction to Conformal Prediction and Distribution-Free
         Uncertainty Quantification." arXiv Preprint 2021, https://arxiv.org/abs/2107.07511
     """
 
@@ -346,9 +350,9 @@ class PlattCalibrator(BinaryClassificationCalibrator):
     References
     ----------
     .. [guo2017] Guo, C.; Pleiss, G.; Sun, Y.; Weinberger, K. Q. "On calibration of modern neural
-    networks". ICML, 2017. https://arxiv.org/abs/1706.04599
+        networks". ICML, 2017. https://arxiv.org/abs/1706.04599
     .. [platt1999] Platt, J. "Probabilistic Outputs for Support Vector Machines and Comparisons to
-    Regularized Likelihood Methods." Adv. Large Margin Classif. 1999, 10 (3), 61–74.
+        Regularized Likelihood Methods." Adv. Large Margin Classif. 1999, 10 (3), 61–74.
     """
 
     def fit(
@@ -415,7 +419,7 @@ class IsotonicCalibrator(BinaryClassificationCalibrator):
     References
     ----------
     .. [guo2017] Guo, C.; Pleiss, G.; Sun, Y.; Weinberger, K. Q. "On calibration of modern neural
-    networks". ICML, 2017. https://arxiv.org/abs/1706.04599
+        networks". ICML, 2017. https://arxiv.org/abs/1706.04599
     """
 
     def fit(self, uncs: Tensor, targets: Tensor, mask: Tensor) -> Self:
@@ -671,7 +675,7 @@ class IsotonicMulticlassCalibrator(MulticlassClassificationCalibrator):
     References
     ----------
     .. [guo2017] Guo, C.; Pleiss, G.; Sun, Y.; Weinberger, K. Q. "On calibration of modern neural
-    networks". ICML, 2017. https://arxiv.org/abs/1706.04599
+        networks". ICML, 2017. https://arxiv.org/abs/1706.04599
     """
 
     def fit(self, uncs: Tensor, targets: Tensor, mask: Tensor) -> Self:

--- a/chemprop/uncertainty/calibrator.py
+++ b/chemprop/uncertainty/calibrator.py
@@ -60,8 +60,8 @@ class RegressionCalibrator(CalibratorBase):
         Parameters
         ----------
         preds: Tensor
-            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is the number of input
-            molecules/reactions, and ``t`` is the number of tasks.
+            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is
+            the number of input molecules/reactions, and ``t`` is the number of tasks.
         uncs: Tensor
             the predicted uncertainties of the shape of ``n x t``
         targets: Tensor
@@ -174,8 +174,8 @@ class MVEWeightingCalibrator(RegressionCalibrator):
         Parameters
         ----------
         preds: Tensor
-            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is the number of input
-            molecules/reactions, and ``t`` is the number of tasks.
+            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is
+            the number of input molecules/reactions, and ``t`` is the number of tasks.
         uncs: Tensor
             the predicted uncertainties of the shape of ``m x n x t``
         targets: Tensor

--- a/chemprop/uncertainty/calibrator.py
+++ b/chemprop/uncertainty/calibrator.py
@@ -87,7 +87,7 @@ class ZScalingCalibrator(RegressionCalibrator):
     """
 
     def fit(self, preds: Tensor, uncs: Tensor, targets: Tensor, mask: Tensor) -> Self:
-        scalings = []
+        scalings = np.zeros(uncs.shape[1])
         for j in range(uncs.shape[1]):
             mask_j = mask[:, j]
             preds_j = preds[:, j][mask_j].numpy()
@@ -102,9 +102,7 @@ class ZScalingCalibrator(RegressionCalibrator):
 
             zscore = errors / np.sqrt(uncs_j)
             initial_guess = np.std(zscore)
-            scalings.append(fmin(objective, x0=initial_guess, disp=False))
-
-        self.scalings = torch.tensor(scalings)
+            scalings[j] = fmin(objective, x0=initial_guess, disp=False)
         return self
 
     def apply(self, uncs: Tensor) -> Tensor:

--- a/chemprop/uncertainty/calibrator.py
+++ b/chemprop/uncertainty/calibrator.py
@@ -103,6 +103,8 @@ class ZScalingCalibrator(RegressionCalibrator):
             zscore = errors / np.sqrt(uncs_j)
             initial_guess = np.std(zscore)
             scalings[j] = fmin(objective, x0=initial_guess, disp=False)
+
+        self.scalings = torch.tensor(scalings)
         return self
 
     def apply(self, uncs: Tensor) -> Tensor:

--- a/chemprop/uncertainty/evaluator.py
+++ b/chemprop/uncertainty/evaluator.py
@@ -20,8 +20,8 @@ class RegressionEvaluator(ABC):
         Parameters
         ----------
         preds: Tensor
-            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is the number of input
-            molecules/reactions, and ``t`` is the number of tasks.
+            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is
+            the number of input molecules/reactions, and ``t`` is the number of tasks.
         uncs: Tensor
             the predicted uncertainties of the shape of ``n x t``
         targets: Tensor
@@ -80,8 +80,8 @@ class CalibrationAreaEvaluator(RegressionEvaluator):
         Parameters
         ----------
         preds: Tensor
-            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is the number of input
-            molecules/reactions, and ``t`` is the number of tasks.
+            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is
+            the number of input molecules/reactions, and ``t`` is the number of tasks.
         uncs: Tensor
             the predicted uncertainties (variance) of the shape of ``n x t``
         targets: Tensor
@@ -122,13 +122,15 @@ class ExpectedNormalizedErrorEvaluator(RegressionEvaluator):
     .. math::
         \mathrm{ENCE} = \frac{1}{N} \sum_{i=1}^{N} \frac{|\mathrm{RMV}_i - \mathrm{RMSE}_i|}{\mathrm{RMV}_i}
 
-    where :math:`N` is the number of bins, :math:`\mathrm{RMV}_i` is the root of the mean uncertainty over the :math:`i`-th bin and :math:`\mathrm{RMSE}_i`
-    is the root mean square error over the :math:`i`-th bin. This discrepancy is further normalized by the
-    uncertainty over the bin, :math:`\mathrm{RMV}_i`, because the error is expected to be naturally higher as the uncertainty increases.
+    where :math:`N` is the number of bins, :math:`\mathrm{RMV}_i` is the root of the mean uncertainty over the
+    :math:`i`-th bin and :math:`\mathrm{RMSE}_i` is the root mean square error over the :math:`i`-th bin. This
+    discrepancy is further normalized by the uncertainty over the bin, :math:`\mathrm{RMV}_i`, because the error
+    is expected to be naturally higher as the uncertainty increases.
 
     References
     ----------
-    .. [1] Levi, D.; Gispan, L.; Giladi, N.; Fetaya, E. "Evaluating and Calibrating Uncertainty Prediction in Regression Tasks." Sensors, 2022, 22(15), 5540. https://www.mdpi.com/1424-8220/22/15/5540.
+    .. [1] Levi, D.; Gispan, L.; Giladi, N.; Fetaya, E. "Evaluating and Calibrating Uncertainty Prediction in Regression Tasks."
+        Sensors, 2022, 22(15), 5540. https://www.mdpi.com/1424-8220/22/15/5540
     """
 
     def evaluate(
@@ -139,8 +141,8 @@ class ExpectedNormalizedErrorEvaluator(RegressionEvaluator):
         Parameters
         ----------
         preds: Tensor
-            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is the number of input
-            molecules/reactions, and ``t`` is the number of tasks.
+            the predictions for regression tasks. It is a tensor of the shape of ``n x t``, where ``n`` is
+            the number of input molecules/reactions, and ``t`` is the number of tasks.
         uncs: Tensor
             the predicted uncertainties (variance) of the shape of ``n x t``
         targets: Tensor

--- a/chemprop/uncertainty/predictor.py
+++ b/chemprop/uncertainty/predictor.py
@@ -56,7 +56,11 @@ class NoUncertaintyPredictor(UncertaintyPredictor):
     def __call__(
         self, dataloader: DataLoader, models: Iterable[MPNN], trainer: pl.Trainer
     ) -> tuple[Tensor, Tensor]:
-        return
+        predss = []
+        for model in models:
+            preds = torch.concat(trainer.predict(model, dataloader), 0)
+            predss.append(preds)
+        return torch.stack(predss), None
 
 
 @UncertaintyPredictorRegistry.register("mve")

--- a/chemprop/uncertainty/predictor.py
+++ b/chemprop/uncertainty/predictor.py
@@ -119,8 +119,7 @@ class EvidentialTotalPredictor(UncertaintyPredictor):
     References
     -----------
     .. [amini2020] Amini, A.; Schwarting, W.; Soleimany, A.; Rus, D. "Deep Evidential Regression".
-    NeurIPS, 2020. https://proceedings.neurips.cc/paper_files/paper/2020/file/aab085461de182608ee9f607f3f7d18f-Paper.pdf
-
+        NeurIPS, 2020. https://arxiv.org/abs/1910.02600
     """
 
     def __call__(
@@ -180,11 +179,7 @@ class EvidentialAleatoricPredictor(UncertaintyPredictor):
 class DropoutPredictor(UncertaintyPredictor):
     """
     A :class:`DropoutPredictor` creates a virtual ensemble of models via Monte Carlo dropout with
-    the provided model [1]_.
-
-    References
-    -----------
-    .. [1] arXiv:1506.02142 [stat.ML]
+    the provided model [gal2016]_.
 
     Parameters
     ----------
@@ -194,6 +189,11 @@ class DropoutPredictor(UncertaintyPredictor):
         The probability of dropping out units in the dropout layers. If unspecified,
         the training probability is used, which is prefered but not possible if the model was not
         trained with dropout (i.e. p=0).
+
+    References
+    -----------
+    .. [gal2016] Gal, Y.; Ghahramani, Z. "Dropout as a bayesian approximation: Representing model uncertainty in deep learning."
+        International conference on machine learning. PMLR, 2016. https://arxiv.org/abs/1506.02142
     """
 
     def __init__(self, ensemble_size: int, dropout: None | float = None):

--- a/chemprop/uncertainty/predictor.py
+++ b/chemprop/uncertainty/predictor.py
@@ -110,14 +110,6 @@ class EnsemblePredictor(UncertaintyPredictor):
         return stacked_preds, vars
 
 
-@UncertaintyPredictorRegistry.register("classification")
-class ClassPredictor(UncertaintyPredictor):
-    def __call__(
-        self, dataloader: DataLoader, models: Iterable[MPNN], trainer: pl.Trainer
-    ) -> tuple[Tensor, Tensor]:
-        return
-
-
 @UncertaintyPredictorRegistry.register("evidential-total")
 class EvidentialTotalPredictor(UncertaintyPredictor):
     """

--- a/chemprop/uncertainty/predictor.py
+++ b/chemprop/uncertainty/predictor.py
@@ -254,12 +254,13 @@ class DropoutPredictor(UncertaintyPredictor):
             del module._p
 
 
-@UncertaintyPredictorRegistry.register("spectra-roundrobin")
-class RoundRobinSpectraPredictor(UncertaintyPredictor):
-    def __call__(
-        self, dataloader: DataLoader, models: Iterable[MPNN], trainer: pl.Trainer
-    ) -> tuple[Tensor, Tensor]:
-        return
+# TODO: Add in v2.1.x
+# @UncertaintyPredictorRegistry.register("spectra-roundrobin")
+# class RoundRobinSpectraPredictor(UncertaintyPredictor):
+#     def __call__(
+#         self, dataloader: DataLoader, models: Iterable[MPNN], trainer: pl.Trainer
+#     ) -> tuple[Tensor, Tensor]:
+#         return
 
 
 @UncertaintyPredictorRegistry.register("classification-dirichlet")

--- a/chemprop/uncertainty/predictor.py
+++ b/chemprop/uncertainty/predictor.py
@@ -110,6 +110,18 @@ class EnsemblePredictor(UncertaintyPredictor):
         return stacked_preds, vars
 
 
+@UncertaintyPredictorRegistry.register("classification")
+class ClassPredictor(UncertaintyPredictor):
+    def __call__(
+        self, dataloader: DataLoader, models: Iterable[MPNN], trainer: pl.Trainer
+    ) -> tuple[Tensor, Tensor]:
+        predss = []
+        for model in models:
+            preds = torch.concat(trainer.predict(model, dataloader), 0)
+            predss.append(preds)
+        return torch.stack(predss), torch.stack(predss)
+
+
 @UncertaintyPredictorRegistry.register("evidential-total")
 class EvidentialTotalPredictor(UncertaintyPredictor):
     """

--- a/chemprop/uncertainty/predictor.py
+++ b/chemprop/uncertainty/predictor.py
@@ -51,7 +51,7 @@ class UncertaintyPredictor(ABC):
 UncertaintyPredictorRegistry = ClassRegistry[UncertaintyPredictor]()
 
 
-@UncertaintyPredictorRegistry.register(None)
+@UncertaintyPredictorRegistry.register("none")
 class NoUncertaintyPredictor(UncertaintyPredictor):
     def __call__(
         self, dataloader: DataLoader, models: Iterable[MPNN], trainer: pl.Trainer

--- a/tests/unit/uncertainty/test_predictors.py
+++ b/tests/unit/uncertainty/test_predictors.py
@@ -5,7 +5,11 @@ from torch.utils.data import DataLoader
 
 from chemprop.data import MoleculeDatapoint, MoleculeDataset, collate_batch
 from chemprop.models import MPNN
-from chemprop.uncertainty.predictor import DropoutPredictor, EnsemblePredictor
+from chemprop.uncertainty.predictor import (
+    DropoutPredictor,
+    EnsemblePredictor,
+    NoUncertaintyPredictor,
+)
 
 
 @pytest.fixture
@@ -27,6 +31,15 @@ def trainer():
         accelerator="cpu",
         devices=1,
     )
+
+
+def test_NoUncertaintyPredictor(data_dir, dataloader, trainer):
+    model = MPNN.load_from_file(data_dir / "example_model_v2_regression_mol.pt")
+    predictor = NoUncertaintyPredictor()
+    preds, uncs = predictor(dataloader, [model], trainer)
+
+    torch.testing.assert_close(preds, torch.tensor([[[2.25354], [2.23501]]]))
+    assert uncs is None
 
 
 def test_DropoutPredictor(data_dir, dataloader, trainer):


### PR DESCRIPTION
## Description
I went through the uncertainty modules and made some minor changes.

- Improve the formatting of docstrings
- Add `NoUncertaintyPredictor` and `ClassPredictor`
- Comment out `RoundRobinSpectraPredictor`
- Use `logging` instead of `warnings.warn`

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
