### PR TITLE
Make sure bounded targets dataframe is all strings

### DIFF
--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -63,6 +63,7 @@ def parse_csv(
     weights = None if weight_col is None else df[weight_col].to_numpy(np.single)
 
     if bounded:
+        Y = Y.astype(str)
         lt_mask = Y.applymap(lambda x: "<" in x).to_numpy()
         gt_mask = Y.applymap(lambda x: ">" in x).to_numpy()
         Y = Y.applymap(lambda x: x.strip("<").strip(">")).to_numpy(np.single)


### PR DESCRIPTION
## Description
As suggested in #1199 to fix #1199

In the CLI, we do some string operations on bounded targets to see if they have a "<" or ">". This only works if all the entries in the DataFrame are strings. In #1199, the user had some missing target values which `pandas` will read in as `np.nan` which is a float. This nan value will stay a float even if the rest of the rows in the column are strings. Compare this to normal floats like `1.1` which are converted to (or actually left as) strings like `"1.1"` if there are other values in the column that can't be converted to floats. 

Using `Y = Y.astype(str)` will convert `np.nan` into `"nan"`. This lets the string operations work. Then `Y = Y.to_numpy(np.single)` will cast the `"nan"` back to `np.nan` (but as a float32). 

There could also be a problem if one column doesn't have any bounded targets because then that column will be turned into floats when reading it in. The change in this PR also fixes that potential problem. 