### PR TITLE
(Data point) weights should be shape `b` or `b x 1`

### DIFF
--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -140,7 +140,7 @@ def make_datapoints(
     Y : np.ndarray
         the target values of shape ``n x m``, where ``m`` is the number of targets
     weights : np.ndarray | None
-        the weights of the datapoints to use in the loss function of shape ``n x m``. If ``None``,
+        the weights of the datapoints to use in the loss function of shape ``n``. If ``None``,
         the weights all default to 1.
     lt_mask : np.ndarray | None
         a boolean mask of shape ``n x m`` indicating whether the targets are less than inequality

--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -100,7 +100,7 @@ class ChempropMetric(torchmetrics.Metric):
         gt_mask: Tensor
         """
         mask = torch.ones_like(targets, dtype=torch.bool) if mask is None else mask
-        weights = torch.ones_like(targets, dtype=torch.float) if weights is None else weights
+        weights = torch.ones(targets.shape[0], dtype=torch.float) if weights is None else weights
         lt_mask = torch.zeros_like(targets, dtype=torch.bool) if lt_mask is None else lt_mask
         gt_mask = torch.zeros_like(targets, dtype=torch.bool) if gt_mask is None else gt_mask
 
@@ -292,7 +292,7 @@ class BinaryMCCLoss(ChempropMetric):
         *args,
     ):
         mask = torch.ones_like(targets, dtype=torch.bool) if mask is None else mask
-        weights = torch.ones_like(targets, dtype=torch.float) if weights is None else weights
+        weights = torch.ones(targets.shape[0], dtype=torch.float) if weights is None else weights
 
         if not (0 <= preds.min() and preds.max() <= 1):  # assume logits
             preds = preds.sigmoid()
@@ -363,7 +363,9 @@ class MulticlassMCCLoss(ChempropMetric):
     ):
         mask = torch.ones_like(targets, dtype=torch.bool) if mask is None else mask
         weights = (
-            torch.ones_like(targets, dtype=torch.float) if weights is None else weights.view(-1, 1)
+            torch.ones((targets.shape[0], 1), dtype=torch.float)
+            if weights is None
+            else weights.view(-1, 1)
         )
 
         if not (0 <= preds.min() and preds.max() <= 1):  # assume logits

--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -85,10 +85,11 @@ class ChempropMetric(torchmetrics.Metric):
         Parameters
         ----------
         preds : Tensor
-            a tensor of shape `b x t x u` (regression), `b x t` (binary classification), or
-            `b x t x c` (multiclass classification) containing the predictions, where `b` is the
-            batch size, `t` is the number of tasks to predict, `u` is the number of
-            targets to predict for each task, and `c` is the number of classes.
+            a tensor of shape `b x t x u` (regression with uncertainty), `b x t` (regression without
+            uncertainty and binary classification, except for binary dirichlet), or `b x t x c`
+            (multiclass classification and binary dirichlet) containing the predictions, where `b`
+            is the batch size, `t` is the number of tasks to predict, `u` is the number of values to
+            predict for each task, and `c` is the number of classes.
         targets : Tensor
             a float tensor of shape `b x t` containing the target values
         mask : Tensor


### PR DESCRIPTION
## Description
The (data point) weights passed to a loss function/metric should be shape `batch_size` or `batch_size x 1` as noted in the base class doc string:
https://github.com/chemprop/chemprop/blob/ba7a496d1b98ae81aaced867f0bd0320649c74e8/chemprop/nn/metrics.py#L97-L98

We had typo in parsing, but more importantly the default weights array in the metrics is shape `batch_size x n_tasks`, which will be an issue when we try to unsqueeze the weights using `weights.view(-1, 1)`. 
