### PR TITLE
Bug Fix: Add handling for `--from-foundation` argument in `hpopt`

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -306,7 +306,7 @@ def process_hpopt_args(args: Namespace) -> Namespace:
             "bond_ffn_num_layers",
         ]:
             search_parameters.discard(param)
-    
+
     if args.from_foundation is not None:
         for param in [
             "activation",
@@ -336,8 +336,6 @@ def process_hpopt_args(args: Namespace) -> Namespace:
 
 
 def build_search_space(search_parameters: list[str], train_epochs: int) -> dict:
-    
-    
     if "warmup_epochs" in search_parameters and SEARCH_SPACE.get("warmup_epochs", None) is None:
         assert (
             train_epochs >= 6

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -306,6 +306,17 @@ def process_hpopt_args(args: Namespace) -> Namespace:
             "bond_ffn_num_layers",
         ]:
             search_parameters.discard(param)
+    
+    if args.from_foundation is not None:
+        for param in [
+            "activation",
+            "dropout",
+            "depth",
+            "aggregation",
+            "aggregation_norm",
+            "message_hidden_dim",
+        ]:
+            search_parameters.discard(param)
 
     if args.constraints_path is None:
         for param in [
@@ -325,6 +336,8 @@ def process_hpopt_args(args: Namespace) -> Namespace:
 
 
 def build_search_space(search_parameters: list[str], train_epochs: int) -> dict:
+    
+    
     if "warmup_epochs" in search_parameters and SEARCH_SPACE.get("warmup_epochs", None) is None:
         assert (
             train_epochs >= 6

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1185,7 +1185,6 @@ def build_model(
         list[ScaleTransform | None],
         list[ScaleTransform | None],
     ],
-    from_foundation: FoundationModels | None = None,
 ) -> MPNN | MulticomponentMPNN:
     X_d_transform, graph_transforms, V_d_transforms, _ = input_transforms
     activation = parse_activation(_ACTIVATION_FUNCTIONS[args.activation], args.activation_args)
@@ -1200,24 +1199,24 @@ def build_model(
         n_tasks = train_dset.Y.shape[1]
         mpnn_cls = MPNN
 
-    if from_foundation is not None:
-        if Path(from_foundation).exists():  # local model
+    if args.from_foundation is not None:
+        if Path(args.from_foundation).exists():  # local model
             if is_multi:
                 mp_blocks = []
                 for _ in range(train_dset.n_components):
                     foundation = MPNN.load_from_file(
-                        from_foundation
+                        args.from_foundation
                     )  # must re-load for each, no good way to copy
                     mp_blocks.append(foundation.message_passing)
                 mp_block = MulticomponentMessagePassing(
                     mp_blocks, train_dset.n_components, args.mpn_shared
                 )
             else:
-                foundation = MPNN.load_from_file(from_foundation)
+                foundation = MPNN.load_from_file(args.from_foundation)
                 mp_block = foundation.message_passing
             agg = foundation.agg
         else:  # remote model
-            match FoundationModels.get(from_foundation):
+            match FoundationModels.get(args.from_foundation):
                 case FoundationModels.CHEMELEON:
                     ckpt_dir = Path().home() / ".chemprop"
                     ckpt_dir.mkdir(exist_ok=True)
@@ -1582,7 +1581,6 @@ def train_model(
                     train_loader.dataset,
                     output_transform,
                     input_transforms,
-                    args.from_foundation,
                 )
         logger.info(model)
 

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1576,12 +1576,7 @@ def train_model(
                     args, train_loader.dataset, output_transform, input_transforms
                 )
             else:
-                model = build_model(
-                    args,
-                    train_loader.dataset,
-                    output_transform,
-                    input_transforms,
-                )
+                model = build_model(args, train_loader.dataset, output_transform, input_transforms)
         logger.info(model)
 
         try:

--- a/chemprop/conf.py
+++ b/chemprop/conf.py
@@ -1,4 +1,6 @@
 """Global configuration variables for chemprop"""
 
-DEFAULT_ATOM_FDIM, DEFAULT_BOND_FDIM = 72, 14  # SimpleMoleculeMolGraphFeaturizer().shape
+from chemprop.featurizers.molgraph.molecule import SimpleMoleculeMolGraphFeaturizer
+
+DEFAULT_ATOM_FDIM, DEFAULT_BOND_FDIM = SimpleMoleculeMolGraphFeaturizer().shape
 DEFAULT_HIDDEN_DIM = 300

--- a/chemprop/conf.py
+++ b/chemprop/conf.py
@@ -1,6 +1,4 @@
 """Global configuration variables for chemprop"""
 
-from chemprop.featurizers.molgraph.molecule import SimpleMoleculeMolGraphFeaturizer
-
-DEFAULT_ATOM_FDIM, DEFAULT_BOND_FDIM = SimpleMoleculeMolGraphFeaturizer().shape
+DEFAULT_ATOM_FDIM, DEFAULT_BOND_FDIM = 72, 14  # SimpleMoleculeMolGraphFeaturizer().shape
 DEFAULT_HIDDEN_DIM = 300


### PR DESCRIPTION
## Bug
Right now `chemprop hpopt` will overwrite the choice of `CheMeleon` as the foundation model. This is because `build_model` expects the `from_foundation` argument, rather than just getting it from `args` (I did it this way for some ill-conceived reason).

## Fix
 - change how `build_model` checks for foundation models
 - remove some params from the search space when using a foundation model since they don't change
 - remove import from `conf.py` to avoid circular import when attempting to unpickle the chemeleon `.pt` during ray hpopt (retains compatibility with current usage - the entered values are what they were, just hardcoded)

## Relevant issues
Didn't open one to track, but found it while investigating #1272 

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added? n/a
