### PR TITLE
Allow multiprocess loading.

### DIFF
--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentError, ArgumentParser, Namespace
 import logging
 from pathlib import Path
+import sys
 
 from chemprop.cli.utils import LookupAction
 from chemprop.cli.utils.args import uppercase
@@ -264,6 +265,11 @@ def validate_common_args(args):
             logger.warning(
                 "Molecule featurizers reduce the memory savings of `--use-cuikmolmaker-featurization`. Consider pre-computing the features manually and providing them via `--descriptors-path`"
             )
+
+    if args.num_workers > 0 and (sys.platform == "win32" or sys.platform == "darwin"):
+        logger.warning(
+            "Multiprocessing can hang on Windows and MacOS. Consider using `--num-workers 0` to avoid this issue."
+        )
 
 
 def find_models(model_paths: list[Path]):

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -152,6 +152,7 @@ def make_fingerprint_for_model(
             args.rxn_mode,
             args.multi_hot_atom_featurizer_mode,
             args.use_cuikmolmaker_featurization,
+            n_workers=args.num_workers,
         )
         for d in test_data
     ]

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -241,6 +241,7 @@ def prepare_data_loader(
             }
             if args.constraints_to_targets is not None
             else None,
+            n_workers=args.num_workers,
             **featurization_kwargs,
         )
     else:

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -224,6 +224,7 @@ def prepare_data_loader(
         ignore_stereo=args.ignore_stereo,
         reorder_atoms=args.reorder_atoms,
     )
+
     if mol_atom_bond:
         datas = build_MAB_data_from_files(
             data_path,
@@ -252,6 +253,7 @@ def prepare_data_loader(
             p_atom_feats=atom_feats_path,
             p_bond_feats=bond_feats_path,
             p_atom_descs=atom_descs_path,
+            n_workers=args.num_workers,
             **featurization_kwargs,
         )
 
@@ -261,6 +263,7 @@ def prepare_data_loader(
             args.rxn_mode,
             args.multi_hot_atom_featurizer_mode,
             args.use_cuikmolmaker_featurization,
+            n_workers=args.num_workers,
         )
         for d in datas
     ]

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -933,6 +933,7 @@ def save_smiles_splits(args: Namespace, output_dir, train_dset, val_dset, test_d
 def build_splits(args, format_kwargs, featurization_kwargs):
     """build the train/val/test splits"""
     logger.info(f"Pulling data from file: {args.data_path}")
+
     if any(
         cols is not None
         for cols in [args.mol_target_columns, args.atom_target_columns, args.bond_target_columns]
@@ -968,6 +969,7 @@ def build_splits(args, format_kwargs, featurization_kwargs):
             p_atom_feats=args.atom_features_path,
             p_bond_feats=args.bond_features_path,
             p_atom_descs=args.atom_descriptors_path,
+            n_workers=args.num_workers,
             **format_kwargs,
             **featurization_kwargs,
         )
@@ -1109,6 +1111,7 @@ def build_datasets(args, train_data, val_data, test_data):
                 args.rxn_mode,
                 args.multi_hot_atom_featurizer_mode,
                 args.use_cuikmolmaker_featurization,
+                n_workers=args.num_workers,
             )
             for data in train_data
         ]
@@ -1118,6 +1121,7 @@ def build_datasets(args, train_data, val_data, test_data):
                 args.rxn_mode,
                 args.multi_hot_atom_featurizer_mode,
                 args.use_cuikmolmaker_featurization,
+                n_workers=args.num_workers,
             )
             for data in val_data
         ]
@@ -1130,6 +1134,7 @@ def build_datasets(args, train_data, val_data, test_data):
                     args.rxn_mode,
                     args.multi_hot_atom_featurizer_mode,
                     args.use_cuikmolmaker_featurization,
+                    n_workers=args.num_workers,
                 )
                 for data in test_data
             ]
@@ -1145,12 +1150,14 @@ def build_datasets(args, train_data, val_data, test_data):
             args.rxn_mode,
             args.multi_hot_atom_featurizer_mode,
             args.use_cuikmolmaker_featurization,
+            n_workers=args.num_workers,
         )
         val_dset = make_dataset(
             val_data,
             args.rxn_mode,
             args.multi_hot_atom_featurizer_mode,
             args.use_cuikmolmaker_featurization,
+            n_workers=args.num_workers,
         )
         if len(test_data) > 0:
             test_dset = make_dataset(
@@ -1158,6 +1165,7 @@ def build_datasets(args, train_data, val_data, test_data):
                 args.rxn_mode,
                 args.multi_hot_atom_featurizer_mode,
                 args.use_cuikmolmaker_featurization,
+                n_workers=args.num_workers,
             )
         else:
             test_dset = None

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -959,6 +959,7 @@ def build_splits(args, format_kwargs, featurization_kwargs):
             }
             if args.constraints_to_targets is not None
             else None,
