### PR TITLE
Expand chirality ignore to ignore bond stereochemistry

### DIFF
--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -87,9 +87,9 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         "--add-h", action="store_true", help="Whether hydrogens should be added to the mol graph"
     )
     data_args.add_argument(
-        "--ignore-chirality",
+        "--ignore-stereo",
         action="store_true",
-        help="Ignore chirality information in the input SMILES",
+        help="Ignore stereochemical information in the input SMILES",
     )
     featurization_args.add_argument(
         "--molecule-featurizers",

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -105,7 +105,7 @@ def make_fingerprint_for_model(
         molecule_featurizers=args.molecule_featurizers,
         keep_h=args.keep_h,
         add_h=args.add_h,
-        ignore_chirality=args.ignore_chirality,
+        ignore_stereo=args.ignore_stereo,
     )
 
     test_data = build_data_from_files(

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -474,7 +474,7 @@ def main(args: Namespace):
         molecule_featurizers=args.molecule_featurizers,
         keep_h=args.keep_h,
         add_h=args.add_h,
-        ignore_chirality=args.ignore_chirality,
+        ignore_stereo=args.ignore_stereo,
     )
 
     train_data, val_data, test_data = build_splits(args, format_kwargs, featurization_kwargs)

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -197,7 +197,7 @@ def prepare_data_loader(
         molecule_featurizers=args.molecule_featurizers,
         keep_h=args.keep_h,
         add_h=args.add_h,
-        ignore_chirality=args.ignore_chirality,
+        ignore_stereo=args.ignore_stereo,
     )
 
     datas = build_data_from_files(

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1256,7 +1256,7 @@ def main(args):
         molecule_featurizers=args.molecule_featurizers,
         keep_h=args.keep_h,
         add_h=args.add_h,
-        ignore_chirality=args.ignore_chirality,
+        ignore_stereo=args.ignore_stereo,
     )
 
     splits = build_splits(args, format_kwargs, featurization_kwargs)

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -122,7 +122,7 @@ def make_datapoints(
     molecule_featurizers: list[str] | None,
     keep_h: bool,
     add_h: bool,
-    ignore_chirality: bool,
+    ignore_stereo: bool,
 ) -> tuple[list[list[MoleculeDatapoint]], list[list[ReactionDatapoint]]]:
     """Make the :class:`MoleculeDatapoint`s and :class:`ReactionDatapoint`s for a given
     dataset.
@@ -178,8 +178,8 @@ def make_datapoints(
         whether to keep hydrogen atoms
     add_h : bool
         whether to add hydrogen atoms
-    ignore_chirality : bool
-        whether to ignore chirality information
+    ignore_stereo : bool
+        whether to ignore stereo information
 
     Returns
     -------
@@ -212,12 +212,12 @@ def make_datapoints(
         N = len(smiss[0])
 
     if len(smiss) > 0:
-        molss = [[make_mol(smi, keep_h, add_h, ignore_chirality) for smi in smis] for smis in smiss]
+        molss = [[make_mol(smi, keep_h, add_h, ignore_stereo) for smi in smis] for smis in smiss]
     if len(rxnss) > 0:
         rctss = [
             [
                 make_mol(
-                    f"{rct_smi}.{agt_smi}" if agt_smi else rct_smi, keep_h, add_h, ignore_chirality
+                    f"{rct_smi}.{agt_smi}" if agt_smi else rct_smi, keep_h, add_h, ignore_stereo
                 )
                 for rct_smi, agt_smi, _ in (rxn.split(">") for rxn in rxns)
             ]
@@ -225,7 +225,7 @@ def make_datapoints(
         ]
         pdtss = [
             [
-                make_mol(pdt_smi, keep_h, add_h, ignore_chirality)
+                make_mol(pdt_smi, keep_h, add_h, ignore_stereo)
                 for _, _, pdt_smi in (rxn.split(">") for rxn in rxns)
             ]
             for rxns in rxnss

--- a/chemprop/data/datapoints.py
+++ b/chemprop/data/datapoints.py
@@ -53,10 +53,10 @@ class _MoleculeDatapointMixin:
         *args,
         keep_h: bool = False,
         add_h: bool = False,
-        ignore_chirality: bool = False,
+        ignore_stereo: bool = False,
         **kwargs,
     ) -> _MoleculeDatapointMixin:
-        mol = make_mol(smi, keep_h, add_h, ignore_chirality)
+        mol = make_mol(smi, keep_h, add_h, ignore_stereo)
 
         kwargs["name"] = smi if "name" not in kwargs else kwargs["name"]
 
@@ -109,7 +109,7 @@ class _ReactionDatapointMixin:
         *args,
         keep_h: bool = False,
         add_h: bool = False,
-        ignore_chirality: bool = False,
+        ignore_stereo: bool = False,
         **kwargs,
     ) -> _ReactionDatapointMixin:
         match rxn_or_smis:
@@ -126,8 +126,8 @@ class _ReactionDatapointMixin:
                     " a product SMILES strings!"
                 )
 
-        rct = make_mol(rct_smi, keep_h, add_h, ignore_chirality)
-        pdt = make_mol(pdt_smi, keep_h, add_h, ignore_chirality)
+        rct = make_mol(rct_smi, keep_h, add_h, ignore_stereo)
+        pdt = make_mol(pdt_smi, keep_h, add_h, ignore_stereo)
 
         kwargs["name"] = name if "name" not in kwargs else kwargs["name"]
 

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -32,7 +32,7 @@ class EnumMapping(StrEnum):
         return zip(cls.keys(), cls.values())
 
 
-def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool = False) -> Chem.Mol:
+def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_stereo: bool = False) -> Chem.Mol:
     """build an RDKit molecule from a SMILES string.
 
     Parameters
@@ -43,8 +43,8 @@ def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool = False
         whether to keep hydrogens in the input smiles. This does not add hydrogens, it only keeps them if they are specified
     add_h : bool
         If True, adds hydrogens to the molecule.
-    ignore_chirality : bool, optional
-        If True, ignores chirality information when constructing the molecule. Default is False.
+    ignore_stereo : bool, optional
+        If True, ignores stereochemical information when constructing the molecule. Default is False.
 
     Returns
     -------
@@ -65,9 +65,11 @@ def make_mol(smi: str, keep_h: bool, add_h: bool, ignore_chirality: bool = False
     if add_h:
         mol = Chem.AddHs(mol)
 
-    if ignore_chirality:
+    if ignore_stereo:
         for atom in mol.GetAtoms():
             atom.SetChiralTag(Chem.ChiralType.CHI_UNSPECIFIED)
+        for bond in mol.GetBonds():
+            bond.SetStereo(Chem.BondStereo.STEREONONE)
 
     return mol
 

--- a/docs/source/tutorial/python/featurizers/molecule_featurizers.ipynb
+++ b/docs/source/tutorial/python/featurizers/molecule_featurizers.ipynb
@@ -38,7 +38,7 @@
     "from chemprop.utils import make_mol\n",
     "\n",
     "smis = [\"C\" * i for i in range(1, 11)]\n",
-    "mols = [make_mol(smi, keep_h=False, add_h=False, ignore_chirality=False) for smi in smis]"
+    "mols = [make_mol(smi, keep_h=False, add_h=False, ignore_stereo=False) for smi in smis]"
    ]
   },
   {

--- a/tests/cli/test_cli_classification_mol.py
+++ b/tests/cli/test_cli_classification_mol.py
@@ -64,16 +64,8 @@ def test_predict_quick(monkeypatch, data_path, model_path):
         main()
 
 
-def test_predict_ignore_chirality(monkeypatch, data_path, model_path):
-    args = [
-        "chemprop",
-        "predict",
-        "-i",
-        data_path,
-        "--model-path",
-        model_path,
-        "--ignore-chirality",
-    ]
+def test_predict_ignore_stereo(monkeypatch, data_path, model_path):
+    args = ["chemprop", "predict", "-i", data_path, "--model-path", model_path, "--ignore-stereo"]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)

