### PR TITLE
MCC metrics higher is better

### DIFF
--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -325,6 +325,8 @@ class BinaryMCCLoss(ChempropMetric):
 
 @MetricRegistry.register("binary-mcc")
 class BinaryMCCMetric(BinaryMCCLoss):
+    higher_is_better = True
+
     def compute(self):
         return 1 - super().compute()
 
@@ -410,6 +412,8 @@ class MulticlassMCCLoss(ChempropMetric):
 
 @MetricRegistry.register("multiclass-mcc")
 class MulticlassMCCMetric(MulticlassMCCLoss):
+    higher_is_better = True
+
     def compute(self):
         return 1 - super().compute()
 


### PR DESCRIPTION
## Description
When I added the MCC metrics (as oppose to the MCC loss) functions, I forgot to flip the class variable `higher_is_better` which we use to set the monitor mode of the Checkpointing call back. 