### PR TITLE
Ensure `device="cpu"` when loading Scalers

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -721,12 +721,12 @@ def normalize_inputs(train_dset, val_dset, args):
 
 def load_and_use_pretrained_model_scalers(model_path: Path, train_dset, val_dset) -> None:
     if isinstance(train_dset, MulticomponentDataset):
-        _model = MulticomponentMPNN.load_from_file(model_path)
+        _model = MulticomponentMPNN.load_from_file(model_path, map_location="cpu")
         blocks = _model.message_passing.blocks
         train_dsets = train_dset.datasets
         val_dsets = val_dset.datasets
     else:
-        _model = MPNN.load_from_file(model_path)
+        _model = MPNN.load_from_file(model_path, map_location="cpu")
         blocks = [_model.message_passing]
         train_dsets = [train_dset]
         val_dsets = [val_dset]


### PR DESCRIPTION
resolves https://github.com/chemprop/chemprop/issues/1221 by ensuring that, when attempting to load pretrained scalers from models, we place the models on the CPU s.t. the scalers that we are rebuilding can interact with them (the new scalers are also on the CPU)