--- a/tests/unit/data/test_datapoint.py
+++ b/tests/unit/data/test_datapoint.py
@@ -7,8 +7,8 @@ SMI = "c1ccccc1"
 
 
 @pytest.fixture(params=["@", "@@"])
-def chiral_smi(request):
-    return f"C[C{request.param}H](O)N"
+def stereo_smi(request):
+    return f"C[C{request.param}H](O)NC\C=C/C"
 
 
 @pytest.fixture(params=range(1, 3))
@@ -42,11 +42,12 @@ def test_addh(smi, targets):
     assert d1.mol.GetNumAtoms() != d2.mol.GetNumAtoms()
 
 
-def test_ignore_chirality(chiral_smi, targets):
-    d1 = MoleculeDatapoint.from_smi(chiral_smi, y=targets)
-    d2 = MoleculeDatapoint.from_smi(chiral_smi, y=targets, ignore_chirality=True)
+def test_ignore_stereo(stereo_smi, targets):
+    d1 = MoleculeDatapoint.from_smi(stereo_smi, y=targets)
+    d2 = MoleculeDatapoint.from_smi(stereo_smi, y=targets, ignore_stereo=True)
 
     assert d1.mol.GetAtomWithIdx(1).GetChiralTag() != d2.mol.GetAtomWithIdx(1).GetChiralTag()
+    assert d1.mol.GetBondWithIdx(5).GetStereo() != d2.mol.GetBondWithIdx(5).GetStereo()
 
 
 def test_replace_token(smi, targets, features_with_nans):

--- a/tests/unit/featurizers/test_cgr.py
+++ b/tests/unit/featurizers/test_cgr.py
@@ -133,13 +133,12 @@ bond_expect_balanced.update(
 
 # A fake `bond` is used in test_calc_edge_features. This is a workaround,
 # as RDKit cannot construct a bond directly in Python
-bond = make_mol("[CH3:1][H:2]", keep_h=True, add_h=False, ignore_chirality=False).GetBondWithIdx(0)
+bond = make_mol("[CH3:1][H:2]", keep_h=True, add_h=False, ignore_stereo=False).GetBondWithIdx(0)
 
 
 def get_reac_prod(rxn_smi: str) -> list:
     return [
-        make_mol(smi, keep_h=True, add_h=False, ignore_chirality=False)
-        for smi in rxn_smi.split(">>")
+        make_mol(smi, keep_h=True, add_h=False, ignore_stereo=False) for smi in rxn_smi.split(">>")
     ]
 
 


### PR DESCRIPTION
## Description
In #1196 we added an option to ignore chiral information in SMILES strings when making the rdkit Mol objects. This is useful because sometimes people train models on SMILES strings that don't have chiral information, but then an end user runs inference on a molecule with chiral information. The default featurizer has a bit for chiral tag, which if untrained, will cause the model to predict an erroneous value for that molecule with chiral information. The same is true for bond stereochemistry (cis/trans, etc.) so this PR expands the reach of `--ignore-chiral` to also ignore bond stereochemistry. 

This will break models trained trained off main since we push #1196 two weeks ago. Because we haven't included it in a tagged version yet, I think this is okay. 