### PR TITLE
Fix hpopt write config

### DIFF
--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -162,28 +162,35 @@ def process_common_args(args: Namespace) -> Namespace:
         if not inds_paths:
             continue
 
-        ind_path_dict = {}
+        # If a config file is used, inds_paths looks like [["0"], ["/path/to/features_0.npz"], ...]
+        if len(inds_paths) != 1 and all(len(item) == 1 for item in inds_paths):
+            ind_path_dict = {
+                int(ind[0]): Path(path[0]) for ind, path in zip(inds_paths[::2], inds_paths[1::2])
+            }
+        # Otherwise [["0", "/path/to/features_0.npz"], ...] or ["/path/to/features_0.npz"]
+        else:
+            ind_path_dict = {}
 
-        for ind_path in inds_paths:
-            if len(ind_path) > 2:
-                raise ArgumentError(
-                    argument=None,
-                    message="Too many arguments were given for atom features/descriptors or bond features. It should be either a two-tuple of molecule index and a path, or a single path (assumed to be the 0-th molecule).",
-                )
+            for ind_path in inds_paths:
+                if len(ind_path) > 2:
+                    raise ArgumentError(
+                        argument=None,
+                        message="Too many arguments were given for atom features/descriptors or bond features. It should be either a two-tuple of molecule index and a path, or a single path (assumed to be the 0-th molecule).",
+                    )
 
-            if len(ind_path) == 1:
-                ind = 0
-                path = ind_path[0]
-            else:
-                ind, path = ind_path
+                if len(ind_path) == 1:
+                    ind = 0
+                    path = ind_path[0]
+                else:
+                    ind, path = ind_path
 
-            if ind_path_dict.get(int(ind), None):
-                raise ArgumentError(
-                    argument=None,
-                    message=f"Duplicate atom features/descriptors or bond features given for molecule index {ind}",
-                )
+                if ind_path_dict.get(int(ind), None):
+                    raise ArgumentError(
+                        argument=None,
+                        message=f"Duplicate atom features/descriptors or bond features given for molecule index {ind}",
+                    )
 
-            ind_path_dict[int(ind)] = Path(path)
+                ind_path_dict[int(ind)] = Path(path)
 
         setattr(args, key, ind_path_dict)
 

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -510,7 +510,8 @@ def main(args: Namespace):
 
     args = update_args_with_config(args, best_config)
 
