### PR TITLE
Add a helpful warning when invalid SMILES are passed

### DIFF
--- a/chemprop/data/datapoints.py
+++ b/chemprop/data/datapoints.py
@@ -75,9 +75,6 @@ class MoleculeDatapoint(_DatapointMixin, _MoleculeDatapointMixin):
     descriptors *after* message passing"""
 
     def __post_init__(self):
-        if self.mol is None:
-            raise ValueError("Input molecule was `None`!")
-
         NAN_TOKEN = 0
         if self.V_f is not None:
             self.V_f[np.isnan(self.V_f)] = NAN_TOKEN

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -57,7 +57,13 @@ def make_mol(smi: str, keep_h: bool, add_h: bool) -> Chem.Mol:
     else:
         mol = Chem.MolFromSmiles(smi)
 
-    return Chem.AddHs(mol) if add_h else mol
+    if add_h:
+        mol = Chem.AddHs(mol)
+
+    if mol is None:
+        raise RuntimeError(f"SMILES {smi} is invalid! (RDKit returned None)")
+
+    return mol
 
 
 def pretty_shape(shape: Iterable[int]) -> str:

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -57,11 +57,11 @@ def make_mol(smi: str, keep_h: bool, add_h: bool) -> Chem.Mol:
     else:
         mol = Chem.MolFromSmiles(smi)
 
-    if add_h:
-        mol = Chem.AddHs(mol)
-
     if mol is None:
         raise RuntimeError(f"SMILES {smi} is invalid! (RDKit returned None)")
+
+    if add_h:
+        mol = Chem.AddHs(mol)
 
     return mol
 


### PR DESCRIPTION
## Description
There have been a number of issues opened in the past which all turned out to be invalid SMILES strings:
 - https://github.com/chemprop/chemprop/issues/965
 - https://github.com/chemprop/chemprop/issues/1122
 - https://github.com/chemprop/chemprop/issues/1044

## Example / Current workflow
We currently report the following slightly unhelpful error:
```python
ValueError: Input molecule was `None`!
```

## Bugfix / Desired workflow
This PR adds a check in `make_mol` to see if `Chem.MolFromSmiles` returns `None`, and then prints the corresponding SMILES.

## Questions
We could probably then safely delete the check for `None`, elsewhere, if we want to.

## Relevant issues
See top.

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?

Edited this in the browser, will let the CI check these.