### PR TITLE
Add Support for Fine-Tuning Foundation Models with `--from-foundation` and add `CheMeleon`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 ignore = E203, E266, E501, F403, E741, W503, W605
 max-line-length = 100
-max-complexity = 20
 per-file-ignores =
     __init__.py: F401
     chemprop/nn/predictors.py: F405

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 ignore = E203, E266, E501, F403, E741, W503, W605
 max-line-length = 100
-max-complexity = 18
+max-complexity = 20
 per-file-ignores =
     __init__.py: F401
     chemprop/nn/predictors.py: F405

--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,6 @@ cython_debug/
 *.ckpt
 chemprop/_version.py
 *.ckpt
-*.ipynb
 config.toml
 
 !tests/data/*

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1016,7 +1016,6 @@ def build_model(
                     )
                 agg = Factory.build(AggregationRegistry["mean"], norm=None)
     else:
-        agg = Factory.build(AggregationRegistry[args.aggregation], norm=args.aggregation_norm)
         mp_cls = AtomMessagePassing if args.atom_messages else BondMessagePassing
         if is_multi:
             mp_blocks = [
@@ -1063,6 +1062,7 @@ def build_model(
                 V_d_transform=V_d_transforms[0],
                 graph_transform=graph_transforms[0],
             )
+        agg = Factory.build(AggregationRegistry[args.aggregation], norm=args.aggregation_norm)
 
     predictor_cls = PredictorRegistry[args.task_type]
     if args.loss_function is not None:

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -47,6 +47,7 @@ from chemprop.data import (
     split_data_by_indices,
 )
 from chemprop.data.datasets import _MolGraphDatasetMixin
+from chemprop.featurizers.atom import AtomFeatureMode
 from chemprop.models import MPNN, MulticomponentMPNN, save_model
 from chemprop.nn import AggregationRegistry, LossFunctionRegistry, MetricRegistry, PredictorRegistry
 from chemprop.nn.message_passing import (
@@ -58,7 +59,6 @@ from chemprop.nn.transforms import GraphTransform, ScaleTransform, UnscaleTransf
 from chemprop.nn.utils import Activation
 from chemprop.utils import Factory
 from chemprop.utils.utils import EnumMapping
-from chemprop.featurizers.atom import AtomFeatureMode
 
 logger = logging.getLogger(__name__)
 
@@ -528,7 +528,7 @@ def validate_train_args(args):
                 if (mode := args.multi_hot_atom_featurizer_mode) != AtomFeatureMode.V2:
                     raise ArgumentError(
                         argument=None,
-                        message=f"Foundation model {fm_name} must be used with `--multi-hot-atom-featurizer-mode V2` not `{mode}`!"
+                        message=f"Foundation model {fm_name} must be used with `--multi-hot-atom-featurizer-mode V2` not `{mode}`!",
                     )
         for arg_value, arg_name in (
             (args.message_hidden_dim, "--message-hidden-dim"),
@@ -987,12 +987,16 @@ def build_model(
                 ckpt_dir = Path(__file__).parent / "_foundation_models"
                 ckpt_dir.mkdir(exist_ok=True)
                 if not (ckpt_dir / "chemeleon_mp.pt").exists():
-                    logger.info("Downloading CheMeleon Foundation model from Zenodo (https://zenodo.org/records/15426601)")
+                    logger.info(
+                        "Downloading CheMeleon Foundation model from Zenodo (https://zenodo.org/records/15426601)"
+                    )
                     urlretrieve(
                         r"https://zenodo.org/records/15426601/files/chemeleon_mp.pt",
                         ckpt_dir / "chemeleon_mp.pt",
                     )
-                logger.info("Please cite DOI: 10.5281/zenodo.15426600 when using CheMeleon in published work")
+                logger.info(
+                    "Please cite DOI: 10.5281/zenodo.15426600 when using CheMeleon in published work"
+                )
                 if is_multi:
                     mp_block = MulticomponentMessagePassing(
                         [

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -155,7 +155,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     )
     transfer_args.add_argument(
         "--from-foundation",
-        help=f"Name of pretrained foundation model used to initialize message passing. One of: {', '.join((FoundationModels.keys()))}",
+        help=f"Name of pretrained foundation model used to initialize message passing. One of: {', '.join((FoundationModels.keys()))}, or a path to a local model file.",
     )
     # transfer_args.add_argument(
     #     "--freeze-first-only",

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -986,7 +986,7 @@ def build_model(
     if from_foundation is not None:
         match FoundationModels.get(from_foundation):
             case FoundationModels.CHEMELEON:
-                ckpt_dir = Path(__file__).parent / "_foundation_models"
+                ckpt_dir = Path().home() / ".chemprop"
                 ckpt_dir.mkdir(exist_ok=True)
                 if not (ckpt_dir / "chemeleon_mp.pt").exists():
                     logger.info(

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -520,7 +520,7 @@ def validate_train_args(args):
                     message=f"Unrecognized foundation model name {fm_name}! Should be one of: {', '.join((FoundationModels.keys()))} or a local file (double check your filepath).",
                 ) from KeyError
             else:
-                local_foundation=True
+                local_foundation = True
         if args.checkpoint is not None:
             raise ArgumentError(
                 argument=None,
@@ -545,7 +545,7 @@ def validate_train_args(args):
                         if arg_value is not None:
                             raise ArgumentError(
                                 argument=None,
-                                message=f"CheMeleon does not support passing {arg_name}"
+                                message=f"CheMeleon does not support passing {arg_name}",
                             )
         _msg = ""
         for arg_value, arg_name in (
@@ -562,7 +562,10 @@ def validate_train_args(args):
             if arg_value is not None:
                 _msg += f"\n`{arg_name} {arg_value}`"
         if _msg:
-            logger.warning("The following arguments are ignored when making the message passing layer because it is initialized from a foundation model:" + _msg)
+            logger.warning(
+                "The following arguments are ignored when making the message passing layer because it is initialized from a foundation model:"
+                + _msg
+            )
 
     # TODO: model_frzn is deprecated and then remove in v2.2
     if args.checkpoint is not None and args.model_frzn is not None:
@@ -1004,11 +1007,12 @@ def build_model(
             if is_multi:
                 mp_blocks = []
                 for _ in range(train_dset.n_components):
-                    foundation = MPNN.load_from_file(from_foundation)  # must re-load for each, no good way to copy
+                    foundation = MPNN.load_from_file(
+                        from_foundation
+                    )  # must re-load for each, no good way to copy
                     mp_blocks.append(foundation.message_passing)
-                mp_block = MulticomponentMessagePassing(mp_blocks,
-                    train_dset.n_components,
-                    args.mpn_shared,
+                mp_block = MulticomponentMessagePassing(
+                    mp_blocks, train_dset.n_components, args.mpn_shared
                 )
             else:
                 foundation = MPNN.load_from_file(from_foundation)
@@ -1025,8 +1029,7 @@ def build_model(
                             f"Downloading CheMeleon Foundation model from Zenodo (https://zenodo.org/records/15460715) to {model_path}"
                         )
                         urlretrieve(
-                            r"https://zenodo.org/records/15460715/files/chemeleon_mp.pt",
-                            model_path,
+                            r"https://zenodo.org/records/15460715/files/chemeleon_mp.pt", model_path
                         )
                     else:
                         logger.info(f"Loading cached CheMeleon from {model_path}")
@@ -1035,16 +1038,18 @@ def build_model(
                     )
                     chemeleon_mp = torch.load(model_path, weights_only=True)
                     if is_multi:
-                        mp_blocks = [BondMessagePassing(**chemeleon_mp['hyper_parameters']) for _ in range(train_dset.n_components)]
+                        mp_blocks = [
+                            BondMessagePassing(**chemeleon_mp["hyper_parameters"])
+                            for _ in range(train_dset.n_components)
+                        ]
                         for block in mp_blocks:
-                            block.load_state_dict(chemeleon_mp['state_dict'])
-                        mp_block = MulticomponentMessagePassing(mp_blocks,
-                            train_dset.n_components,
-                            args.mpn_shared,
+                            block.load_state_dict(chemeleon_mp["state_dict"])
+                        mp_block = MulticomponentMessagePassing(
+                            mp_blocks, train_dset.n_components, args.mpn_shared
                         )
                     else:
-                        mp_block = BondMessagePassing(**chemeleon_mp['hyper_parameters'])
-                        mp_block.load_state_dict(chemeleon_mp['state_dict'])
+                        mp_block = BondMessagePassing(**chemeleon_mp["hyper_parameters"])
+                        mp_block.load_state_dict(chemeleon_mp["state_dict"])
                     agg = Factory.build(AggregationRegistry["mean"])
     else:
         mp_cls = AtomMessagePassing if args.atom_messages else BondMessagePassing

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -525,7 +525,9 @@ def validate_train_args(args):
         # model-specific validation
         match FoundationModels.get(fm_name):
             case FoundationModels.CHEMELEON:
-                if (mode := AtomFeatureMode.get(args.multi_hot_atom_featurizer_mode)) != AtomFeatureMode.V2:
+                if (
+                    mode := AtomFeatureMode.get(args.multi_hot_atom_featurizer_mode)
+                ) != AtomFeatureMode.V2:
                     raise ArgumentError(
                         argument=None,
                         message=f"Foundation model {fm_name} must be used with `--multi-hot-atom-featurizer-mode V2` not `{mode}`!",

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -525,7 +525,7 @@ def validate_train_args(args):
         # model-specific validation
         match FoundationModels.get(fm_name):
             case FoundationModels.CHEMELEON:
-                if (mode := args.multi_hot_atom_featurizer_mode) != AtomFeatureMode.V2:
+                if (mode := AtomFeatureMode.get(args.multi_hot_atom_featurizer_mode)) != AtomFeatureMode.V2:
                     raise ArgumentError(
                         argument=None,
                         message=f"Foundation model {fm_name} must be used with `--multi-hot-atom-featurizer-mode V2` not `{mode}`!",

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -988,14 +988,17 @@ def build_model(
             case FoundationModels.CHEMELEON:
                 ckpt_dir = Path().home() / ".chemprop"
                 ckpt_dir.mkdir(exist_ok=True)
-                if not (ckpt_dir / "chemeleon_mp.pt").exists():
+                model_path = ckpt_dir / "chemeleon_mp.pt"
+                if not model_path.exists():
                     logger.info(
-                        "Downloading CheMeleon Foundation model from Zenodo (https://zenodo.org/records/15426601)"
+                        f"Downloading CheMeleon Foundation model from Zenodo (https://zenodo.org/records/15426601) to {model_path}"
                     )
                     urlretrieve(
                         r"https://zenodo.org/records/15426601/files/chemeleon_mp.pt",
-                        ckpt_dir / "chemeleon_mp.pt",
+                        model_path,
                     )
+                else:
+                    logger.info(f"Loading cached CheMeleon from {model_path}")
                 logger.info(
                     "Please cite DOI: 10.5281/zenodo.15426600 when using CheMeleon in published work"
                 )
@@ -1003,7 +1006,7 @@ def build_model(
                     mp_block = MulticomponentMessagePassing(
                         [
                             torch.load(
-                                ckpt_dir / "chemeleon_mp.pt", map_location="cpu", weights_only=False
+                                model_path, map_location="cpu", weights_only=False
                             )
                             for _ in range(train_dset.n_components)
                         ],

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1049,10 +1049,6 @@ def build_model(
             mp_block = MulticomponentMessagePassing(
                 mp_blocks, train_dset.n_components, args.mpn_shared
             )
-            # NOTE(degraff): this if/else block should be handled by the init of MulticomponentMessagePassing
-            # if args.mpn_shared:
-            #     mp_block = MulticomponentMessagePassing(mp_blocks[0], n_components, args.mpn_shared)
-            # else:
         else:
             mp_block = mp_cls(
                 train_dset.featurizer.atom_fdim,

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1014,7 +1014,7 @@ def build_model(
                     mp_block = torch.load(
                         ckpt_dir / "chemeleon_mp.pt", map_location="cpu", weights_only=False
                     )
-                agg = Factory.build(AggregationRegistry["mean"], norm=None)
+                agg = Factory.build(AggregationRegistry["mean"])
     else:
         mp_cls = AtomMessagePassing if args.atom_messages else BondMessagePassing
         if is_multi:

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -16,7 +16,7 @@ class EnumMapping(StrEnum):
             return cls[name.upper()]
         except KeyError:
             raise KeyError(
-                f"Unsupported {cls.__name__} member! got: '{name}'. expected one of: {cls.keys()}"
+                f"Unsupported {cls.__name__} member! got: '{name}'. expected one of: {", ".join(cls.keys())}"
             )
 
     @classmethod

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -16,7 +16,7 @@ class EnumMapping(StrEnum):
             return cls[name.upper()]
         except KeyError:
             raise KeyError(
-                f"Unsupported {cls.__name__} member! got: '{name}'. expected one of: {", ".join(cls.keys())}"
+                f"Unsupported {cls.__name__} member! got: '{name}'. expected one of: {', '.join(cls.keys())}"
             )
 
     @classmethod

--- a/docs/source/chemeleon_foundation_finetuning.nblink
+++ b/docs/source/chemeleon_foundation_finetuning.nblink
@@ -1,0 +1,3 @@
+{
+"path": "../../examples/chemeleon_foundation_finetuning.ipynb"
+}

--- a/docs/source/notebooks.rst
+++ b/docs/source/notebooks.rst
@@ -22,6 +22,7 @@ Chemprop's usage within Python scripts is also illustrated by the Jupyter notebo
     mpnn_fingerprints
     active_learning
     transfer_learning
+    chemeleon_foundation_finetuning
     uncertainty
     interpreting_monte_carlo_tree_search
     shapley_value_with_customized_featurizers

--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -216,6 +216,19 @@ When training the new model, its architecture **must** resemble that of the old 
 
 It is also possible to freeze the weights of a loaded Chemprop model during training, such as for transfer learning applications. To do so, you first need to load a pre-trained model by specifying its checkpoint file using :code:`--checkpoint <path>`. After loading the model, the MPNN weights can be frozen via :code:`--freeze-encoder`. You can control how the weights are frozen in the FFN layers by using :code:`--frzn-ffn-layers <n>` flag, where the :code:`n` is the first n layers are frozen in the FFN layers. By default, :code:`n` is set to 0, meaning all FFN layers are trainable unless specified otherwise.
 
+Finetuning Foundation Models
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+During finetuning one can pretrain a model on an unrelated task and then re-use the learned representation in a new task to improve predictions. This has the effect of improving predictions, particularly on small datasets, by circumventing the need to the model to re-learn the basic facets of molecules representation. 
+
+Unlike Transfer Learning, this does **not** require that the downstream task's FFN has the same architecture as the pretrained model. When finetuning, the Message Passing (depth, hidden size, activation function, etc.) and Aggregation configurations are fixed to be whatever they were during pretraining, but the FNN is initialized from scratch according to the users request and then trained.
+
+Users can access pretrained foundation models by using the :code:`--from-foundation <name>` command line argument. Currently, the following foundation models are available in ChemProp:
+
+ * :code:`CheMeleon` Mordred-descriptor based foundation model pretrained on 1MM molecules from PubChem, suitable for many tasks and especially small datasets. See the `CheMeleon GitHub repository <https://github.com/JacksonBurns/chemeleon>`_ for more information.
+
+The first time a given model is requested it will automatically be downloaded for you.
+
 .. _train-on-reactions:
 
 Training on Reactions

--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -226,8 +226,9 @@ Unlike Transfer Learning, this does **not** require that the downstream task's F
 Users can access pretrained foundation models by using the :code:`--from-foundation <name>` command line argument. Currently, the following foundation models are available in ChemProp:
 
  * :code:`CheMeleon` Mordred-descriptor based foundation model pretrained on 1MM molecules from PubChem, suitable for many tasks and especially small datasets. See the `CheMeleon GitHub repository <https://github.com/JacksonBurns/chemeleon>`_ for more information.
+ * :code:`<your-model>.pt` specify a filepath for a ChemProp model trained via the CLI and the Message Passing will be re-used with a new FFN
 
-The first time a given model is requested it will automatically be downloaded for you and saved to a directory called `.chemprop` in your home directory.
+The first time a given model is requested it will automatically be downloaded for you and saved to a directory called `.chemprop` in your home directory (except for your own models).
 
 .. _train-on-reactions:
 

--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -227,7 +227,7 @@ Users can access pretrained foundation models by using the :code:`--from-foundat
 
  * :code:`CheMeleon` Mordred-descriptor based foundation model pretrained on 1MM molecules from PubChem, suitable for many tasks and especially small datasets. See the `CheMeleon GitHub repository <https://github.com/JacksonBurns/chemeleon>`_ for more information.
 
-The first time a given model is requested it will automatically be downloaded for you.
+The first time a given model is requested it will automatically be downloaded for you and saved to a directory called `.chemprop` in your home directory.
 
 .. _train-on-reactions:
 

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -252,7 +252,7 @@
                 "## Training\n",
                 "\n",
                 "The remainder of this notebook again follows the typical training routine.\n",
-                "With the addition of `CheMeleon` your model may take longer to train but will (hopefully!) have better performance, particularly if the dataset you have is small!"
+                "With the addition of `CheMeleon` your model may take longer to complete a single epoch due to the increased number of parameters but will (hopefully!) have better performance, particularly if the dataset you have is small, and require fewer epochs to converge!"
             ]
         },
         {

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -100,7 +100,10 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "If you have an existing ChemProp model, you can simply replace your `agg`, `featurizer`, and `mp` with these classes and you can immediately take advantage of `CheMeleon`!"
+                "If you have an existing ChemProp model, you can simply replace your `agg`, `featurizer`, and `mp` with these classes and you can immediately take advantage of `CheMeleon`!\n",
+                "\n",
+                "In general, we suggest continuing to train the `CheMeleon` weights during finetuning.\n",
+                "You may find that in some cases, freezing the weights (`mp.eval()`) may improve performance."
             ]
         },
         {

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -117,7 +117,10 @@
                 "\n",
                 "The one important change is that we must set `input_dim=mp.output_dim` when we initialize our FFN.\n",
                 "This ensure that the dimension of the learned representation from `CheMeleon` matches the input size for the regressor.\n",
-                "Also important to note here is that to make the `CheMeleon` model useful you set up your own FFN to regress the target you care about - in this case lipophilicity."
+                "Also important to note here is that to make the `CheMeleon` model useful you set up your own FFN to regress the target you care about - in this case lipophilicity.\n",
+                "\n",
+                "You can also use `CheMeleon` for classification tasks.\n",
+                "See the [regular classification demo notebook](https://chemprop.readthedocs.io/en/latest/training_classification.html), which can be modified as shown above to load `CheMeleon`."
             ]
         },
         {

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -116,7 +116,7 @@
                 "If you have existing Chemprop training code you can simply replace your `agg`, `featurizer`, and `mp` with these classes and you can immediately take advantage of `CheMeleon`!\n",
                 "\n",
                 "In general, we suggest continuing to train the `CheMeleon` weights during finetuning.\n",
-                "You may find that in some cases, freezing the weights (`mp.eval()`) may improve performance."
+                "You may find that in some cases, freezing the weights (`mp.eval()`, `mp.apply(lambda module: module.requires_grad_(False))`) may improve performance."
             ]
         },
         {

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -129,7 +129,7 @@
                 "It's **mostly** the same as the `training` example provided in the Chemprop repository - for a more detailed breakdown, [see the docs here](https://chemprop.readthedocs.io/en/latest/training.html).\n",
                 "\n",
                 "The one important change is that we must set `input_dim=mp.output_dim` when we initialize our FFN.\n",
-                "This ensure that the dimension of the learned representation from `CheMeleon` matches the input size for the regressor.\n",
+                "This ensures that the dimension of the learned representation from `CheMeleon` matches the input size for the regressor.\n",
                 "Also important to note here is that to make the `CheMeleon` model useful you set up your own FFN to regress the target you care about - in this case lipophilicity.\n",
                 "\n",
                 "You can also use `CheMeleon` for classification tasks.\n",

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -1,0 +1,419 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# `CheMeleon` Foundation Finetuning\n",
+                "\n",
+                "This notebook demonstrates how to use the `CheMeleon` foundation model with ChemProp to achieve accurate prediction on small datasets.\n",
+                "One can also use this functionality from the Command Line Interface by using `--from-foundation chemeleon`."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/chemprop/chemprop/blob/main/examples/chemeleon_foundation_finetuning.ipynb)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Install chemprop from GitHub if running in Google Colab\n",
+                "import os\n",
+                "\n",
+                "if os.getenv(\"COLAB_RELEASE_TAG\"):\n",
+                "    try:\n",
+                "        import chemprop\n",
+                "    except ImportError:\n",
+                "        !git clone https://github.com/chemprop/chemprop.git\n",
+                "        %cd chemprop\n",
+                "        !pip install .\n",
+                "        %cd examples"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Retrieving the `CheMeleon` Model\n",
+                "\n",
+                "The `CheMeleon` model file is stored on Zenodo at [this link](https://zenodo.org/records/15426601).\n",
+                "Please cite the Zenodo if you use this model in published work.\n",
+                "You can manually download for your own use, or simply execute the below cell to programatically download it using Python:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "('chemeleon_mp.pt', <http.client.HTTPMessage at 0x7d20df1891f0>)"
+                        ]
+                    },
+                    "execution_count": 2,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "from urllib.request import urlretrieve\n",
+                "\n",
+                "urlretrieve(\n",
+                "    r\"https://zenodo.org/records/15426601/files/chemeleon_mp.pt\",\n",
+                "    \"chemeleon_mp.pt\",\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Initializing `CheMeleon`\n",
+                "\n",
+                "`CheMeleon` uses the following classes for featurization, message passing, and aggregation:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import torch\n",
+                "\n",
+                "from chemprop import featurizers, nn\n",
+                "\n",
+                "featurizer = featurizers.SimpleMoleculeMolGraphFeaturizer()\n",
+                "agg = nn.MeanAggregation()\n",
+                "mp = torch.load(\"chemeleon_mp.pt\", map_location=\"cpu\", weights_only=False)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "If you have an existing ChemProp model, you can simply replace your `agg`, `featurizer`, and `mp` with these classes and you can immediately take advantage of `CheMeleon`!"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Standard ChemProp Preparation\n",
+                "\n",
+                "The below code handles importing needed modules, setting up the data, and initializing the ChemProp model.\n",
+                "It's **mostly** the same as the `training` example provided in the ChemProp repository - for a more detailed breakdown, check that notebook.\n",
+                "\n",
+                "The one important change is that we must set `input_dim=mp.output_dim` when we initialize our FFN.\n",
+                "This ensure that the dimension of the learned representation from `CheMeleon` matches the input size for the regressor.\n",
+                "Also important to note here is that to make the `CheMeleon` model useful you set up your own FFN to regress the target you care about - in this case lipophilicity."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "The return type of make_split_indices has changed in v2.1 - see help(make_split_indices)\n"
+                    ]
+                }
+            ],
+            "source": [
+                "from pathlib import Path\n",
+                "\n",
+                "from lightning import pytorch as pl\n",
+                "from lightning.pytorch.callbacks import ModelCheckpoint\n",
+                "import pandas as pd\n",
+                "\n",
+                "from chemprop import data, models\n",
+                "\n",
+                "chemprop_dir = Path.cwd().parent\n",
+                "input_path = chemprop_dir / \"tests\" / \"data\" / \"regression\" / \"mol\" / \"mol.csv\" # path to your data .csv file\n",
+                "num_workers = 0 # number of workers for dataloader. 0 means using main process for data loading\n",
+                "smiles_column = 'smiles' # name of the column containing SMILES strings\n",
+                "target_columns = ['lipo'] # list of names of the columns containing targets\n",
+                "df_input = pd.read_csv(input_path)\n",
+                "smis = df_input.loc[:, smiles_column].values\n",
+                "ys = df_input.loc[:, target_columns].values\n",
+                "all_data = [data.MoleculeDatapoint.from_smi(smi, y) for smi, y in zip(smis, ys)]\n",
+                "mols = [d.mol for d in all_data]  # RDkit Mol objects are use for structure based splits\n",
+                "train_indices, val_indices, test_indices = data.make_split_indices(mols, \"random\", (0.8, 0.1, 0.1))  # unpack the tuple into three separate lists\n",
+                "train_data, val_data, test_data = data.split_data_by_indices(\n",
+                "    all_data, train_indices, val_indices, test_indices\n",
+                ")\n",
+                "train_dset = data.MoleculeDataset(train_data[0], featurizer)\n",
+                "scaler = train_dset.normalize_targets()\n",
+                "val_dset = data.MoleculeDataset(val_data[0], featurizer)\n",
+                "val_dset.normalize_targets(scaler)\n",
+                "test_dset = data.MoleculeDataset(test_data[0], featurizer)\n",
+                "train_loader = data.build_dataloader(train_dset, num_workers=num_workers)\n",
+                "val_loader = data.build_dataloader(val_dset, num_workers=num_workers, shuffle=False)\n",
+                "test_loader = data.build_dataloader(test_dset, num_workers=num_workers, shuffle=False)\n",
+                "output_transform = nn.UnscaleTransform.from_standard_scaler(scaler)\n",
+                "ffn = nn.RegressionFFN(output_transform=output_transform, input_dim=mp.output_dim)\n",
+                "metric_list = [nn.metrics.RMSE(), nn.metrics.MAE()]\n",
+                "mpnn = models.MPNN(mp, agg, ffn, batch_norm=False, metrics=metric_list)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Now we can take a look at the model, which we can see has the huge message passing setup from `CheMeleon`:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "MPNN(\n",
+                            "  (message_passing): BondMessagePassing(\n",
+                            "    (W_i): Linear(in_features=86, out_features=2048, bias=False)\n",
+                            "    (W_h): Linear(in_features=2048, out_features=2048, bias=False)\n",
+                            "    (W_o): Linear(in_features=2120, out_features=2048, bias=True)\n",
+                            "    (dropout): Dropout(p=0.0, inplace=False)\n",
+                            "    (tau): ReLU()\n",
+                            "    (V_d_transform): Identity()\n",
+                            "    (graph_transform): Identity()\n",
+                            "  )\n",
+                            "  (agg): MeanAggregation()\n",
+                            "  (bn): Identity()\n",
+                            "  (predictor): RegressionFFN(\n",
+                            "    (ffn): MLP(\n",
+                            "      (0): Sequential(\n",
+                            "        (0): Linear(in_features=2048, out_features=300, bias=True)\n",
+                            "      )\n",
+                            "      (1): Sequential(\n",
+                            "        (0): ReLU()\n",
+                            "        (1): Dropout(p=0.0, inplace=False)\n",
+                            "        (2): Linear(in_features=300, out_features=1, bias=True)\n",
+                            "      )\n",
+                            "    )\n",
+                            "    (criterion): MSE(task_weights=[[1.0]])\n",
+                            "    (output_transform): UnscaleTransform()\n",
+                            "  )\n",
+                            "  (X_d_transform): Identity()\n",
+                            "  (metrics): ModuleList(\n",
+                            "    (0): RMSE(task_weights=[[1.0]])\n",
+                            "    (1): MAE(task_weights=[[1.0]])\n",
+                            "    (2): MSE(task_weights=[[1.0]])\n",
+                            "  )\n",
+                            ")"
+                        ]
+                    },
+                    "execution_count": 5,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "mpnn"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Training\n",
+                "\n",
+                "The remainder of this notebook again follows the typical training routine.\n",
+                "With the addition of `CheMeleon` your model may take longer to train but will (hopefully!) have better performance, particularly if the dataset you have is small!"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "GPU available: True (cuda), used: True\n",
+                        "TPU available: False, using: 0 TPU cores\n",
+                        "HPU available: False, using: 0 HPUs\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Configure model checkpointing\n",
+                "checkpointing = ModelCheckpoint(\n",
+                "    \"checkpoints\",  # Directory where model checkpoints will be saved\n",
+                "    \"best-{epoch}-{val_loss:.2f}\",  # Filename format for checkpoints, including epoch and validation loss\n",
+                "    \"val_loss\",  # Metric used to select the best checkpoint (based on validation loss)\n",
+                "    mode=\"min\",  # Save the checkpoint with the lowest validation loss (minimization objective)\n",
+                "    save_last=True,  # Always save the most recent checkpoint, even if it's not the best\n",
+                ")\n",
+                "trainer = pl.Trainer(\n",
+                "    logger=False,\n",
+                "    enable_checkpointing=True, # Use `True` if you want to save model checkpoints. The checkpoints will be saved in the `checkpoints` folder.\n",
+                "    enable_progress_bar=True,\n",
+                "    accelerator=\"auto\",\n",
+                "    devices=1,\n",
+                "    max_epochs=20, # number of epochs to train for\n",
+                "    callbacks=[checkpointing], # Use the configured checkpoint callback\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "/home/jackson/miniconda3/envs/chemprop_dev/lib/python3.12/site-packages/lightning/pytorch/callbacks/model_checkpoint.py:654: Checkpoint directory /home/jackson/chemprop/examples/checkpoints exists and is not empty.\n",
+                        "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+                        "Loading `train_dataloader` to estimate number of stepping batches.\n",
+                        "/home/jackson/miniconda3/envs/chemprop_dev/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:425: The 'train_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=15` in the `DataLoader` to improve performance.\n",
+                        "\n",
+                        "  | Name            | Type               | Params | Mode \n",
+                        "---------------------------------------------------------------\n",
+                        "0 | message_passing | BondMessagePassing | 8.7 M  | train\n",
+                        "1 | agg             | MeanAggregation    | 0      | train\n",
+                        "2 | bn              | Identity           | 0      | train\n",
+                        "3 | predictor       | RegressionFFN      | 615 K  | train\n",
+                        "4 | X_d_transform   | Identity           | 0      | train\n",
+                        "5 | metrics         | ModuleList         | 0      | train\n",
+                        "---------------------------------------------------------------\n",
+                        "9.3 M     Trainable params\n",
+                        "0         Non-trainable params\n",
+                        "9.3 M     Total params\n",
+                        "37.317    Total estimated model params size (MB)\n",
+                        "25        Modules in train mode\n",
+                        "0         Modules in eval mode\n"
+                    ]
+                },
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Sanity Checking DataLoader 0:   0%|          | 0/1 [00:00<?, ?it/s]"
+                    ]
+                },
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "/home/jackson/miniconda3/envs/chemprop_dev/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:425: The 'val_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=15` in the `DataLoader` to improve performance.\n"
+                    ]
+                },
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00,  9.25it/s, train_loss_step=0.029, val_loss=0.546, train_loss_epoch=0.0155] "
+                    ]
+                },
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "`Trainer.fit` stopped: `max_epochs=20` reached.\n"
+                    ]
+                },
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00,  5.06it/s, train_loss_step=0.029, val_loss=0.546, train_loss_epoch=0.0155]\n"
+                    ]
+                }
+            ],
+            "source": [
+                "trainer.fit(mpnn, train_loader, val_loader)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "/home/jackson/miniconda3/envs/chemprop_dev/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/checkpoint_connector.py:145: `.test(ckpt_path=None)` was called without a model. The best model of the previous `fit` call will be used. You can pass `.test(ckpt_path='best')` to use the best model or `.test(ckpt_path='last')` to use the last model. If you pass a value, this warning will be silenced.\n",
+                        "Restoring states from the checkpoint path at /home/jackson/chemprop/examples/checkpoints/best-epoch=10-val_loss=0.50.ckpt\n",
+                        "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+                        "Loaded model weights from the checkpoint at /home/jackson/chemprop/examples/checkpoints/best-epoch=10-val_loss=0.50.ckpt\n",
+                        "/home/jackson/miniconda3/envs/chemprop_dev/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:425: The 'test_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=15` in the `DataLoader` to improve performance.\n"
+                    ]
+                },
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Testing DataLoader 0: 100%|██████████| 1/1 [00:00<00:00, 97.02it/s] \n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/html": [
+                            "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+                            "┃<span style=\"font-weight: bold\">        Test metric        </span>┃<span style=\"font-weight: bold\">       DataLoader 0        </span>┃\n",
+                            "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+                            "│<span style=\"color: #008080; text-decoration-color: #008080\">         test/mae          </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.6407745480537415     </span>│\n",
+                            "│<span style=\"color: #008080; text-decoration-color: #008080\">         test/rmse         </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.7919761538505554     </span>│\n",
+                            "└───────────────────────────┴───────────────────────────┘\n",
+                            "</pre>\n"
+                        ],
+                        "text/plain": [
+                            "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+                            "┃\u001b[1m \u001b[0m\u001b[1m       Test metric       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      DataLoader 0       \u001b[0m\u001b[1m \u001b[0m┃\n",
+                            "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+                            "│\u001b[36m \u001b[0m\u001b[36m        test/mae         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.6407745480537415    \u001b[0m\u001b[35m \u001b[0m│\n",
+                            "│\u001b[36m \u001b[0m\u001b[36m        test/rmse        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.7919761538505554    \u001b[0m\u001b[35m \u001b[0m│\n",
+                            "└───────────────────────────┴───────────────────────────┘\n"
+                        ]
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                }
+            ],
+            "source": [
+                "results = trainer.test(dataloaders=test_loader)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "chemprop_dev",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.12.9"
+        },
+        "orig_nbformat": 4
+    },
+    "nbformat": 4,
+    "nbformat_minor": 2
+}

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -113,7 +113,7 @@
                 "## Standard ChemProp Preparation\n",
                 "\n",
                 "The below code handles importing needed modules, setting up the data, and initializing the ChemProp model.\n",
-                "It's **mostly** the same as the `training` example provided in the ChemProp repository - for a more detailed breakdown, check that notebook.\n",
+                "It's **mostly** the same as the `training` example provided in the ChemProp repository - for a more detailed breakdown, [see the docs here](https://chemprop.readthedocs.io/en/latest/training.html).\n",
                 "\n",
                 "The one important change is that we must set `input_dim=mp.output_dim` when we initialize our FFN.\n",
                 "This ensure that the dimension of the learned representation from `CheMeleon` matches the input size for the regressor.\n",

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -55,7 +55,7 @@
                 {
                     "data": {
                         "text/plain": [
-                            "('chemeleon_mp.pt', <http.client.HTTPMessage at 0x7d20df1891f0>)"
+                            "('chemeleon_mp.pt', <http.client.HTTPMessage at 0x751223631d60>)"
                         ]
                     },
                     "execution_count": 2,
@@ -67,7 +67,7 @@
                 "from urllib.request import urlretrieve\n",
                 "\n",
                 "urlretrieve(\n",
-                "    r\"https://zenodo.org/records/15426601/files/chemeleon_mp.pt\",\n",
+                "    r\"https://zenodo.org/records/15460715/files/chemeleon_mp.pt\",\n",
                 "    \"chemeleon_mp.pt\",\n",
                 ")"
             ]
@@ -85,7 +85,18 @@
             "cell_type": "code",
             "execution_count": 3,
             "metadata": {},
-            "outputs": [],
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "<All keys matched successfully>"
+                        ]
+                    },
+                    "execution_count": 3,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
             "source": [
                 "import torch\n",
                 "\n",
@@ -93,7 +104,9 @@
                 "\n",
                 "featurizer = featurizers.SimpleMoleculeMolGraphFeaturizer()\n",
                 "agg = nn.MeanAggregation()\n",
-                "mp = torch.load(\"chemeleon_mp.pt\", map_location=\"cpu\", weights_only=False)"
+                "chemeleon_mp = torch.load(\"chemeleon_mp.pt\", weights_only=True)\n",
+                "mp = nn.BondMessagePassing(**chemeleon_mp['hyper_parameters'])\n",
+                "mp.load_state_dict(chemeleon_mp['state_dict'])"
             ]
         },
         {
@@ -326,7 +339,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00,  9.25it/s, train_loss_step=0.029, val_loss=0.546, train_loss_epoch=0.0155] "
+                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00,  9.11it/s, train_loss_step=0.0298, val_loss=0.548, train_loss_epoch=0.0245]"
                     ]
                 },
                 {
@@ -340,7 +353,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00,  5.06it/s, train_loss_step=0.029, val_loss=0.546, train_loss_epoch=0.0155]\n"
+                        "Epoch 19: 100%|██████████| 2/2 [00:00<00:00,  4.84it/s, train_loss_step=0.0298, val_loss=0.548, train_loss_epoch=0.0245]\n"
                     ]
                 }
             ],
@@ -358,9 +371,9 @@
                     "output_type": "stream",
                     "text": [
                         "/home/jackson/miniconda3/envs/chemprop_dev/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/checkpoint_connector.py:145: `.test(ckpt_path=None)` was called without a model. The best model of the previous `fit` call will be used. You can pass `.test(ckpt_path='best')` to use the best model or `.test(ckpt_path='last')` to use the last model. If you pass a value, this warning will be silenced.\n",
-                        "Restoring states from the checkpoint path at /home/jackson/chemprop/examples/checkpoints/best-epoch=10-val_loss=0.50.ckpt\n",
+                        "Restoring states from the checkpoint path at /home/jackson/chemprop/examples/checkpoints/best-epoch=16-val_loss=0.49.ckpt\n",
                         "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-                        "Loaded model weights from the checkpoint at /home/jackson/chemprop/examples/checkpoints/best-epoch=10-val_loss=0.50.ckpt\n",
+                        "Loaded model weights from the checkpoint at /home/jackson/chemprop/examples/checkpoints/best-epoch=16-val_loss=0.49.ckpt\n",
                         "/home/jackson/miniconda3/envs/chemprop_dev/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:425: The 'test_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=15` in the `DataLoader` to improve performance.\n"
                     ]
                 },
@@ -368,7 +381,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Testing DataLoader 0: 100%|██████████| 1/1 [00:00<00:00, 97.02it/s] \n"
+                        "Testing DataLoader 0: 100%|██████████| 1/1 [00:00<00:00, 87.82it/s] \n"
                     ]
                 },
                 {
@@ -377,8 +390,8 @@
                             "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
                             "┃<span style=\"font-weight: bold\">        Test metric        </span>┃<span style=\"font-weight: bold\">       DataLoader 0        </span>┃\n",
                             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
-                            "│<span style=\"color: #008080; text-decoration-color: #008080\">         test/mae          </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.6407745480537415     </span>│\n",
-                            "│<span style=\"color: #008080; text-decoration-color: #008080\">         test/rmse         </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.7919761538505554     </span>│\n",
+                            "│<span style=\"color: #008080; text-decoration-color: #008080\">         test/mae          </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.5628008842468262     </span>│\n",
+                            "│<span style=\"color: #008080; text-decoration-color: #008080\">         test/rmse         </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.6701957583427429     </span>│\n",
                             "└───────────────────────────┴───────────────────────────┘\n",
                             "</pre>\n"
                         ],
@@ -386,8 +399,8 @@
                             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
                             "┃\u001b[1m \u001b[0m\u001b[1m       Test metric       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      DataLoader 0       \u001b[0m\u001b[1m \u001b[0m┃\n",
                             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
-                            "│\u001b[36m \u001b[0m\u001b[36m        test/mae         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.6407745480537415    \u001b[0m\u001b[35m \u001b[0m│\n",
-                            "│\u001b[36m \u001b[0m\u001b[36m        test/rmse        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.7919761538505554    \u001b[0m\u001b[35m \u001b[0m│\n",
+                            "│\u001b[36m \u001b[0m\u001b[36m        test/mae         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.5628008842468262    \u001b[0m\u001b[35m \u001b[0m│\n",
+                            "│\u001b[36m \u001b[0m\u001b[36m        test/rmse        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.6701957583427429    \u001b[0m\u001b[35m \u001b[0m│\n",
                             "└───────────────────────────┴───────────────────────────┘\n"
                         ]
                     },

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -6,7 +6,7 @@
             "source": [
                 "# `CheMeleon` Foundation Finetuning\n",
                 "\n",
-                "This notebook demonstrates how to use the `CheMeleon` foundation model with ChemProp to achieve accurate prediction on small datasets.\n",
+                "This notebook demonstrates how to use the `CheMeleon` foundation model with Chemprop to achieve accurate prediction on small datasets.\n",
                 "One can also use this functionality from the Command Line Interface by using `--from-foundation chemeleon`."
             ]
         },
@@ -100,7 +100,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "If you have an existing ChemProp model, you can simply replace your `agg`, `featurizer`, and `mp` with these classes and you can immediately take advantage of `CheMeleon`!\n",
+                "If you have existing Chemprop training code you can simply replace your `agg`, `featurizer`, and `mp` with these classes and you can immediately take advantage of `CheMeleon`!\n",
                 "\n",
                 "In general, we suggest continuing to train the `CheMeleon` weights during finetuning.\n",
                 "You may find that in some cases, freezing the weights (`mp.eval()`) may improve performance."
@@ -110,10 +110,10 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "## Standard ChemProp Preparation\n",
+                "## Standard Chemprop Preparation\n",
                 "\n",
-                "The below code handles importing needed modules, setting up the data, and initializing the ChemProp model.\n",
-                "It's **mostly** the same as the `training` example provided in the ChemProp repository - for a more detailed breakdown, [see the docs here](https://chemprop.readthedocs.io/en/latest/training.html).\n",
+                "The below code handles importing needed modules, setting up the data, and initializing the Chemprop model.\n",
+                "It's **mostly** the same as the `training` example provided in the Chemprop repository - for a more detailed breakdown, [see the docs here](https://chemprop.readthedocs.io/en/latest/training.html).\n",
                 "\n",
                 "The one important change is that we must set `input_dim=mp.output_dim` when we initialize our FFN.\n",
                 "This ensure that the dimension of the learned representation from `CheMeleon` matches the input size for the regressor.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,12 @@ recursive = true
 aggressive = 2
 max_line_length = 100
 
-
 [tool.pytest.ini_options]
 addopts = "--cov chemprop"
+markers = [
+    "integration",
+    "CLI",
+]
 
 [tool.isort]
 profile = "black"

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -8,7 +8,7 @@ import torch
 
 from chemprop.cli.hpopt import NO_HYPEROPT, NO_OPTUNA, NO_RAY
 from chemprop.cli.main import main
-from chemprop.cli.train import TrainSubcommand
+from chemprop.cli.train import FoundationModels, TrainSubcommand
 from chemprop.models.model import MPNN
 
 pytestmark = pytest.mark.CLI
@@ -68,6 +68,29 @@ def test_train_quick(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+
+def test_train_quick_from_foundation(monkeypatch, data_path):
+    input_path, *_ = data_path
+
+    for foundation in FoundationModels.keys():
+        args = [
+            "chemprop",
+            "train",
+            "-i",
+            input_path,
+            "--epochs",
+            "3",
+            "--num-workers",
+            "0",
+            "--show-individual-scores",
+            "--from-foundation",
+            foundation,
+        ]
+
+        with monkeypatch.context() as m:
+            m.setattr("sys.argv", args)
+            main()
 
 
 def test_train_config(monkeypatch, config_path, tmp_path):

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -93,6 +93,28 @@ def test_train_quick_from_foundation(monkeypatch, data_path):
             main()
 
 
+def test_train_quick_from_local_foundation(monkeypatch, data_path, model_path):
+    input_path, *_ = data_path
+
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--epochs",
+        "3",
+        "--num-workers",
+        "0",
+        "--show-individual-scores",
+        "--from-foundation",
+        model_path,
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
 def test_train_config(monkeypatch, config_path, tmp_path):
     args = [
         "chemprop",


### PR DESCRIPTION
## Description

This pull request implements support for finetuning foundation models in `ChemProp` via the Command Line Interface (CLI), which was not previously possible.

A demo notebook for the same, but via the Python module interface, is also added.

Finally, support for the [`CheMeleon`](https://github.com/JacksonBurns/chemeleon) model by myself and @akshatzalte is also added.

## Example / Current workflow

Right now, ChemProp supports transfer learning in which a model is trained and then fine-tuned on the _same_ task. This does **not** allow the user to change the architecture during finetuning.

It is desirable to re-use only the learned representation and to create a new FFN that applies to some entirely new task. This is currently not possible via the CLI for ChemProp. It is possible via Python Modules, but we don't have a demo for it.

## Bugfix / Desired workflow

This PR exposes finetuning using a pretrained learned representation through a new CLI flag `--from-foundation`. Passing the name of a foundation model with this flag will automatically download it from Zenodo and then initialize the Message Passing, featurizer, and Aggregation according to that model. Documentation for this new feature has also been added.

The demo notebook shows how to do this as well, basically just a formalization of what was already possible via the Python module interface. This demo notebook has also been added to the documentation.

This PR also serves as a demo for how to add other foundation models in the future. Any foundation models added in the future should follow the below process (click the link to see the representative commit):
 1. 52b5f3b0c1a2b6515482de09daa8f1a226f1d731 add the model to the enumeration, then add specific logic to validate arguments, then implement the downloading and initialization of the pretrained model following the example of `CheMeleon`
 2. 245cd6487e2a581a3e3354829e34f37b82dfd94d add (or update an existing) demo notebook for the new model
 3. 24e906f5803ccc186fefb689a8ad6d7938aaebbb add the model the list of available models in the CLI

Any newly added foundation model will be automatically tested by `pytest`.

## Questions

We can change the name of the flag, if desired.

## Relevant issues

This was an MLPDS feature request from @am2145 as well, though I never opened an issue to track it (oops).

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
