### PR TITLE
Fix dropout uncertainty output shape

### DIFF
--- a/chemprop/uncertainty/estimator.py
+++ b/chemprop/uncertainty/estimator.py
@@ -225,7 +225,7 @@ class DropoutEstimator(UncertaintyEstimator):
                 individual_preds.append(preds)
 
             stacked_preds = torch.stack(individual_preds, dim=0).float()
-            means = torch.mean(stacked_preds, dim=0).unsqueeze(0)
+            means = torch.mean(stacked_preds, dim=0)
             vars = torch.var(stacked_preds, dim=0, correction=0)
             self._restore_model(model)
             meanss.append(means)

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -31,6 +31,11 @@ def model_path(data_dir):
 
 
 @pytest.fixture
+def extra_model_path(data_dir):
+    return str(data_dir / "example_model_v2_regression_mol_with_metrics.ckpt")
+
+
+@pytest.fixture
 def mve_model_path(data_dir):
     return str(data_dir / "example_model_v2_regression_mve_mol.pt")
 
@@ -143,6 +148,44 @@ def test_train_quick_features(monkeypatch, data_path):
 def test_predict_quick(monkeypatch, data_path, model_path):
     input_path, *_ = data_path
     args = ["chemprop", "predict", "-i", input_path, "--model-path", model_path]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
+def test_predict_ensemble_quick(monkeypatch, data_path, model_path, extra_model_path):
+    input_path, *_ = data_path
+    args = [
+        "chemprop",
+        "predict",
+        "-i",
+        input_path,
+        "--model-path",
+        model_path,
+        extra_model_path,
+        "--uncertainty-method",
+        "ensemble",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
+def test_predict_dropout_quick(monkeypatch, data_path, model_path, extra_model_path):
+    input_path, *_ = data_path
+    args = [
+        "chemprop",
+        "predict",
+        "-i",
+        input_path,
+        "--model-path",
+        model_path,
+        extra_model_path,
+        "--uncertainty-method",
+        "dropout",
+    ]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)


### PR DESCRIPTION
## Description
Fixes #1204

In #1055, we changed `DropoutEstimator` to work for multiple models, with the idea that dropout would be used with each model to get a prediction and uncertainty estimate for each model, which would be individually written to the `preds_individual.csv` and then averaged to be written in `preds.csv`. But when we added `torch.stack(meanss)` to get the `n_datapoints x n_targets` preds into an `n_models x n_datapoints x n_targets` tensor, we forgot that the preds tensors already were shape `1 x n_datapoints x n_targets` (because we only supported one model) by using unsqueeze: `means = torch.mean(stacked_preds, dim=0).unsqueeze(0)`. Removing the unsqueeze gets the output tensor in the expected shape. 

I also added a CLI test for dropout and ensembling. 