-    args = TrainSubcommand.parser.parse_known_args(namespace=args)[0]
+    TrainSubcommand.parser.parse_known_args()
+
     save_config(TrainSubcommand.parser, args, best_config_save_path)
 
     logger.info(

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -706,8 +706,15 @@ def save_config(parser: ArgumentParser, args: Namespace, config_path: Path):
 
     for key in ["atom_features_path", "atom_descriptors_path", "bond_features_path"]:
         if getattr(config_args, key) is not None:
-            for index, path in getattr(config_args, key).items():
-                getattr(config_args, key)[index] = str(path)
+            setattr(
+                config_args,
+                key,
+                [
+                    item
+                    for index, path in getattr(config_args, key).items()
+                    for item in (index, str(path))
+                ],
+            )
 
     parser.write_config_file(parsed_namespace=config_args, output_file_paths=[str(config_path)])
 

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -530,7 +530,13 @@ def test_optuna_quick(monkeypatch, data_path, tmp_path):
 
 @pytest.mark.skipif(NO_RAY or NO_HYPEROPT, reason="Ray and/or Hyperopt not installed")
 def test_hyperopt_quick(monkeypatch, data_path, tmp_path):
-    input_path, *_ = data_path
+    (
+        input_path,
+        descriptors_path,
+        atom_features_path,
+        bond_features_path,
+        atom_descriptors_path,
+    ) = data_path
 
     args = [
         "chemprop",
@@ -549,6 +555,14 @@ def test_hyperopt_quick(monkeypatch, data_path, tmp_path):
         "morgan_binary",
         "--search-parameter-keywords",
         "all",
+        "--descriptors-path",
+        descriptors_path,
+        "--atom-features-path",
+        atom_features_path,
+        "--bond-features-path",
+        bond_features_path,
+        "--atom-descriptors-path",
+        atom_descriptors_path,
     ]
 
     with monkeypatch.context() as m:


### PR DESCRIPTION
## The problem
In #1185, a user found that they couldn't use `--atom-features-path` with hpopt because when hpopt tries to make the config file to use when training actual models (as we show in the [docs](https://chemprop.readthedocs.io/en/latest/tutorial/cli/hpopt.html#applying-optimal-hyperparameters)), the code complains about trying to append to a dict. 

## A solution
Don't try to update `args: Namespace`. 

## Background 
The `ArgumentParser` from `ConfigArgParse` has a handy method `write_config_file` to write a config file that you can use to re-run a command. For example, at the start of a `chemprop train ...` job we write a config file to the output directory both to help keep track of what hyperparameters were used for training those models as well as to make it easier to re-run that training. 

In `chemprop hpopt` we want to make a config file that the user can then use to train a model. The problem is that parsers in `hpopt` and `train` are different parsers (though they are both subparsers of the main chemprop parser). If we use the `hpopt` parser to write the config file, it will include the hpopt only arguments like `raytune-num-samples` and throw an error like `chemprop: error: unrecognized arguments: --raytune_num_samples=5`.

So instead we use the `train` parser to write the config file. But first the `train` parser needs to be told what the args are. `parse_known_args` [populates](https://github.com/bw2/ConfigArgParse/blob/ee77f44d03415f2afe73c82096bae2293db29a3b/configargparse.py#L846) a dictionary called `self._source_to_settings` that stores what arguments were given to the parser and from what sources (command line, environment variables, config file, defaults). `write_config_file` [calls](https://github.com/bw2/ConfigArgParse/blob/ee77f44d03415f2afe73c82096bae2293db29a3b/configargparse.py#L1025-L1026) `get_items_for_config_file_output` which goes through each argument in `_source_to_settings` and gets the value for that argument from the namespace that was passed to `write_config_file`.  So we do https://github.com/chemprop/chemprop/blob/1229525b68b3841e76f4c70a25ef2222775a61a3/chemprop/cli/hpopt.py#L513
But in addition to making `self._source_to_settings`, this will this will also parse the command line arguments that were give to `hpopt` again [here](https://github.com/bw2/ConfigArgParse/blob/ee77f44d03415f2afe73c82096bae2293db29a3b/configargparse.py#L829-L830) since we don't pass `args=<list of str>`.  And because we pass in `namespace=args`, the parsed CLI arguments (at least the ones known to the `train` parser) will be used to update the `args: Namespace`. `atoms-features-path` has the "append" action so it will try to append the CLI values to what is currently in `args.atom_features_path`, but we previously changed this to a dictionary so that won't work. The solution is simply to not try to update `args: Namespace` because it already contains all the values we want. We just need to call `parser.parse_known_args` so that `write_config_file` will know what attributes in `args: Namespace` to pull.

## Caveat
Because `write_config_file` only writes things that were parsed, this creates a distinction between defaults and implicit defaults. By implicit defaults, I mean attribute values that we set after parsing like `output_dir` in training. https://github.com/chemprop/chemprop/blob/1229525b68b3841e76f4c70a25ef2222775a61a3/chemprop/cli/train.py#L476-477. Defaults are written to the config file because they get included in `_source_to_settings` during parsing, but implicit defaults do not. I don't see this as a problem right now, but good to keep this in mind for the future. 

## Other details about Actions
When the known args are parsed by the `TrainSubcommand` parser, it will call the action associated with each argument on the command line. Actions are instances of an action class that tell argparse what to do with the values given for an argument. In the case of atom-features-path, its action [is](https://github.com/chemprop/chemprop/blob/1229525b68b3841e76f4c70a25ef2222775a61a3/chemprop/cli/common.py#L127) `"append"` which will create an `_AppendAction` (code refs [1](https://github.com/python/cpython/blob/061da44bacf347cc1fe82b03976e95f9c0992673/Lib/argparse.py#L1453), [2](https://github.com/python/cpython/blob/061da44bacf347cc1fe82b03976e95f9c0992673/Lib/argparse.py#L1611-L1613), [3](https://github.com/python/cpython/blob/061da44bacf347cc1fe82b03976e95f9c0992673/Lib/argparse.py#L1362)). This action instance is [called](https://github.com/python/cpython/blob/061da44bacf347cc1fe82b03976e95f9c0992673/Lib/argparse.py#L2026) if the argument is specified, which gets the current value of the `atom_features_path` attribute in the namespace (or creates an empty list if the attribute is `None`) and tries to append the value given to that. In our case though, we [process](https://github.com/chemprop/chemprop/blob/1229525b68b3841e76f4c70a25ef2222775a61a3/chemprop/cli/common.py#L159) this list after it is parsed to turn it into a dictionary. In this case the list looks like `["../../data/atom_features.npz"]` and the dictionary looks like `{0: Path(../../data/atom_features.npz)`. When this argument is re-parsed, python will complain that it can't append to a dictionary. 

The other arguments that are re-parsed like `task-type` don't have a problem because they use `_StoreAction` which just [overwrites](https://github.com/python/cpython/blob/061da44bacf347cc1fe82b03976e95f9c0992673/Lib/argparse.py#L924) the attribute value in the namespace to the value given. This could be a future source of bug reports if we don't merge this PR. If a user included `--batch-size 10` for example as an arugment to `hpopt`, `args.batch_size` would initially be set to 10, but then during hyperparameter optimization this would be [updated](https://github.com/chemprop/chemprop/blob/1229525b68b3841e76f4c70a25ef2222775a61a3/chemprop/cli/hpopt.py#L304) to the value that `ray` is testing. At the end of hyperparameter optimization, the namespace is [updated](https://github.com/chemprop/chemprop/blob/1229525b68b3841e76f4c70a25ef2222775a61a3/chemprop/cli/hpopt.py#L511) with the best value of `batch_size`, but parsing the command line again would set `batch_size` to 10 and this would be printed out. 

