### PR TITLE
Allow importing uncertainty as a subpackage

### DIFF
--- a/chemprop/__init__.py
+++ b/chemprop/__init__.py
@@ -1,5 +1,14 @@
-from . import data, exceptions, featurizers, models, nn, schedulers, utils
+from . import data, exceptions, featurizers, models, nn, schedulers, uncertainty, utils
 
-__all__ = ["data", "featurizers", "models", "nn", "utils", "exceptions", "schedulers"]
+__all__ = [
+    "data",
+    "featurizers",
+    "models",
+    "nn",
+    "utils",
+    "exceptions",
+    "schedulers",
+    "uncertainty",
+]
 
 __version__ = "2.1.2"


### PR DESCRIPTION
## Description

The `uncertainty` subpackage is missing from `chemprop.__all__`, which causes the following statements to fail:

```py
from chemprop import uncertainty
```

```py
import chemprop
estimator = chemprop.uncertainty.EnsembleEstimator()
```

This PR adds `uncertainty` to `chemprop.__all__`.