### PR TITLE
Set all transforms to train during validation

### DIFF
--- a/chemprop/models/model.py
+++ b/chemprop/models/model.py
@@ -154,6 +154,9 @@ class MPNN(pl.LightningModule):
 
     def on_validation_model_eval(self) -> None:
         self.eval()
+        self.message_passing.V_d_transform.train()
+        self.message_passing.graph_transform.train()
+        self.X_d_transform.train()
         self.predictor.output_transform.train()
 
     def validation_step(self, batch: TrainingBatch, batch_idx: int = 0):

--- a/chemprop/models/multi.py
+++ b/chemprop/models/multi.py
@@ -51,6 +51,14 @@ class MulticomponentMPNN(MPNN):
 
         return H if X_d is None else torch.cat((H, self.X_d_transform(X_d)), 1)
 
+    def on_validation_model_eval(self) -> None:
+        self.eval()
+        for block in self.message_passing.blocks:
+            block.V_d_transform.train()
+            block.graph_transform.train()
+        self.X_d_transform.train()
+        self.predictor.output_transform.train()
+
     @classmethod
     def _load(cls, path, map_location, **submodules):
         d = torch.load(path, map_location)


### PR DESCRIPTION
When `lightning` runs the validation loop, it automatically sets the model to `eval` mode. This is needed to turn off dropout and to tell the batch normalization layer to use its running average statistics instead of batch statistics, the same as is done during inference. 

But this also sets the `output_transform` to `eval`, which would cause the model to unscale the model predictions before comparing with the target values stored in the validation dataset. This is a problem because we made the choice to keep the validation loss in the same scaled space as the training loss so that they would be some what comparable. To do this we scale the target values in the validation dataset, so they should be compared to the raw scaled-space predictions of the model (not the unscaled version). We fixed this by manually setting the `output_transform` back to `train` in `on_validation_model_eval`.

Our examples also show that the graph transforms and extra datapoint descriptors transforms should be scaled in the validation set, based on the scaling in the training dataset. This isn't actually necessary, but what we have chosen. Currently though we don't set those transforms to training mode so the extra descriptors are being double scaled. I have fixed that.

This also makes me wonder why we do any scaling in the datasets themselves. Couldn't we just fit a scaler to the training data, add it to the model and then always perform the transform scaling? The train and val loss would both be in the unscaled space and maybe that is less preferred? 