### PR TITLE
Add support for empty test set

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1136,8 +1136,11 @@ def build_datasets(args, train_data, val_data, test_data):
             for dataset, label in zip(
                 [train_dset, val_dset, test_dset], ["Training", "Validation", "Test"]
             ):
-                column_headers, table_rows = summarize(args.target_columns, args.task_type, dataset)
-                output = build_table(column_headers, table_rows, f"Summary of {label} Data")
+                if dataset is not None:
+                    column_headers, table_rows = summarize(args.target_columns, args.task_type, dataset)
+                    output = build_table(column_headers, table_rows, f"Summary of {label} Data")
+                else:
+                    output = label + " set is empty."
                 logger.info("\n" + output)
 
     return train_dset, val_dset, test_dset

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -974,7 +974,7 @@ def build_splits(args, format_kwargs, featurization_kwargs):
             split_idxss = json.load(json_file)
         train_indices = [parse_indices(d["train"]) for d in split_idxss]
         val_indices = [parse_indices(d["val"]) for d in split_idxss]
-        test_indices = [parse_indices(d["test"]) for d in split_idxss]
+        test_indices = [parse_indices(d["test"]) if "test" in d else [] for d in split_idxss]
         args.num_replicates = len(split_idxss)
 
     else:

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1137,7 +1137,9 @@ def build_datasets(args, train_data, val_data, test_data):
                 [train_dset, val_dset, test_dset], ["Training", "Validation", "Test"]
             ):
                 if dataset is not None:
-                    column_headers, table_rows = summarize(args.target_columns, args.task_type, dataset)
+                    column_headers, table_rows = summarize(
+                        args.target_columns, args.task_type, dataset
+                    )
                     output = build_table(column_headers, table_rows, f"Summary of {label} Data")
                 else:
                     output = label + " set is empty."

