### PR TITLE
Adds CLI option to ignore chirality in SMILES

### DIFF
--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -24,11 +24,6 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         help="Column names in the input CSV containing reaction SMILES in the format ``REACTANT>AGENT>PRODUCT``, where 'AGENT' is optional",
     )
     data_args.add_argument(
-        "--ignore-chirality",
-        action="store_true",
-        help="Ignore chirality information in the input SMILES",
-    )
-    data_args.add_argument(
         "--no-header-row",
         action="store_true",
         help="Turn off using the first row in the input CSV as column names",
@@ -90,6 +85,11 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
     )
     featurization_args.add_argument(
         "--add-h", action="store_true", help="Whether hydrogens should be added to the mol graph"
+    )
+    data_args.add_argument(
+        "--ignore-chirality",
+        action="store_true",
+        help="Ignore chirality information in the input SMILES",
     )
     featurization_args.add_argument(
         "--molecule-featurizers",

--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -24,6 +24,11 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         help="Column names in the input CSV containing reaction SMILES in the format ``REACTANT>AGENT>PRODUCT``, where 'AGENT' is optional",
     )
     data_args.add_argument(
+        "--ignore-chirality",
+        action="store_true",
+        help="Ignore chirality information in the input SMILES",
+    )
+    data_args.add_argument(
         "--no-header-row",
         action="store_true",
         help="Turn off using the first row in the input CSV as column names",

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -102,7 +102,10 @@ def make_fingerprint_for_model(
     )
 
     featurization_kwargs = dict(
-        molecule_featurizers=args.molecule_featurizers, keep_h=args.keep_h, add_h=args.add_h
+        molecule_featurizers=args.molecule_featurizers,
+        keep_h=args.keep_h,
+        add_h=args.add_h,
+        ignore_chirality=args.ignore_chirality,
     )
 
     test_data = build_data_from_files(

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -471,7 +471,10 @@ def main(args: Namespace):
     )
 
     featurization_kwargs = dict(
-        molecule_featurizers=args.molecule_featurizers, keep_h=args.keep_h, add_h=args.add_h
+        molecule_featurizers=args.molecule_featurizers,
+        keep_h=args.keep_h,
+        add_h=args.add_h,
+        ignore_chirality=args.ignore_chirality,
     )
 
     train_data, val_data, test_data = build_splits(args, format_kwargs, featurization_kwargs)

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -194,7 +194,10 @@ def prepare_data_loader(
     )
 
     featurization_kwargs = dict(
-        molecule_featurizers=args.molecule_featurizers, keep_h=args.keep_h, add_h=args.add_h
+        molecule_featurizers=args.molecule_featurizers,
+        keep_h=args.keep_h,
+        add_h=args.add_h,
+        ignore_chirality=args.ignore_chirality,
     )
 
     datas = build_data_from_files(

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1253,7 +1253,10 @@ def main(args):
     )
 
     featurization_kwargs = dict(
-        molecule_featurizers=args.molecule_featurizers, keep_h=args.keep_h, add_h=args.add_h
+        molecule_featurizers=args.molecule_featurizers,
+        keep_h=args.keep_h,
+        add_h=args.add_h,
+        ignore_chirality=args.ignore_chirality,
     )
 
     splits = build_splits(args, format_kwargs, featurization_kwargs)

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -121,6 +121,7 @@ def make_datapoints(
     molecule_featurizers: list[str] | None,
     keep_h: bool,
     add_h: bool,
+    ignore_chirality: bool,
 ) -> tuple[list[list[MoleculeDatapoint]], list[list[ReactionDatapoint]]]:
     """Make the :class:`MoleculeDatapoint`s and :class:`ReactionDatapoint`s for a given
     dataset.
@@ -173,7 +174,11 @@ def make_datapoints(
         RDKit :class:`~rdkit.Chem.Mol` objects, reactant(s) and product(s). Each
         ``molecule_featurizer`` will be applied to both of these objects.
     keep_h : bool
+        whether to keep hydrogen atoms
     add_h : bool
+        whether to add hydrogen atoms
+    ignore_chirality : bool
+        whether to ignore chirality information
 
     Returns
     -------
@@ -206,17 +211,22 @@ def make_datapoints(
         N = len(smiss[0])
 
     if len(smiss) > 0:
-        molss = [[make_mol(smi, keep_h, add_h) for smi in smis] for smis in smiss]
+        molss = [[make_mol(smi, keep_h, add_h, ignore_chirality) for smi in smis] for smis in smiss]
     if len(rxnss) > 0:
         rctss = [
             [
-                make_mol(f"{rct_smi}.{agt_smi}" if agt_smi else rct_smi, keep_h, add_h)
+                make_mol(
+                    f"{rct_smi}.{agt_smi}" if agt_smi else rct_smi, keep_h, add_h, ignore_chirality
+                )
                 for rct_smi, agt_smi, _ in (rxn.split(">") for rxn in rxns)
             ]
             for rxns in rxnss
         ]
         pdtss = [
-            [make_mol(pdt_smi, keep_h, add_h) for _, _, pdt_smi in (rxn.split(">") for rxn in rxns)]
+            [
+                make_mol(pdt_smi, keep_h, add_h, ignore_chirality)
+                for _, _, pdt_smi in (rxn.split(">") for rxn in rxns)
+            ]
             for rxns in rxnss
         ]
 

--- a/chemprop/data/datapoints.py
+++ b/chemprop/data/datapoints.py
@@ -48,9 +48,15 @@ class _MoleculeDatapointMixin:
 
     @classmethod
     def from_smi(
-        cls, smi: str, *args, keep_h: bool = False, add_h: bool = False, **kwargs
+        cls,
+        smi: str,
+        *args,
+        keep_h: bool = False,
+        add_h: bool = False,
+        ignore_chirality: bool = False,
+        **kwargs,
     ) -> _MoleculeDatapointMixin:
-        mol = make_mol(smi, keep_h, add_h)
+        mol = make_mol(smi, keep_h, add_h, ignore_chirality)
 
         kwargs["name"] = smi if "name" not in kwargs else kwargs["name"]
 
@@ -103,6 +109,7 @@ class _ReactionDatapointMixin:
         *args,
         keep_h: bool = False,
         add_h: bool = False,
+        ignore_chirality: bool = False,
         **kwargs,
     ) -> _ReactionDatapointMixin:
         match rxn_or_smis:
@@ -119,8 +126,8 @@ class _ReactionDatapointMixin:
                     " a product SMILES strings!"
                 )
 
-        rct = make_mol(rct_smi, keep_h, add_h)
-        pdt = make_mol(pdt_smi, keep_h, add_h)
+        rct = make_mol(rct_smi, keep_h, add_h, ignore_chirality)
+        pdt = make_mol(pdt_smi, keep_h, add_h, ignore_chirality)
 
         kwargs["name"] = name if "name" not in kwargs else kwargs["name"]
 

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -32,7 +32,7 @@ class EnumMapping(StrEnum):
         return zip(cls.keys(), cls.values())
 
 
-def make_mol(smi: str, keep_h: bool, add_h: bool) -> Chem.Mol:
+def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool) -> Chem.Mol:
     """build an RDKit molecule from a SMILES string.
 
     Parameters
@@ -43,6 +43,8 @@ def make_mol(smi: str, keep_h: bool, add_h: bool) -> Chem.Mol:
         whether to keep hydrogens in the input smiles. This does not add hydrogens, it only keeps them if they are specified
     add_h : bool
         whether to add hydrogens to the molecule
+    ignore_chirality : bool
+        whether to ignore chirality information
 
     Returns
     -------
@@ -62,6 +64,10 @@ def make_mol(smi: str, keep_h: bool, add_h: bool) -> Chem.Mol:
 
     if add_h:
         mol = Chem.AddHs(mol)
+
+    if ignore_chirality:
+        for atom in mol.GetAtoms():
+            atom.SetChiralTag(Chem.ChiralType.CHI_UNSPECIFIED)
 
     return mol
 

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -32,7 +32,7 @@ class EnumMapping(StrEnum):
         return zip(cls.keys(), cls.values())
 
 
-def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool) -> Chem.Mol:
+def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool=False) -> Chem.Mol:
     """build an RDKit molecule from a SMILES string.
 
     Parameters
@@ -42,9 +42,9 @@ def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool) -> Che
     keep_h : bool
         whether to keep hydrogens in the input smiles. This does not add hydrogens, it only keeps them if they are specified
     add_h : bool
-        whether to add hydrogens to the molecule
-    ignore_chirality : bool
-        whether to ignore chirality information
+        If True, adds hydrogens to the molecule.
+    ignore_chirality : bool, optional
+        If True, ignores chirality information when constructing the molecule. Default is False.
 
     Returns
     -------

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -32,7 +32,7 @@ class EnumMapping(StrEnum):
         return zip(cls.keys(), cls.values())
 
 
-def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool=False) -> Chem.Mol:
+def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool = False) -> Chem.Mol:
     """build an RDKit molecule from a SMILES string.
 
     Parameters

