### PR TITLE
Report test performance at the end of `hpopt`

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -571,6 +571,10 @@ def main(args: Namespace):
         train_dset, args.batch_size, args.num_workers, seed=args.data_seed
     )
 
+    test_loader = build_dataloader(
+        test_dset, args.batch_size, args.num_workers, seed=args.data_seed
+    )
+
     if isinstance(train_loader.dataset, MolAtomBondDataset):
         model = build_MAB_model(args, train_loader.dataset, output_transform, input_transforms)
         monitor_mode = (
@@ -613,6 +617,10 @@ def main(args: Namespace):
     result_df.to_csv(all_progress_save_path, index=False)
 
     ray.shutdown()
+
+    # call build_model on best_checkpoint_save_path
+    # initialize the lightning trainer
+    # run inference and then log results on the testing dataset
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Currently the `hpopt` CLI partitions out a test set, but then does not use it. This makes it challenging for users to gauge the performance of the final model, especially given that the provided validation set performances have been 'leaked' during hyperparameter optimization.

## Bugfix / Desired workflow
Use the `logger` to report the performance on the newly added `test_loader` by loading the best resulting model checkpoint and initializing a basic `Trainer(...)` instance. May need to raise a warning about not being able to do so if checkpointing or temporary file writes are disabled, which I believe our CLI makes possible, and perhaps do so early in `hpopt` execution.

## Questions
Do we want to just log the performance to the command line (it's only a couple numbers, anyway) or write it to a file?

## Relevant issues
Resolves #1260 where this feature was requested

## Checklist (WIP)
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
