### PR TITLE
remove unneeded folders from python distrubution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+# required to make the tarball distrbution ignore unnecessary files
+include pyproject.toml
+include README.md
+recursive-include chemprop *
+global-exclude *.pyc
+global-exclude __pycache__/
+prune tests
+prune docs
+prune notebooks
+prune examples
+prune requirements
+prune .github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,4 @@ force_sort_within_sections = true
 
 [tool.setuptools.packages.find]
 include = ["chemprop"]
+exclude = ["tests", "examples", "docs", "requirements", ".github"]


### PR DESCRIPTION
our previous build attempt got rejected for being too large (130 MB with a limit of 100 MB). remove these files wich are not needed anyway

Build failure is here: https://github.com/chemprop/chemprop/actions/runs/15331593506/job/43143986608#step:6:230
