### PR TITLE
Adding RIGR featurizer as a flag (`--rigr`)

### DIFF
--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -138,6 +138,11 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         action="append",
         help="If a single path is given, it is assumed to correspond to the 0-th molecule. Alternatively, it can be a two-tuple of molecule index and path to additional bond features to supply before message passing (e.g., ``--bond-features-path 0 /path/to/features_0.npz`` indicates that the features at the given path should be supplied to the 0-th component. To supply additional features for multiple components, repeat this argument on the command line for each component's respective values (e.g., ``--bond-features-path [...] --bond-features-path [...]``).",
     )
+    featurization_args.add_argument(
+        "--rigr",
+        action="store_true",
+        help="Resonance Invariant Graph Representation (RIGR) []",
+    )
     # TODO: Add in v2.2
     # parser.add_argument(
     #     "--constraints-path",

--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -139,9 +139,7 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         help="If a single path is given, it is assumed to correspond to the 0-th molecule. Alternatively, it can be a two-tuple of molecule index and path to additional bond features to supply before message passing (e.g., ``--bond-features-path 0 /path/to/features_0.npz`` indicates that the features at the given path should be supplied to the 0-th component. To supply additional features for multiple components, repeat this argument on the command line for each component's respective values (e.g., ``--bond-features-path [...] --bond-features-path [...]``).",
     )
     featurization_args.add_argument(
-        "--rigr",
-        action="store_true",
-        help="Resonance Invariant Graph Representation (RIGR) []",
+        "--rigr", action="store_true", help="Resonance Invariant Graph Representation (RIGR) []"
     )
     # TODO: Add in v2.2
     # parser.add_argument(

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -116,7 +116,8 @@ def make_fingerprint_for_model(
     )
     logger.info(f"test size: {len(test_data[0])}")
     test_dsets = [
-        make_dataset(d, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr) for d in test_data
+        make_dataset(d, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
+        for d in test_data
     ]
 
     if multicomponent:

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -116,7 +116,7 @@ def make_fingerprint_for_model(
     )
     logger.info(f"test size: {len(test_data[0])}")
     test_dsets = [
-        make_dataset(d, args.rxn_mode, args.multi_hot_atom_featurizer_mode) for d in test_data
+        make_dataset(d, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr) for d in test_data
     ]
 
     if multicomponent:

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -207,7 +207,10 @@ def prepare_data_loader(
         **featurization_kwargs,
     )
 
-    dsets = [make_dataset(d, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr) for d in datas]
+    dsets = [
+        make_dataset(d, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
+        for d in datas
+    ]
     dset = data.MulticomponentDataset(dsets) if multicomponent else dsets[0]
 
     return data.build_dataloader(dset, args.batch_size, args.num_workers, shuffle=False)

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -207,7 +207,7 @@ def prepare_data_loader(
         **featurization_kwargs,
     )
 
-    dsets = [make_dataset(d, args.rxn_mode, args.multi_hot_atom_featurizer_mode) for d in datas]
+    dsets = [make_dataset(d, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr) for d in datas]
     dset = data.MulticomponentDataset(dsets) if multicomponent else dsets[0]
 
     return data.build_dataloader(dset, args.batch_size, args.num_workers, shuffle=False)

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -896,10 +896,16 @@ def build_datasets(args, train_data, val_data, test_data):
         train_data = train_data[0]
         val_data = val_data[0]
         test_data = test_data[0]
-        train_dset = make_dataset(train_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
-        val_dset = make_dataset(val_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
+        train_dset = make_dataset(
+            train_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr
+        )
+        val_dset = make_dataset(
+            val_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr
+        )
         if len(test_data) > 0:
-            test_dset = make_dataset(test_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
+            test_dset = make_dataset(
+                test_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr
+            )
         else:
             test_dset = None
     if args.task_type != "spectral":

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -875,18 +875,18 @@ def build_datasets(args, train_data, val_data, test_data):
     multicomponent = len(train_data) > 1
     if multicomponent:
         train_dsets = [
-            make_dataset(data, args.rxn_mode, args.multi_hot_atom_featurizer_mode)
+            make_dataset(data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
             for data in train_data
         ]
         val_dsets = [
-            make_dataset(data, args.rxn_mode, args.multi_hot_atom_featurizer_mode)
+            make_dataset(data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
             for data in val_data
         ]
         train_dset = MulticomponentDataset(train_dsets)
         val_dset = MulticomponentDataset(val_dsets)
         if len(test_data[0]) > 0:
             test_dsets = [
-                make_dataset(data, args.rxn_mode, args.multi_hot_atom_featurizer_mode)
+                make_dataset(data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
                 for data in test_data
             ]
             test_dset = MulticomponentDataset(test_dsets)
@@ -896,10 +896,10 @@ def build_datasets(args, train_data, val_data, test_data):
         train_data = train_data[0]
         val_data = val_data[0]
         test_data = test_data[0]
-        train_dset = make_dataset(train_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode)
-        val_dset = make_dataset(val_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode)
+        train_dset = make_dataset(train_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
+        val_dset = make_dataset(val_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
         if len(test_data) > 0:
-            test_dset = make_dataset(test_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode)
+            test_dset = make_dataset(test_data, args.rxn_mode, args.multi_hot_atom_featurizer_mode, args.rigr)
         else:
             test_dset = None
     if args.task_type != "spectral":

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -8,6 +8,7 @@ import pandas as pd
 from chemprop.data.datapoints import MoleculeDatapoint, ReactionDatapoint
 from chemprop.data.datasets import MoleculeDataset, ReactionDataset
 from chemprop.featurizers.atom import get_multi_hot_atom_featurizer
+from chemprop.featurizers.bond import MultiHotBondFeaturizer
 from chemprop.featurizers.molecule import MoleculeFeaturizerRegistry
 from chemprop.featurizers.molgraph import (
     CondensedGraphOfReactionFeaturizer,
@@ -401,13 +402,16 @@ def make_dataset(
     data: Sequence[MoleculeDatapoint] | Sequence[ReactionDatapoint],
     reaction_mode: str,
     multi_hot_atom_featurizer_mode: str = "V2",
+    rigr: bool = False,
 ) -> MoleculeDataset | ReactionDataset:
-    atom_featurizer = get_multi_hot_atom_featurizer(multi_hot_atom_featurizer_mode)
+    atom_featurizer = get_multi_hot_atom_featurizer(multi_hot_atom_featurizer_mode, rigr=rigr)
+    bond_featurizer = MultiHotBondFeaturizer(rigr=rigr)
 
     if isinstance(data[0], MoleculeDatapoint):
         extra_atom_fdim = data[0].V_f.shape[1] if data[0].V_f is not None else 0
         extra_bond_fdim = data[0].E_f.shape[1] if data[0].E_f is not None else 0
         featurizer = SimpleMoleculeMolGraphFeaturizer(
+            bond_featurizer=bond_featurizer,
             atom_featurizer=atom_featurizer,
             extra_atom_fdim=extra_atom_fdim,
             extra_bond_fdim=extra_bond_fdim,

--- a/chemprop/featurizers/atom.py
+++ b/chemprop/featurizers/atom.py
@@ -94,6 +94,7 @@ class MultiHotAtomFeaturizer(VectorFeaturizer[Atom]):
                 1 + len(self.num_Hs),
                 1 + len(self.hybridizations),
                 1,
+                1,
             ]
         self.__size = sum(subfeat_sizes)
 

--- a/chemprop/featurizers/atom.py
+++ b/chemprop/featurizers/atom.py
@@ -55,7 +55,7 @@ class MultiHotAtomFeaturizer(VectorFeaturizer[Atom]):
         chiral_tags: Sequence[int],
         num_Hs: Sequence[int],
         hybridizations: Sequence[int],
-        rigr: bool=False,
+        rigr: bool = False,
     ):
         self.atomic_nums = {j: i for i, j in enumerate(atomic_nums)}
         self.degrees = {i: i for i in degrees}
@@ -66,11 +66,7 @@ class MultiHotAtomFeaturizer(VectorFeaturizer[Atom]):
         self.rigr = rigr
 
         if rigr:
-            self._subfeats: list[dict] = [
-                self.atomic_nums,
-                self.degrees,
-                self.num_Hs,
-            ]
+            self._subfeats: list[dict] = [self.atomic_nums, self.degrees, self.num_Hs]
             subfeat_sizes = [
                 1 + len(self.atomic_nums),
                 1 + len(self.degrees),
@@ -108,11 +104,7 @@ class MultiHotAtomFeaturizer(VectorFeaturizer[Atom]):
             return x
 
         if self.rigr:
-            feats = [
-                a.GetAtomicNum(),
-                a.GetTotalDegree(),
-                int(a.GetTotalNumHs()),
-            ]
+            feats = [a.GetAtomicNum(), a.GetTotalDegree(), int(a.GetTotalNumHs())]
         else:
             feats = [
                 a.GetAtomicNum(),
@@ -148,7 +140,7 @@ class MultiHotAtomFeaturizer(VectorFeaturizer[Atom]):
         return x
 
     @classmethod
-    def v1(cls, max_atomic_num: int = 100, rigr: bool=False):
+    def v1(cls, max_atomic_num: int = 100, rigr: bool = False):
         """The original implementation used in Chemprop V1 [1]_, [2]_.
 
         Parameters
@@ -183,7 +175,7 @@ class MultiHotAtomFeaturizer(VectorFeaturizer[Atom]):
         )
 
     @classmethod
-    def v2(cls, rigr: bool=False):
+    def v2(cls, rigr: bool = False):
         """An implementation that includes an atom type bit for all elements in the first four rows of the periodic table plus iodine."""
 
         return cls(
@@ -205,7 +197,7 @@ class MultiHotAtomFeaturizer(VectorFeaturizer[Atom]):
         )
 
     @classmethod
-    def organic(cls, rigr: bool=False):
+    def organic(cls, rigr: bool = False):
         r"""A specific parameterization intended for use with organic or drug-like molecules.
 
         This parameterization features:
@@ -237,7 +229,9 @@ class AtomFeatureMode(EnumMapping):
     ORGANIC = auto()
 
 
-def get_multi_hot_atom_featurizer(mode: str | AtomFeatureMode, rigr: bool=False) -> MultiHotAtomFeaturizer:
+def get_multi_hot_atom_featurizer(
+    mode: str | AtomFeatureMode, rigr: bool = False
+) -> MultiHotAtomFeaturizer:
     """Build the corresponding multi-hot atom featurizer."""
     match AtomFeatureMode.get(mode):
         case AtomFeatureMode.V1:

--- a/chemprop/featurizers/bond.py
+++ b/chemprop/featurizers/bond.py
@@ -47,7 +47,10 @@ class MultiHotBondFeaturizer(VectorFeaturizer[Bond]):
     """
 
     def __init__(
-        self, bond_types: Sequence[BondType] | None = None, stereos: Sequence[int] | None = None, rigr: bool = False
+        self,
+        bond_types: Sequence[BondType] | None = None,
+        stereos: Sequence[int] | None = None,
+        rigr: bool = False,
     ):
         self.bond_types = bond_types or [
             BondType.SINGLE,

--- a/chemprop/featurizers/molecule.py
+++ b/chemprop/featurizers/molecule.py
@@ -93,3 +93,18 @@ class V1RDKit2DFeaturizer(V1RDKit2DFeaturizerMixin):
 class V1RDKit2DNormalizedFeaturizer(V1RDKit2DFeaturizerMixin):
     def __init__(self):
         self.generator = rdNormalizedDescriptors.RDKit2DNormalized()
+
+@MoleculeFeaturizerRegistry("charge")
+class ChargeFeaurizer(VectorFeaturizer[Mol]):
+    def __call__(self, mol: Chem.Mol) -> np.ndarray:
+        return np.array([Chem.GetFormalCharge(mol)])
+    def __len__(self) -> int:
+        return 1
+
+@MoleculeFeaturizerRegistry("multiplicity")
+class MultiplicityFeaurizer(VectorFeaturizer[Mol]):
+    def __call__(self, mol: Chem.Mol) -> np.ndarray:
+        mult = sum(atom.GetNumRadicalElectrons() for atom in mol.GetAtoms()) + 1
+        return np.array([mult])
+    def __len__(self) -> int:
+        return 1

--- a/chemprop/featurizers/molecule.py
+++ b/chemprop/featurizers/molecule.py
@@ -94,17 +94,21 @@ class V1RDKit2DNormalizedFeaturizer(V1RDKit2DFeaturizerMixin):
     def __init__(self):
         self.generator = rdNormalizedDescriptors.RDKit2DNormalized()
 
+
 @MoleculeFeaturizerRegistry("charge")
 class ChargeFeaurizer(VectorFeaturizer[Mol]):
     def __call__(self, mol: Chem.Mol) -> np.ndarray:
         return np.array([Chem.GetFormalCharge(mol)])
+
     def __len__(self) -> int:
         return 1
+
 
 @MoleculeFeaturizerRegistry("multiplicity")
 class MultiplicityFeaurizer(VectorFeaturizer[Mol]):
     def __call__(self, mol: Chem.Mol) -> np.ndarray:
         mult = sum(atom.GetNumRadicalElectrons() for atom in mol.GetAtoms()) + 1
         return np.array([mult])
+
     def __len__(self) -> int:
         return 1


### PR DESCRIPTION
## Description
This PR aims to implement the RIGR featurizer in the main chemprop by allowing users to add a `--rigr` flag in their scripts. The GitHub page for RIGR is [here](https://github.com/akshatzalte/chemprop/tree/rigr_home). This featurizer ensures a consistent representation for different resonance structures of the same chemical species. The basic idea is to remove the atom and bond features that vary across resonance forms like bond order and formal charge. This PR also adds *charge* and *multiplicity* features at the molecular level (can be used along with `--rigr`).

## Example / Current workflow
Current featurizer treats different resonance forms of the same molecules differently.

## Bugfix / Desired workflow
RIGR featurizer seeks to solve this issue of resonance variance, especially while training chemprop models (or inferring them) using datasets with a significant fraction of resonance-active species.