--- a/docs/source/tutorial/python/featurizers/molecule_featurizers.ipynb
+++ b/docs/source/tutorial/python/featurizers/molecule_featurizers.ipynb
@@ -38,7 +38,7 @@
     "from chemprop.utils import make_mol\n",
     "\n",
     "smis = [\"C\" * i for i in range(1, 11)]\n",
-    "mols = [make_mol(smi, keep_h=False, add_h=False) for smi in smis]"
+    "mols = [make_mol(smi, keep_h=False, add_h=False, ignore_chirality=False) for smi in smis]"
    ]
   },
   {

--- a/tests/cli/test_cli_classification_mol.py
+++ b/tests/cli/test_cli_classification_mol.py
@@ -64,6 +64,22 @@ def test_predict_quick(monkeypatch, data_path, model_path):
         main()
 
 
+def test_predict_ignore_chirality(monkeypatch, data_path, model_path):
+    args = [
+        "chemprop",
+        "predict",
+        "-i",
+        data_path,
+        "--model-path",
+        model_path,
+        "--ignore-chirality",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
 def test_predict_dirichlet_quick(monkeypatch, data_path, dirichlet_model_path):
     args = [
         "chemprop",

--- a/tests/unit/data/test_datapoint.py
+++ b/tests/unit/data/test_datapoint.py
@@ -6,6 +6,11 @@ from chemprop.data import MoleculeDatapoint
 SMI = "c1ccccc1"
 
 
+@pytest.fixture(params=["@", "@@"])
+def chiral_smi(request):
+    return f"C[C{request.param}H](O)N"
+
+
 @pytest.fixture(params=range(1, 3))
 def targets(request):
     return np.random.rand(request.param)
@@ -35,6 +40,13 @@ def test_addh(smi, targets):
     d2 = MoleculeDatapoint.from_smi(smi, y=targets, add_h=True)
 
     assert d1.mol.GetNumAtoms() != d2.mol.GetNumAtoms()
+
+
+def test_ignore_chirality(chiral_smi, targets):
+    d1 = MoleculeDatapoint.from_smi(chiral_smi, y=targets)
+    d2 = MoleculeDatapoint.from_smi(chiral_smi, y=targets, ignore_chirality=True)
+
+    assert d1.mol.GetAtomWithIdx(1).GetChiralTag() != d2.mol.GetAtomWithIdx(1).GetChiralTag()
 
 
 def test_replace_token(smi, targets, features_with_nans):

--- a/tests/unit/featurizers/test_cgr.py
+++ b/tests/unit/featurizers/test_cgr.py
@@ -133,11 +133,14 @@ bond_expect_balanced.update(
 
 # A fake `bond` is used in test_calc_edge_features. This is a workaround,
 # as RDKit cannot construct a bond directly in Python
-bond = make_mol("[CH3:1][H:2]", keep_h=True, add_h=False).GetBondWithIdx(0)
+bond = make_mol("[CH3:1][H:2]", keep_h=True, add_h=False, ignore_chirality=False).GetBondWithIdx(0)
 
 
 def get_reac_prod(rxn_smi: str) -> list:
-    return [make_mol(smi, keep_h=True, add_h=False) for smi in rxn_smi.split(">>")]
+    return [
+        make_mol(smi, keep_h=True, add_h=False, ignore_chirality=False)
+        for smi in rxn_smi.split(">>")
+    ]
 
 
 def randomize_case(s: str) -> str:


### PR DESCRIPTION
## Description

Addresses #1076, #1077, and #1078.

This PR adds the CLI option `--ignore-chirality` to be used in all commands (`train`, `predict`, etc.).

The solution is analogous to the implementation of `--add-h` and `--keep-h`: a new argument was added to class methods that instantiate datapoints from SMILES strings. **Note**: like `--add-h` and `--keep-h`, `--ignore-chirality` shows up in the CLI help as a featurization option.

## Checklist
- [x] linted with flake8, black, and isort
- [x] unit tests added