### PR TITLE
Fix: Splits file can have multiple splitting schemes

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -765,6 +765,7 @@ def build_splits(args, format_kwargs, featurization_kwargs):
         train_indices = [parse_indices(d["train"]) for d in split_idxss]
         val_indices = [parse_indices(d["val"]) for d in split_idxss]
         test_indices = [parse_indices(d["test"]) for d in split_idxss]
+        args.num_replicates = len(train_indices)
 
     else:
         splitting_data = all_data[args.split_key_molecule]

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -765,7 +765,7 @@ def build_splits(args, format_kwargs, featurization_kwargs):
         train_indices = [parse_indices(d["train"]) for d in split_idxss]
         val_indices = [parse_indices(d["val"]) for d in split_idxss]
         test_indices = [parse_indices(d["test"]) for d in split_idxss]
-        args.num_replicates = len(train_indices)
+        args.num_replicates = len(split_idxss)
 
     else:
         splitting_data = all_data[args.split_key_molecule]


### PR DESCRIPTION
In the training CLI we have:

https://github.com/chemprop/chemprop/blob/185ab0fda9d63b238ff3f567ae236b40d4769b86/chemprop/cli/train.py#L1261-L1264

This is a problem though because `args.num_replicates` isn't the only way to train on multiple splits of data. The separate splits file can also do that. There will be multiple splitting schemes, but the results will overwrite each other because `num_replicates` is still 1. The splits column in the input data file cannot. 