### PR TITLE
Fix `save_individual_predictions` with ensembling

### DIFF
--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -397,7 +397,7 @@ def save_individual_predictions(
     )
     df_test[output_columns] = test_individual_preds
 
-    if args.uncertainty_method not in ["none", "classification"]:
+    if args.uncertainty_method not in ["none", "classification", "ensemble"]:
         m, n, t = test_individual_uncs.shape
         test_individual_uncs = np.transpose(test_individual_uncs, (1, 0, 2)).reshape(n, m * t)
         df_test[unc_columns] = np.round(test_individual_uncs, 6)


### PR DESCRIPTION
## Description
This issue is identified by @jonwzheng. When making predictions with ensembling uncertainty, it would lead to the trace error shown below. This is because Chemprop saves individual prediction results and their corresponding uncertainty values when multiple models are used to make predictions. It is useful for MVE and evidential methods, as each model can have its own predicted uncertainty. However, the ensembling method can only provide one predicted uncertainty across multiple models.

## Trace Error
> 2024-11-20T19:42:30 - INFO:chemprop.cli.predict - Predictions saved to 'expt_preds.csv'
> Traceback (most recent call last):
>   File "/home/jonzheng/miniconda3/envs/chemprop/bin/chemprop", line 8, in <module>
>     sys.exit(main())
>              ^^^^^^
>   File "/home/jonzheng/chemprop/chemprop/cli/main.py", line 85, in main
>     func(args)
>   File "/home/jonzheng/chemprop/chemprop/cli/predict.py", line 51, in func
>     main(args)
>   File "/home/jonzheng/chemprop/chemprop/cli/predict.py", line 435, in main
>     make_prediction_for_models(args, model_paths, multicomponent, output_path=args.output)
>   File "/home/jonzheng/chemprop/chemprop/cli/predict.py", line 320, in make_prediction_for_models
>     save_individual_predictions(
>   File "/home/jonzheng/chemprop/chemprop/cli/predict.py", line 403, in save_individual_predictions
>     df_test[unc_columns] = np.round(test_individual_uncs, 6)
>     ~~~~~~~^^^^^^^^^^^^^
>   File "/home/jonzheng/miniconda3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4299, in __setitem__
>     self._setitem_array(key, value)
>   File "/home/jonzheng/miniconda3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4355, in _setitem_array
>     return self._setitem_array(key, value)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/jonzheng/miniconda3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4350, in _setitem_array
>     self._iset_not_inplace(key, value)
>   File "/home/jonzheng/miniconda3/envs/chemprop/lib/python3.11/site-packages/pandas/core/frame.py", line 4377, in _iset_not_inplace
>     raise ValueError("Columns must be same length as key")
> ValueError: Columns must be same length as key

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
