### PR TITLE
Zero-indexing refactoring of splits.json used in both tutorial & test

### DIFF
--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -97,12 +97,15 @@ Our code supports several methods of splitting data into train, validation, and 
 
     chemprop train --splits-file splits.json -i data.csv -t regression
 
+.. note::
+    Use zero-indexing when assigning data indices to different sets. Additionally note that ranges have inclusive ends (ie. [0,1] / "0-1" / "0,1" are equivalent).
+
 .. code-block:: JSON
     :caption: splits.json
 
     [
-        {"train": [1, 2], "val": "3-5", "test": "6,7"},
-        {"val": [1, 2], "test": "3-5", "train": "6,7"},
+        {"train": [0, 1], "val": "2-3", "test": "4,5"},
+        {"val": [0, 1], "test": "2-3", "train": "4,5"},
     ]
 
 .. note::

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -700,25 +700,3 @@ def test_custom_activation_quick(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
-
-
-def test_empty_testset(monkeypatch, data_path):
-    input_path, *_ = data_path
-    args = [
-        "chemprop",
-        "train",
-        "-i",
-        input_path,
-        "--smiles-columns",
-        "smiles",
-        "--target-columns",
-        "lipo",
-        "--split-sizes",
-        "0.5",
-        "0.5",
-        "0",
-    ]
-
-    with monkeypatch.context() as m:
-        m.setattr("sys.argv", args)
-        main()

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -700,3 +700,25 @@ def test_custom_activation_quick(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+
+def test_empty_testset(monkeypatch, data_path):
+    input_path, *_ = data_path
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        "smiles",
+        "--target-columns",
+        "lipo",
+        "--split-sizes",
+        "0.5",
+        "0.5",
+        "0",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -404,8 +404,8 @@ def test_train_splits_file(monkeypatch, data_path, tmp_path):
     input_path, *_ = data_path
     splits_file = str(tmp_path / "splits.json")
     splits = [
-        {"train": [1, 2], "val": "3-5", "test": "6,7"},
-        {"val": [1, 2], "test": "3-5", "train": "6,7"},
+        {"train": [0, 1], "val": "2-3", "test": "4,5"},
+        {"val": [0, 1], "test": "2-3", "train": "4,5"},
     ]
 
     with open(splits_file, "w") as f:


### PR DESCRIPTION
## Description
Refactor the splits.json file used in both tutorial & testing to follow 0-indexing.

## Example / Current workflow
The current splits.json assigned indices 1 through 7 to train/val/test sets, which is misleading toward an assumption that the splitting module expect 1-indexing, while in reality the model operates on 0-indexing and using 1-indexing can lead to assignment offset and index-out-of-range error. This issue has not been exposed in prior testing because datasets used for testing generally have size greater than 8, yet error would occur if we run the split on a dataset of exactly 7 elements.

## Bugfix / Desired workflow
Modified splits.json to assign indices 0 through 5 instead, in accordance with the 0-index pipeline.

## Questions
N/A

## Relevant issues
N/A

## Checklist
- [Yes] linted with flake8?