--- a/chemprop/data/splitting.py
+++ b/chemprop/data/splitting.py
@@ -110,11 +110,7 @@ def make_split_indices(
                 result = mol_split_fun(
                     np.array(mols_without_atommaps), sampler="scaffold", **astartes_kwargs
                 )
-                # flip val & test back if test size is 0
-                if sizes[2] == 0.0:
-                    train, test, val = _unpack_astartes_result(result, include_val)
-                else:
-                    train, val, test = _unpack_astartes_result(result, include_val)
+                train, val, test = _unpack_astartes_result(result, include_val)
 
             # Use to constrain data with the same smiles go in the same split.
             case SplitType.RANDOM_WITH_REPEATED_SMILES:
@@ -131,11 +127,7 @@ def make_split_indices(
                 result = split_fun(
                     np.arange(len(unique_smiles)), sampler="random", **astartes_kwargs
                 )
-                # flip val & test back if test size is 0
-                if sizes[2] == 0.0:
-                    train_idxs, test_idxs, val_idxs = _unpack_astartes_result(result, include_val)
-                else:
-                    train_idxs, val_idxs, test_idxs = _unpack_astartes_result(result, include_val)
+                train_idxs, val_idxs, test_idxs = _unpack_astartes_result(result, include_val)
 
                 # convert these to the 'actual' indices from the original list using the dict we made
                 train = sum((smiles_indices[unique_smiles[i]] for i in train_idxs), [])
@@ -144,11 +136,7 @@ def make_split_indices(
 
             case SplitType.RANDOM:
                 result = split_fun(np.arange(n_datapoints), sampler="random", **astartes_kwargs)
-                # flip val & test back if test size is 0
-                if sizes[2] == 0.0:
-                    train, test, val = _unpack_astartes_result(result, include_val)
-                else:
-                    train, val, test = _unpack_astartes_result(result, include_val)
+                train, val, test = _unpack_astartes_result(result, include_val)
 
             case SplitType.KENNARD_STONE:
                 result = mol_split_fun(
@@ -159,11 +147,7 @@ def make_split_indices(
                     fprints_hopts=dict(n_bits=2048),
                     **astartes_kwargs,
                 )
-                # flip val & test back if test size is 0
-                if sizes[2] == 0.0:
-                    train, test, val = _unpack_astartes_result(result, include_val)
-                else:
-                    train, val, test = _unpack_astartes_result(result, include_val)
+                train, val, test = _unpack_astartes_result(result, include_val)
 
             case SplitType.KMEANS:
                 result = mol_split_fun(
@@ -174,14 +158,14 @@ def make_split_indices(
                     fprints_hopts=dict(n_bits=2048),
                     **astartes_kwargs,
                 )
-                if sizes[2] == 0.0:
-                    train, test, val = _unpack_astartes_result(result, include_val)
-                else:
-                    train, val, test = _unpack_astartes_result(result, include_val)
+                train, val, test = _unpack_astartes_result(result, include_val)
 
             case _:
                 raise RuntimeError("Unreachable code reached!")
 
+        # flip val and test back if test size is 0
+        if sizes[2] == 0:
+            val, test = test, val
         train_replicates.append(train)
         val_replicates.append(val)
         test_replicates.append(test)

--- a/chemprop/data/splitting.py
+++ b/chemprop/data/splitting.py
@@ -88,7 +88,7 @@ def make_split_indices(
     if sizes[1] == 0.0 or sizes[2] == 0.0:
         # flip val and test size if test size is not 0 (to bypass astartes check)
         if sizes[2] == 0.0:
-            astartes_kwargs["test_size"]=sizes[1]
+            astartes_kwargs["test_size"] = sizes[1]
         include_val = False
         split_fun = train_test_split
         mol_split_fun = train_test_split_molecules
@@ -136,7 +136,7 @@ def make_split_indices(
                     train_idxs, test_idxs, val_idxs = _unpack_astartes_result(result, include_val)
                 else:
                     train_idxs, val_idxs, test_idxs = _unpack_astartes_result(result, include_val)
-                
+
                 # convert these to the 'actual' indices from the original list using the dict we made
                 train = sum((smiles_indices[unique_smiles[i]] for i in train_idxs), [])
                 val = sum((smiles_indices[unique_smiles[j]] for j in val_idxs), [])
@@ -181,7 +181,7 @@ def make_split_indices(
 
             case _:
                 raise RuntimeError("Unreachable code reached!")
-            
+
         train_replicates.append(train)
         val_replicates.append(val)
         test_replicates.append(test)

--- a/chemprop/data/splitting.py
+++ b/chemprop/data/splitting.py
@@ -164,7 +164,7 @@ def make_split_indices(
                 raise RuntimeError("Unreachable code reached!")
 
         # flip val and test back if test size is 0
-        if sizes[2] == 0:
+        if sizes[2] == 0.0:
             val, test = test, val
         train_replicates.append(train)
         val_replicates.append(val)

--- a/chemprop/data/splitting.py
+++ b/chemprop/data/splitting.py
@@ -86,7 +86,7 @@ def make_split_indices(
     )
     # if no validation set, reassign the splitting functions
     if sizes[1] == 0.0 or sizes[2] == 0.0:
-        # flip val and test size if test size is not 0 (to bypass astartes check)
+        # flip val and test size if test size is 0 (to bypass astartes check)
         if sizes[2] == 0.0:
             astartes_kwargs["test_size"] = sizes[1]
         include_val = False

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -700,3 +700,24 @@ def test_custom_activation_quick(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+
+def test_empty_testset(monkeypatch):
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        "data.csv",
+        "--smiles-columns",
+        "smiles",
+        "--target-columns",
+        "y",
+        "--split-sizes",
+        "0.5",
+        "0.5",
+        "0",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -702,16 +702,17 @@ def test_custom_activation_quick(monkeypatch, data_path):
         main()
 
 
-def test_empty_testset(monkeypatch):
+def test_empty_testset(monkeypatch, data_path):
+    input_path, *_ = data_path
     args = [
         "chemprop",
         "train",
         "-i",
-        "data.csv",
+        input_path,
         "--smiles-columns",
         "smiles",
         "--target-columns",
-        "y",
+        "lipo",
         "--split-sizes",
         "0.5",
         "0.5",


### PR DESCRIPTION
## Description
Add support for empty/null test set for data input, by exchanging val and test arguments in splitting.py, and checking emptiness of test arguments before indexing in train.py.

## Example / Current workflow
The current workflow disallows empty test set - ie. having a train-val-test split of 0.5-0.5-0 triggers an error.

## Bugfix / Desired workflow
The new workflow handles empty test set - ie. 0.5-0.5-0 split - without error, and trains upon the resulting train/val sets as intended.

## Questions
N/A

## Relevant issues
#1165

## Checklist
- [Yes] linted with flake8?
