### PR TITLE
ensure models loaded for transfer learning are on CPU

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1521,7 +1521,7 @@ def train_model(
                 mpnn_cls = MPNN
 
             model_path = model_paths[model_idx] if args.checkpoint else args.model_frzn
-            model = mpnn_cls.load_from_file(model_path)
+            model = mpnn_cls.load_from_file(model_path, map_location=torch.device("cpu"))
 
             if args.checkpoint:
                 model.apply(


### PR DESCRIPTION
When training and then transfer learning with ChemProp, a model trained on GPU expects the same GPU to be present. This is not always the case (which we account for during inference by specifying map location as CPU) but can happen, which is why we missed it.

Resolves https://github.com/chemprop/chemprop/issues/1251