### PR TITLE
Add output size to attentive hparams

### DIFF
--- a/chemprop/nn/agg.py
+++ b/chemprop/nn/agg.py
@@ -117,6 +117,7 @@ class AttentiveAggregation(Aggregation):
     def __init__(self, dim: int = 0, *args, output_size: int, **kwargs):
         super().__init__(dim, *args, **kwargs)
 
+        self.hparams["output_size"] = output_size
         self.W = nn.Linear(output_size, 1)
 
     def forward(self, H: Tensor, batch: Tensor) -> Tensor:


### PR DESCRIPTION
Closes #1120 

The AttentiveAggregation class uses a single learned linear layer to calculate what the weight of each node should be in aggregation based on the node's learned representation. I don't see this as an option in v1, so I think it is new to v2, but I don't really know its background.

In any event, it needs to know what the length of the node representation is so it can instantiate a linear layer. We need to save this length as a hyperparameter under aggregation so that we can reload it from a checkpoint. 