+            n_workers=args.num_workers,
             **featurization_kwargs,
         )
     else:

--- a/chemprop/cli/utils/MAB_parsing.py
+++ b/chemprop/cli/utils/MAB_parsing.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from chemprop.data import MolAtomBondDatapoint
 from chemprop.featurizers.molecule import MoleculeFeaturizerRegistry
-from chemprop.utils import make_mol
+from chemprop.utils import make_mol, parallel_execute
 
 
 def build_MAB_data_from_files(
@@ -27,6 +27,7 @@ def build_MAB_data_from_files(
     constraints_cols_to_target_cols: dict[str, int] | None,
     molecule_featurizers: Sequence[str] | None,
     descriptor_cols: Sequence[str] | None = None,
+    n_workers: int = 1,
     **make_mol_kwargs,
 ):
     df = pd.read_csv(p_data, index_col=False)
@@ -34,7 +35,9 @@ def build_MAB_data_from_files(
     X_d_extra = df[descriptor_cols] if descriptor_cols else None
 
     smis = df[smiles_cols[0]].values if smiles_cols is not None else df.iloc[:, 0].values
-    mols = [make_mol(smi, **make_mol_kwargs) for smi in smis]
+    mols = parallel_execute(
+        make_mol, [(smi,) + tuple(make_mol_kwargs.values()) for smi in smis], n_workers=n_workers
+    )
     n_datapoints = len(mols)
 
     weights = (

--- a/chemprop/cli/utils/MAB_parsing.py
+++ b/chemprop/cli/utils/MAB_parsing.py
@@ -83,7 +83,7 @@ def build_MAB_data_from_files(
                 np.vstack(
                     parallel_execute(
                         create_and_call_object,
-                        [(mf.__class__, mol) for mol in mols],
+                        [(mf.__class__, (mol,)) for mol in mols],
                         n_workers=n_workers,
                     )
                 )

--- a/chemprop/cli/utils/MAB_parsing.py
+++ b/chemprop/cli/utils/MAB_parsing.py
@@ -27,7 +27,7 @@ def build_MAB_data_from_files(
     constraints_cols_to_target_cols: dict[str, int] | None,
     molecule_featurizers: Sequence[str] | None,
     descriptor_cols: Sequence[str] | None = None,
-    n_workers: int = 1,
+    n_workers: int = 0,
     **make_mol_kwargs,
 ):
     df = pd.read_csv(p_data, index_col=False)

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -27,7 +27,7 @@ from chemprop.featurizers.molgraph import (
     RxnMode,
     SimpleMoleculeMolGraphFeaturizer,
 )
-from chemprop.utils import created_and_call_object, make_mol, parallel_execute
+from chemprop.utils import create_and_call_object, make_mol, parallel_execute
 
 logger = logging.getLogger(__name__)
 
@@ -338,7 +338,7 @@ def make_datapoints(
                         [
                             np.vstack(
                                 parallel_execute(
-                                    created_and_call_object,
+                                    create_and_call_object,
                                     [(mf.__class__, mol) for mol in mols],
                                     n_workers=n_workers,
                                 )
@@ -359,7 +359,7 @@ def make_datapoints(
             def construct_row(rct, pdt, molecule_featurizers):
                 return np.hstack(
                     [
-                        created_and_call_object(mf.__class__, mol)
+                        create_and_call_object(mf.__class__, mol)
                         for mf in molecule_featurizers
                         for mol in (rct, pdt)
                     ]

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -339,7 +339,7 @@ def make_datapoints(
                             np.vstack(
                                 parallel_execute(
                                     create_and_call_object,
-                                    [(mf.__class__, mol) for mol in mols],
+                                    [(mf.__class__, (mol,)) for mol in mols],
                                     n_workers=n_workers,
                                 )
                             )
@@ -359,7 +359,7 @@ def make_datapoints(
             def construct_row(rct, pdt, molecule_featurizers):
                 return np.hstack(
                     [
-                        create_and_call_object(mf.__class__, mol)
+                        create_and_call_object(mf.__class__, (mol,))
                         for mf in molecule_featurizers
                         for mol in (rct, pdt)
                     ]
@@ -533,7 +533,6 @@ def make_dataset(
     cuikmolmaker_featurization: bool = False,
     n_workers: int = 1,
 ) -> MoleculeDataset | CuikmolmakerDataset | MolAtomBondDataset | ReactionDataset:
-
     atom_featurizer = get_multi_hot_atom_featurizer(multi_hot_atom_featurizer_mode)
     match multi_hot_atom_featurizer_mode:
         case "RIGR":

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -534,7 +534,7 @@ def make_dataset(
             extra_atom_fdim=extra_atom_fdim,
             extra_bond_fdim=extra_bond_fdim,
         )
-        return MolAtomBondDataset(data, featurizer)
+        return MolAtomBondDataset(data, featurizer, n_workers=n_workers)
 
     if isinstance(data[0], (MoleculeDatapoint, LazyMoleculeDatapoint)):
         extra_atom_fdim = data[0].V_f.shape[1] if data[0].V_f is not None else 0

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -142,7 +142,7 @@ def make_datapoints(
     ignore_stereo: bool,
     reorder_atoms: bool,
     use_cuikmolmaker_featurization: bool,
-    n_workers: int = 1,
+    n_workers: int = 0,
 ) -> tuple[
     list[list[MoleculeDatapoint]] | list[list[LazyMoleculeDatapoint]], list[list[ReactionDatapoint]]
 ]:
@@ -438,7 +438,7 @@ def build_data_from_files(
     p_bond_feats: dict[int, PathLike],
     p_atom_descs: dict[int, PathLike],
     descriptor_cols: Sequence[str] | None = None,
-    n_workers: int = 1,
+    n_workers: int = 0,
     **featurization_kwargs: Mapping,
 ) -> list[list[MoleculeDatapoint] | list[ReactionDatapoint]]:
     smiss, rxnss, Y, weights, lt_mask, gt_mask, X_d_extra = parse_csv(
@@ -531,7 +531,7 @@ def make_dataset(
     reaction_mode: Literal[*tuple(RxnMode.keys())] = "REAC_DIFF",
     multi_hot_atom_featurizer_mode: Literal["V1", "V2", "ORGANIC", "RIGR"] = "V2",
     cuikmolmaker_featurization: bool = False,
-    n_workers: int = 1,
+    n_workers: int = 0,
 ) -> MoleculeDataset | CuikmolmakerDataset | MolAtomBondDataset | ReactionDataset:
     atom_featurizer = get_multi_hot_atom_featurizer(multi_hot_atom_featurizer_mode)
     match multi_hot_atom_featurizer_mode:

--- a/chemprop/data/datasets.py
+++ b/chemprop/data/datasets.py
@@ -202,10 +202,13 @@ class MoleculeDataset(_MolGraphDatasetMixin, MolGraphDataset):
         the data from which to create a dataset
     featurizer : MoleculeFeaturizer
         the featurizer with which to generate MolGraphs of the molecules
+    n_workers : int, optional
+        number of workers to use for cache calculation
     """
 
     data: list[MoleculeDatapoint]
     featurizer: Featurizer[Mol, MolGraph] = field(default_factory=SimpleMoleculeMolGraphFeaturizer)
+    n_workers: int = 1
 
     def __post_init__(self):
         if self.data is None:
@@ -231,9 +234,12 @@ class MoleculeDataset(_MolGraphDatasetMixin, MolGraphDataset):
 
     def _init_cache(self):
         """initialize the cache"""
-        self.mg_cache = (MolGraphCache if self.cache else MolGraphCacheOnTheFly)(
-            self.mols, self.V_fs, self.E_fs, self.featurizer
-        )
+        if self.cache:
+            self.mg_cache = MolGraphCache(
+                self.mols, self.V_fs, self.E_fs, self.featurizer, n_workers=self.n_workers
+            )
+        else:
+            self.mg_cache = MolGraphCacheOnTheFly(self.mols, self.V_fs, self.E_fs, self.featurizer)
 
     @property
     def smiles(self) -> list[str]:
@@ -645,6 +651,8 @@ class ReactionDataset(_MolGraphDatasetMixin, MolGraphDataset):
     """the dataset from which to load"""
     featurizer: Featurizer[Rxn, MolGraph] = field(default_factory=CGRFeaturizer)
     """the featurizer with which to generate MolGraphs of the input"""
+    n_workers: int = 1
+    """number of workers to use for cache calculation"""
 
     def __post_init__(self):
         if self.data is None:
@@ -660,9 +668,18 @@ class ReactionDataset(_MolGraphDatasetMixin, MolGraphDataset):
     @cache.setter
     def cache(self, cache: bool = False):
         self.__cache = cache
-        self.mg_cache = (MolGraphCache if cache else MolGraphCacheOnTheFly)(
-            self.mols, [None] * len(self), [None] * len(self), self.featurizer
-        )
+        if cache:
+            self.mg_cache = MolGraphCache(
+                self.mols,
+                [None] * len(self),
+                [None] * len(self),
+                self.featurizer,
+                n_workers=self.n_workers,
+            )
+        else:
+            self.mg_cache = MolGraphCacheOnTheFly(
+                self.mols, [None] * len(self), [None] * len(self), self.featurizer
+            )
 
     def __getitem__(self, idx: int) -> Datum:
         d = self.data[idx]

--- a/chemprop/data/datasets.py
+++ b/chemprop/data/datasets.py
@@ -208,7 +208,7 @@ class MoleculeDataset(_MolGraphDatasetMixin, MolGraphDataset):
 
     data: list[MoleculeDatapoint]
     featurizer: Featurizer[Mol, MolGraph] = field(default_factory=SimpleMoleculeMolGraphFeaturizer)
-    n_workers: int = 1
+    n_workers: int = 0
 
     def __post_init__(self):
         if self.data is None:
@@ -651,7 +651,7 @@ class ReactionDataset(_MolGraphDatasetMixin, MolGraphDataset):
     """the dataset from which to load"""
     featurizer: Featurizer[Rxn, MolGraph] = field(default_factory=CGRFeaturizer)
     """the featurizer with which to generate MolGraphs of the input"""
-    n_workers: int = 1
+    n_workers: int = 0
     """number of workers to use for cache calculation"""
 
     def __post_init__(self):

--- a/chemprop/featurizers/molecule.py
+++ b/chemprop/featurizers/molecule.py
@@ -1,6 +1,7 @@
 import logging
 
 from descriptastorus.descriptors import rdDescriptors, rdNormalizedDescriptors
+import multiprocess
 import numpy as np
 from rdkit import Chem
 from rdkit.Chem import Descriptors, Mol
@@ -51,11 +52,12 @@ class MorganCountFeaturizer(MorganFeaturizerMixin, CountFeaturizerMixin, VectorF
 @MoleculeFeaturizerRegistry("rdkit_2d")
 class RDKit2DFeaturizer(VectorFeaturizer[Mol]):
     def __init__(self):
-        logger.warning(
-            "The RDKit 2D features can deviate signifcantly from a normal distribution. Consider "
-            "manually scaling them using an appropriate scaler before creating datapoints, rather "
-            "than using the scikit-learn `StandardScaler` (the default in Chemprop)."
-        )
+        if multiprocess.current_process().name == "MainProcess":
+            logger.warning(
+                "The RDKit 2D features can deviate signifcantly from a normal distribution. Consider "
+                "manually scaling them using an appropriate scaler before creating datapoints, rather "
+                "than using the scikit-learn `StandardScaler` (the default in Chemprop)."
+            )
 
     def __len__(self) -> int:
         return len(Descriptors.descList)

--- a/chemprop/featurizers/molgraph/cache.py
+++ b/chemprop/featurizers/molgraph/cache.py
@@ -57,9 +57,7 @@ class MolGraphCache(MolGraphCacheFacade):
         featurizer: Featurizer[S, MolGraph],
         n_workers: int = 1,
     ):
-        self._mgs = parallel_execute(
-            featurizer, [inputs, V_fs, E_fs], n_workers=n_workers, zipped=False
-        )
+        self._mgs = parallel_execute(featurizer, zip(*[inputs, V_fs, E_fs]), n_workers=n_workers)
 
     def __len__(self) -> int:
         return len(self._mgs)

--- a/chemprop/featurizers/molgraph/cache.py
+++ b/chemprop/featurizers/molgraph/cache.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from chemprop.data.molgraph import MolGraph
 from chemprop.featurizers.base import Featurizer, S
+from chemprop.utils import parallel_execute
 
 
 class MolGraphCacheFacade(Sequence[MolGraph], Generic[S]):
@@ -54,8 +55,11 @@ class MolGraphCache(MolGraphCacheFacade):
         V_fs: Iterable[np.ndarray | None],
         E_fs: Iterable[np.ndarray | None],
         featurizer: Featurizer[S, MolGraph],
+        n_workers: int = 1,
     ):
-        self._mgs = [featurizer(input, V_f, E_f) for input, V_f, E_f in zip(inputs, V_fs, E_fs)]
+        self._mgs = parallel_execute(
+            featurizer, [inputs, V_fs, E_fs], n_workers=n_workers, zipped=False
+        )
 
     def __len__(self) -> int:
         return len(self._mgs)

--- a/chemprop/featurizers/molgraph/cache.py
+++ b/chemprop/featurizers/molgraph/cache.py
@@ -57,7 +57,7 @@ class MolGraphCache(MolGraphCacheFacade):
         featurizer: Featurizer[S, MolGraph],
         n_workers: int = 1,
     ):
-        self._mgs = parallel_execute(featurizer, zip(*[inputs, V_fs, E_fs]), n_workers=n_workers)
+        self._mgs = parallel_execute(featurizer, zip(inputs, V_fs, E_fs), n_workers=n_workers)
 
     def __len__(self) -> int:
         return len(self._mgs)

--- a/chemprop/featurizers/molgraph/cache.py
+++ b/chemprop/featurizers/molgraph/cache.py
@@ -55,7 +55,7 @@ class MolGraphCache(MolGraphCacheFacade):
         V_fs: Iterable[np.ndarray | None],
         E_fs: Iterable[np.ndarray | None],
         featurizer: Featurizer[S, MolGraph],
-        n_workers: int = 1,
+        n_workers: int = 0,
     ):
         self._mgs = parallel_execute(featurizer, zip(inputs, V_fs, E_fs), n_workers=n_workers)
 

--- a/chemprop/utils/__init__.py
+++ b/chemprop/utils/__init__.py
@@ -1,5 +1,5 @@
 from .registry import ClassRegistry, Factory
-from .utils import EnumMapping, created_and_call_object, make_mol, parallel_execute, pretty_shape
+from .utils import EnumMapping, create_and_call_object, make_mol, parallel_execute, pretty_shape
 
 __all__ = [
     "ClassRegistry",
@@ -7,6 +7,6 @@ __all__ = [
     "EnumMapping",
     "make_mol",
     "pretty_shape",
-    "created_and_call_object",
+    "create_and_call_object",
     "parallel_execute",
 ]

--- a/chemprop/utils/__init__.py
+++ b/chemprop/utils/__init__.py
@@ -1,5 +1,5 @@
 from .registry import ClassRegistry, Factory
-from .utils import EnumMapping, make_mol, parallel_execute, pretty_shape
+from .utils import EnumMapping, created_and_call_object, make_mol, parallel_execute, pretty_shape
 
 __all__ = [
     "ClassRegistry",
@@ -7,5 +7,6 @@ __all__ = [
     "EnumMapping",
     "make_mol",
     "pretty_shape",
+    "created_and_call_object",
     "parallel_execute",
 ]

--- a/chemprop/utils/__init__.py
+++ b/chemprop/utils/__init__.py
@@ -1,4 +1,11 @@
 from .registry import ClassRegistry, Factory
-from .utils import EnumMapping, make_mol, pretty_shape
+from .utils import EnumMapping, make_mol, parallel_execute, pretty_shape
 
-__all__ = ["ClassRegistry", "Factory", "EnumMapping", "make_mol", "pretty_shape"]
+__all__ = [
+    "ClassRegistry",
+    "Factory",
+    "EnumMapping",
+    "make_mol",
+    "pretty_shape",
+    "parallel_execute",
+]

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 import os
-from typing import Callable, Iterable, Iterator, Type
+from typing import Any, Callable, Iterable, Iterator, Type
 
 import multiprocess
 import numpy as np
@@ -90,15 +90,30 @@ def make_mol(
     return mol
 
 
-def create_and_call_object(class_definition: Type, object_input):
-    """Creates object from class_definition and calls it with object_input.
+def create_and_call_object(
+    cls: Type,
+    call_args: tuple = (),
+    call_kwargs: dict = None,
+    init_args: tuple = (),
+    init_kwargs: dict = None,
+) -> Any:
+    """
+    Instantiate a class with optional init args, then call the instance with args.
     This is useful for parallel calls to methods that contain boost functions.
     """
-    return class_definition()(object_input)
+    if call_kwargs is None:
+        call_kwargs = {}
+    if init_kwargs is None:
+        init_kwargs = {}
+
+    return cls(*init_args, **init_kwargs)(*call_args, **call_kwargs)
 
 
 def parallel_execute(
-    exe_func: Callable, func_args: Iterable, n_workers: int = 1, zipped: bool = True
+    exe_func: Callable,
+    func_args: Iterable[tuple] = (),
+    func_kwargs: Iterable[dict] = (),
+    n_workers: int = 1,
 ) -> list:
     """Optionally executes a function in parallel.
 
@@ -110,25 +125,31 @@ def parallel_execute(
         arguments for each iteration of function execution.
     n_workers : int, optional
         Number of parallel workers.
-    zipped : bool, optional
-        If True, avoids aggregating list of variables.
 
     Returns
     -------
     list
         list of function outputs for each argument.
     """
-    if not zipped:
-        func_args = zip(*func_args)
+    func_args = list(func_args)
+    func_kwargs = list(func_kwargs)
+
+    if not func_kwargs:
+        func_kwargs = [{}] * len(func_args)
+    if not func_args:
+        func_args = [()] * len(func_kwargs)
+
+    combined = list(zip(func_args, func_kwargs))
+
     if n_workers >= 2:
 
-        def wrapped_call(args):
-            return exe_func(*args)
+        def wrapped_call(args, kwargs):
+            return exe_func(*args, **kwargs)
 
         with multiprocess.Pool(n_workers) as p:
-            results = p.map(wrapped_call, func_args)
+            results = p.starmap(wrapped_call, combined)
     else:
-        results = [exe_func(*func_arg) for func_arg in func_args]
+        results = [exe_func(*func_arg, **func_kwargs) for (func_arg, func_kwargs) in combined]
     return results
 
 

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 import os
-from typing import Callable, Iterable, Iterator
+from typing import Callable, Iterable, Iterator, Type
 
 import multiprocess
 import numpy as np
@@ -88,6 +88,13 @@ def make_mol(
         mol = Chem.rdmolops.RenumberAtoms(mol, new_order)
 
     return mol
+
+
+def created_and_call_object(class_definition: Type, object_input):
+    """Creates object from class_definition and calls it with object_input.
+    This is useful for parallel calls to methods that contain boost functions.
+    """
+    return class_definition()(object_input)
 
 
 def parallel_execute(

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -90,7 +90,7 @@ def make_mol(
     return mol
 
 
-def created_and_call_object(class_definition: Type, object_input):
+def create_and_call_object(class_definition: Type, object_input):
     """Creates object from class_definition and calls it with object_input.
     This is useful for parallel calls to methods that contain boost functions.
     """

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -113,7 +113,7 @@ def parallel_execute(
     exe_func: Callable,
     func_args: Iterable[tuple] = (),
     func_kwargs: Iterable[dict] = (),
-    n_workers: int = 1,
+    n_workers: int = 0,
 ) -> list:
     """Optionally executes a function in parallel.
 

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -123,6 +123,8 @@ def parallel_execute(
         function to execute.
     func_args : Iterable
         arguments for each iteration of function execution.
+    func_kwargs : Iterable
+        keyword arguments for each iteration of function execution.
     n_workers : int, optional
         Number of parallel workers.
 

--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -238,7 +238,9 @@ The first time a given model is requested it will automatically be downloaded fo
 Performant Training
 ^^^^^^^^^^^^^^^^^^^
 
-Training can be accelerated using a molecular featurizer package called ``cuik-molmaker``. This package is not installed by default, but can be installed using the script ``check_and_install_cuik_molmaker.py``. In order to enable the accelerated featurizer, use the :code:`--use-cuikmolmaker-featurization` flag. This featurizer also performs on-the-fly featurization of molecules and reduces memory usage which is particularly useful for large datasets.
+By default, graph featurization occurs a single time at the beginning of the training run, and the results are cached for use during each training epoch. This saves time but requires more memory. This behavior can be turned off by specifying :code:`--no-cache`. In either case, graph featurization can be sped up by using more CPU cores, specified via :code:`--num-workers`. This will also convert SMILES strings to :code:`Chem.Mol`s in parallel and compute any molecule features specified with :code:`--molecule-featurizers` in parallel.
+
+Training can be further accelerated using a molecular featurizer package called ``cuik-molmaker``. This package is not installed by default, but can be installed using the script ``check_and_install_cuik_molmaker.py``. In order to enable the accelerated featurizer, use the :code:`--use-cuikmolmaker-featurization` flag. This featurizer also performs on-the-fly featurization of molecules and reduces memory usage which is particularly useful for large datasets.
 
 
 .. _train-on-reactions:
@@ -322,7 +324,7 @@ Extra Datapoint Descriptors
 
 Additional datapoint descriptors can be concatenated to the learned representation after aggregation. These extra descriptors could be molecule-level features. If you install from source, you can modify the code to load custom descriptors as follows:
 
-1. **Generate features:** If you want to generate molecule features in code, you can write a custom features generator function using the default featurizers in :code:`chemprop/featurizers/`. This also works for custom atom and bond features.
+1. **Generate features:** If you want to generate molecular features in code, you can write a custom features generator function using the default featurizers in :code:`chemprop/featurizers/`. This also works for custom atom and bond features.
 2. **Load features:** Additional descriptors can be provided using :code:`--descriptors-path /path/to/descriptors.npz` where the descriptors are saved as a numpy :code:`.npz` file. This file can be saved using :code:`np.savez("/path/to/descriptors.npz", X_d)`, where :code:`X_d` is a 2D array with a shape of number of datapoints by number of additional descriptors. Note that the descriptors must be in the same order as the SMILES strings in your data file. The extra descriptors are scaled by default. This can be disabled with the option :code:`--no-descriptor-scaling`.
 
 

--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -238,7 +238,10 @@ The first time a given model is requested it will automatically be downloaded fo
 Performant Training
 ^^^^^^^^^^^^^^^^^^^
 
-By default, graph featurization occurs a single time at the beginning of the training run, and the results are cached for use during each training epoch. This saves time but requires more memory. This behavior can be turned off by specifying :code:`--no-cache`. In either case, graph featurization can be sped up by using more CPU cores, specified via :code:`--num-workers`. This will also convert SMILES strings to :code:`Chem.Mol`s in parallel and compute any molecule features specified with :code:`--molecule-featurizers` in parallel.
+By default, graph featurization occurs a single time at the beginning of the training run, and the results are cached for use during each training epoch. This saves time but requires more memory. This behavior can be turned off by specifying :code:`--no-cache`. In either case, graph featurization can be sped up by using more CPU cores, specified via :code:`--num-workers`. This will also convert SMILES strings to :code:`Chem.Mol` objects in parallel and compute any molecule features specified with :code:`--molecule-featurizers` in parallel.
+
+.. note::
+  Setting :code:`num_workers` to a value greater than 0 can cause hangs on Windows and MacOS
 
 Training can be further accelerated using a molecular featurizer package called ``cuik-molmaker``. This package is not installed by default, but can be installed using the script ``check_and_install_cuik_molmaker.py``. In order to enable the accelerated featurizer, use the :code:`--use-cuikmolmaker-featurization` flag. This featurizer also performs on-the-fly featurization of molecules and reduces memory usage which is particularly useful for large datasets.
 

--- a/docs/source/tutorial/python/data/datasets.ipynb
+++ b/docs/source/tutorial/python/data/datasets.ipynb
@@ -168,7 +168,9 @@
     "\n",
     "If the cache needs to be recreated, set the cache to True again. To clear the cache, set it to False. \n",
     "\n",
-    "Note we recommend [scaling](../scaling.ipynb) additional atom and bond features before setting the cache, as scaling them after caching will require the cache to be recreated, which is done automatically."
+    "Note we recommend [scaling](../scaling.ipynb) additional atom and bond features before setting the cache, as scaling them after caching will require the cache to be recreated, which is done automatically. \n",
+    "\n",
+    "To featurize the graphs in parallel when caching, use the `n_workers` argument when creating the dataset."
    ]
   },
   {
@@ -177,6 +179,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "dataset = MoleculeDataset(mol_datapoints, n_workers=3)\n",
+    "\n",
     "dataset.cache = True  # Generate the molgraphs and cache them\n",
     "dataset.cache = True  # Recreate the cache\n",
     "dataset.cache = False  # Clear the cache\n",

--- a/docs/source/tutorial/python/data/datasets.ipynb
+++ b/docs/source/tutorial/python/data/datasets.ipynb
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/source/tutorial/python/data/datasets.ipynb
+++ b/docs/source/tutorial/python/data/datasets.ipynb
@@ -170,16 +170,21 @@
     "\n",
     "Note we recommend [scaling](../scaling.ipynb) additional atom and bond features before setting the cache, as scaling them after caching will require the cache to be recreated, which is done automatically. \n",
     "\n",
-    "To featurize the graphs in parallel when caching, use the `n_workers` argument when creating the dataset."
+    "To featurize the graphs in parallel when caching, use the `n_workers` argument when creating the dataset. Note that this may cause hangs on Windows and MacOS. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = MoleculeDataset(mol_datapoints, n_workers=3)\n",
+    "import sys\n",
+    "\n",
+    "if sys.platform not in [\"win32\", \"darwin\"]:\n",
+    "    dataset = MoleculeDataset(mol_datapoints, n_workers=3)\n",
+    "else:\n",
+    "    dataset = MoleculeDataset(mol_datapoints)\n",
     "\n",
     "dataset.cache = True  # Generate the molgraphs and cache them\n",
     "dataset.cache = True  # Recreate the cache\n",

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -238,3 +238,51 @@ def test_train_molecule_featurizers(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+
+def test_train_multiprocess(monkeypatch, data_path):
+    input_path, descriptors_path, *_ = data_path
+
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        "smiles",
+        "solvent",
+        "--epochs",
+        "3",
+        "--num-workers",
+        "2",
+        "--descriptors-path",
+        descriptors_path,
+        "--molecule-featurizers",
+        "v1_rdkit_2d_normalized",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
+def test_predict_multiprocess(monkeypatch, data_path, model_path):
+    input_path, _, _, _, _, _ = data_path
+
+    args = [
+        "chemprop",
+        "predict",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        "smiles",
+        "solvent",
+        "--model-path",
+        model_path,
+        "--num-workers",
+        "2",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -241,6 +241,9 @@ def test_train_molecule_featurizers(monkeypatch, data_path):
         main()
 
 
+@pytest.mark.skipif(
+    sys.platform in ["win32", "darwin"], reason="Multiprocessing can hang on Windows and MacOS."
+)
 def test_train_multiprocess(monkeypatch, data_path):
     input_path, descriptors_path, *_ = data_path
 

--- a/tests/cli/test_cli_regression_mol+mol.py
+++ b/tests/cli/test_cli_regression_mol+mol.py
@@ -2,6 +2,7 @@
 """
 
 import json
+import sys
 
 import pytest
 
@@ -266,6 +267,9 @@ def test_train_multiprocess(monkeypatch, data_path):
         main()
 
 
+@pytest.mark.skipif(
+    sys.platform in ["win32", "darwin"], reason="Multiprocessing can hang on Windows and MacOS."
+)
 def test_predict_multiprocess(monkeypatch, data_path, model_path):
     input_path, _, _, _, _, _ = data_path
 

--- a/tests/unit/utils/test_multiprocess.py
+++ b/tests/unit/utils/test_multiprocess.py
@@ -1,0 +1,19 @@
+from chemprop.utils import parallel_execute
+
+
+def test_parallel_execution():
+    def add_two(x, y):
+        return x + y
+
+    expected_result = [3, 7]
+
+    results_single_worker = parallel_execute(add_two, [[1, 2], [3, 4]], n_workers=1)
+    assert results_single_worker == expected_result
+
+    results_multi_worker = parallel_execute(add_two, [[1, 2], [3, 4]], n_workers=2)
+    assert results_multi_worker == expected_result
+
+    results_zipped_multi_worker = parallel_execute(
+        add_two, [[1, 3], [2, 4]], n_workers=2, zipped=False
+    )
+    assert results_zipped_multi_worker == expected_result

--- a/tests/unit/utils/test_multiprocess.py
+++ b/tests/unit/utils/test_multiprocess.py
@@ -8,8 +8,7 @@ from chemprop.utils import make_mol, parallel_execute
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32" or sys.platform == "darwin",
-    reason="Multiprocessing can hang on Windows and MacOS.",
+    sys.platform in ["win32", "darwin"], reason="Multiprocessing can hang on Windows and MacOS."
 )
 def test_parallel_execution():
     def add_two(x, y):
@@ -29,8 +28,7 @@ def test_parallel_execution():
     os.cpu_count() < 4, reason="Speedup is expected if multiple threads are available."
 )
 @pytest.mark.skipif(
-    sys.platform == "win32" or sys.platform == "darwin",
-    reason="Multiprocessing can hang on Windows and MacOS.",
+    sys.platform in ["win32", "darwin"], reason="Multiprocessing can hang on Windows and MacOS."
 )
 def test_parallel_is_faster():
     smis = ["C1=CC=C(N=C1)C1=CC=C(N=C1)C1=CC=C(N=C1)C1=CC=C(Cl)N=C1" * 100] * 4

--- a/tests/unit/utils/test_multiprocess.py
+++ b/tests/unit/utils/test_multiprocess.py
@@ -31,7 +31,7 @@ def test_parallel_is_faster():
     parallel_results = parallel_execute(
         make_mol, [(smi, keep_h, add_h, ignore_stereo, reorder_atoms) for smi in smis], n_workers=4
     )
-    paralle_runtime = time.time() - start_time
+    parallel_runtime = time.time() - start_time
 
     start_time = time.time()
     sequential_results = [
@@ -40,5 +40,4 @@ def test_parallel_is_faster():
     sequential_runtime = time.time() - start_time
 
     assert len(sequential_results) == len(parallel_results)
-    print(paralle_runtime, sequential_runtime)
-    assert paralle_runtime < sequential_runtime
+    assert parallel_runtime < sequential_runtime

--- a/tests/unit/utils/test_multiprocess.py
+++ b/tests/unit/utils/test_multiprocess.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 
 import pytest
@@ -6,6 +7,10 @@ import pytest
 from chemprop.utils import make_mol, parallel_execute
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32" or sys.platform == "darwin",
+    reason="Multiprocessing can hang on Windows and MacOS.",
+)
 def test_parallel_execution():
     def add_two(x, y):
         return x + y
@@ -22,6 +27,10 @@ def test_parallel_execution():
 # @pytest.mark.skip(reason="Debuggers can slow down multiprocessing.")
 @pytest.mark.skipif(
     os.cpu_count() < 4, reason="Speedup is expected if multiple threads are available."
+)
+@pytest.mark.skipif(
+    sys.platform == "win32" or sys.platform == "darwin",
+    reason="Multiprocessing can hang on Windows and MacOS.",
 )
 def test_parallel_is_faster():
     smis = ["C1=CC=C(N=C1)C1=CC=C(N=C1)C1=CC=C(N=C1)C1=CC=C(Cl)N=C1" * 100] * 4


### PR DESCRIPTION
## Description
Large datasets (100k+ molecules) are slow to load. This PR leverages multiprocessing to load and featurize molecules faster if applicable.

## Example / Current workflow
With old code loading molecules and constructing graphs with following parameters: 
> chemprop train -i my_big_file.csv --num-workers 0 

is as slow as with: 
> chemprop train -i my_big_file.csv --num-workers 16

This PR speeds up the loading if `--num-workers` is increased. 

## Bugfix / Desired workflow
N.A.

## Questions
N.A.

## Relevant issues
N.A.

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
