### PR TITLE
Fix randomly failing overfit test

### DIFF
--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -700,25 +700,3 @@ def test_custom_activation_quick(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
-
-
-def test_empty_testset(monkeypatch, data_path):
-    input_path, *_ = data_path
-    args = [
-        "chemprop",
-        "train",
-        "-i",
-        input_path,
-        "--smiles-columns",
-        "smiles",
-        "--target-columns",
-        "lipo",
-        "--split-sizes",
-        "0.5",
-        "0.5",
-        "0",
-    ]
-
-    with monkeypatch.context() as m:
-        m.setattr("sys.argv", args)
-        main()

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -700,3 +700,25 @@ def test_custom_activation_quick(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+
+def test_empty_testset(monkeypatch, data_path):
+    input_path, *_ = data_path
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        "smiles",
+        "--target-columns",
+        "lipo",
+        "--split-sizes",
+        "0.5",
+        "0.5",
+        "0",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()

--- a/tests/integration/test_regression_MAB.py
+++ b/tests/integration/test_regression_MAB.py
@@ -52,6 +52,7 @@ def test_quick(mol_atom_bond_mpnn, dataloader):
     trainer.fit(mol_atom_bond_mpnn, dataloader, None)
 
 
+pl.seed_everything(0)
 @pytest.mark.parametrize(
     "mol_atom_bond_mpnn",
     [

--- a/tests/integration/test_regression_MAB.py
+++ b/tests/integration/test_regression_MAB.py
@@ -53,6 +53,8 @@ def test_quick(mol_atom_bond_mpnn, dataloader):
 
 
 pl.seed_everything(0)
+
+
 @pytest.mark.parametrize(
     "mol_atom_bond_mpnn",
     [


### PR DESCRIPTION
## Description
Fix the test_overfit function in chemprop/tests/integration/test_regression_MAB.py.

## Example / Current workflow
The current test_overfit is non-deterministic, sometimes producing MSE above the 0.01 threshold, leading to random test failures.

## Bugfix / Desired workflow
The fix is to set the seed before initializing parameters of the test. After doing so, test_overfit produces deterministic MSE values, even when the tests are reordered.

## Questions
N/A

## Relevant issues
N/A

## Checklist
- [Yes] linted with flake8?
- [N/A] unit tests added?
