### PR TITLE
Allow --data-path to take in multiple paths

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -125,6 +125,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         "-i",
         "--data-path",
         type=Path,
+        nargs="*",
         help="Path to an input CSV file containing SMILES and the associated target values",
     )
     parser.add_argument(
@@ -565,19 +566,20 @@ def process_train_args(args: Namespace) -> Namespace:
 
 
 def validate_train_args(args):
-    if args.config_path is None and args.data_path is None:
+    if args.config_path is None and not args.data_path:
         raise ArgumentError(argument=None, message="Data path must be provided for training.")
 
     if args.output_dir is None:
-        args.output_dir = CHEMPROP_TRAIN_DIR / args.data_path.stem / NOW
+        args.output_dir = CHEMPROP_TRAIN_DIR / args.data_path[0].stem / NOW
 
     if args.num_folds is not None:  # i.e. user-specified
         raise ArgumentError(argument=None, message=_CV_REMOVAL_ERROR)
 
-    if args.data_path.suffix not in [".csv"]:
-        raise ArgumentError(
-            argument=None, message=f"Input data must be a CSV file. Got {args.data_path}"
-        )
+    for path in args.data_path:
+        if path.suffix not in [".csv"]:
+            raise ArgumentError(
+                argument=None, message=f"Input data must be a CSV file. Got {path}"
+            )
 
     if args.epochs != -1 and args.epochs <= args.warmup_epochs:
         raise ArgumentError(
@@ -691,7 +693,7 @@ def validate_train_args(args):
         )
 
     input_cols, target_cols = get_column_names(
-        args.data_path,
+        args.data_path[0],
         args.smiles_columns,
         args.reaction_columns,
         args.target_columns,
@@ -922,79 +924,129 @@ def save_smiles_splits(args: Namespace, output_dir, train_dset, val_dset, test_d
 
 def build_splits(args, format_kwargs, featurization_kwargs):
     """build the train/val/test splits"""
-    logger.info(f"Pulling data from file: {args.data_path}")
-    if any(
-        cols is not None
-        for cols in [args.mol_target_columns, args.atom_target_columns, args.bond_target_columns]
-    ):
-        for key in ["no_header_row", "rxn_cols", "ignore_cols", "splits_col", "target_cols"]:
-            format_kwargs.pop(key, None)
-        featurization_kwargs.pop("use_cuikmolmaker_featurization", None)
-        all_data = build_MAB_data_from_files(
-            args.data_path,
-            p_descriptors=args.descriptors_path,
-            p_atom_feats=args.atom_features_path,
-            p_bond_feats=args.bond_features_path,
-            p_atom_descs=args.atom_descriptors_path,
-            p_bond_descs=args.bond_descriptors_path,
-            **format_kwargs,
-            mol_target_cols=args.mol_target_columns,
-            atom_target_cols=args.atom_target_columns,
-            bond_target_cols=args.bond_target_columns,
-            p_constraints=args.constraints_path,
-            constraints_cols_to_target_cols={
-                col: i for i, col in enumerate(args.constraints_to_targets)
-            }
-            if args.constraints_to_targets is not None
-            else None,
-            **featurization_kwargs,
-        )
-    else:
-        all_data = build_data_from_files(
-            args.data_path,
-            p_descriptors=args.descriptors_path,
-            p_atom_feats=args.atom_features_path,
-            p_bond_feats=args.bond_features_path,
-            p_atom_descs=args.atom_descriptors_path,
-            **format_kwargs,
-            **featurization_kwargs,
-        )
+    logger.info(f"Pulling data from file(s): {args.data_path}")
 
-    if args.splits_column is not None:
-        df = pd.read_csv(
-            args.data_path, header=None if args.no_header_row else "infer", index_col=False
-        )
-        grouped = df.groupby(df[args.splits_column].str.lower())
-        train_indices = grouped.groups.get("train", pd.Index([])).tolist()
-        val_indices = grouped.groups.get("val", pd.Index([])).tolist()
-        test_indices = grouped.groups.get("test", pd.Index([])).tolist()
-        train_indices, val_indices, test_indices = [train_indices], [val_indices], [test_indices]
-
-    elif args.splits_file is not None:
-        with open(args.splits_file, "rb") as json_file:
-            split_idxss = json.load(json_file)
-        train_indices = [parse_indices(d["train"]) for d in split_idxss]
-        val_indices = [parse_indices(d["val"]) for d in split_idxss]
-        test_indices = [parse_indices(d["test"]) if "test" in d else [] for d in split_idxss]
-        args.num_replicates = len(split_idxss)
-
-    else:
-        splitting_data = all_data[args.split_key_molecule]
-
-        if isinstance(splitting_data[0], ReactionDatapoint):
-            splitting_mols = [datapoint.rct for datapoint in splitting_data]
+    def make_data(data_path):
+        if any(
+            cols is not None
+            for cols in [args.mol_target_columns, args.atom_target_columns, args.bond_target_columns]
+        ):
+            for key in ["no_header_row", "rxn_cols", "ignore_cols", "splits_col", "target_cols"]:
+                format_kwargs.pop(key, None)
+            featurization_kwargs.pop("use_cuikmolmaker_featurization", None)
+            return build_MAB_data_from_files(
+                data_path,
+                p_descriptors=args.descriptors_path,
+                p_atom_feats=args.atom_features_path,
+                p_bond_feats=args.bond_features_path,
+                p_atom_descs=args.atom_descriptors_path,
+                p_bond_descs=args.bond_descriptors_path,
+                **format_kwargs,
+                mol_target_cols=args.mol_target_columns,
+                atom_target_cols=args.atom_target_columns,
+                bond_target_cols=args.bond_target_columns,
+                p_constraints=args.constraints_path,
+                constraints_cols_to_target_cols={
+                    col: i for i, col in enumerate(args.constraints_to_targets)
+                }
+                if args.constraints_to_targets is not None
+                else None,
+                **featurization_kwargs,
+            )
         else:
-            splitting_mols = [datapoint.mol for datapoint in splitting_data]
-        train_indices, val_indices, test_indices = make_split_indices(
-            splitting_mols, args.split, args.split_sizes, args.data_seed, args.num_replicates
+            return build_data_from_files(
+                data_path,
+                p_descriptors=args.descriptors_path,
+                p_atom_feats=args.atom_features_path,
+                p_bond_feats=args.bond_features_path,
+                p_atom_descs=args.atom_descriptors_path,
+                **format_kwargs,
+                **featurization_kwargs,
+            )
+        
+    if len(args.data_path)>3:
+        raise ValueError(f"More than 3 data_files provided:{args.data_path}")
+
+    if len(args.data_path)==3:
+        train_data = [make_data(args.data_path[0])]
+        val_data = [make_data(args.data_path[1])]
+        test_data = [make_data(args.data_path[2])]
+
+    elif len(args.data_path) == 2:
+        train_val_data = make_data(args.data_path[0])
+
+        if args.splits_column is not None:
+            df = pd.read_csv(
+                args.data_path[0], header=None if args.no_header_row else "infer", index_col=False
+            )
+            grouped = df.groupby(df[args.splits_column].str.lower())
+            train_indices = grouped.groups.get("train", pd.Index([])).tolist()
+            val_indices   = grouped.groups.get("val",   pd.Index([])).tolist()
+            train_indices, val_indices = [train_indices], [val_indices]
+
+        elif args.splits_file is not None:
+            with open(args.splits_file, "rb") as json_file:
+                split_idxss = json.load(json_file)
+            train_indices = [parse_indices(d["train"]) for d in split_idxss]
+            val_indices   = [parse_indices(d["val"])   for d in split_idxss]
+            args.num_replicates = len(split_idxss)
+
+        else:
+            splitting_data = train_val_data[args.split_key_molecule]
+            if isinstance(splitting_data[0], ReactionDatapoint):
+                splitting_mols = [d.rct for d in splitting_data]
+            else:
+                splitting_mols = [d.mol for d in splitting_data]
+            if args.split_sizes[2] != 0:
+                logger.warning("Get nonzero size for test, defaulted to 9:1 test-val split.")
+                args.split_sizes = [0.9, 0.1, 0]
+            train_indices, val_indices, _ = make_split_indices(
+                splitting_mols, args.split, args.split_sizes, args.data_seed, args.num_replicates
+            )
+
+        train_data, val_data, _ = split_data_by_indices(
+            train_val_data, train_indices, val_indices, None
         )
 
-    train_data, val_data, test_data = split_data_by_indices(
-        all_data, train_indices, val_indices, test_indices
-    )
-    for i_split in range(len(train_data)):
-        sizes = [len(train_data[i_split][0]), len(val_data[i_split][0]), len(test_data[i_split][0])]
-        logger.info(f"train/val/test split_{i_split} sizes: {sizes}")
+        test_data = [make_data(args.data_path[1]) for _ in range(args.num_replicates)]
+
+    else:
+        all_data = make_data(args.data_path[0])
+        if args.splits_column is not None:
+            df = pd.read_csv(
+                args.data_path[0], header=None if args.no_header_row else "infer", index_col=False
+            )
+            grouped = df.groupby(df[args.splits_column].str.lower())
+            train_indices = grouped.groups.get("train", pd.Index([])).tolist()
+            val_indices = grouped.groups.get("val", pd.Index([])).tolist()
+            test_indices = grouped.groups.get("test", pd.Index([])).tolist()
+            train_indices, val_indices, test_indices = [train_indices], [val_indices], [test_indices]
+
+        elif args.splits_file is not None:
+            with open(args.splits_file, "rb") as json_file:
+                split_idxss = json.load(json_file)
+            train_indices = [parse_indices(d["train"]) for d in split_idxss]
+            val_indices = [parse_indices(d["val"]) for d in split_idxss]
+            test_indices = [parse_indices(d["test"]) if "test" in d else [] for d in split_idxss]
+            args.num_replicates = len(split_idxss)
+
+        else:
+            splitting_data = all_data[args.split_key_molecule]
+
+            if isinstance(splitting_data[0], ReactionDatapoint):
+                splitting_mols = [datapoint.rct for datapoint in splitting_data]
+            else:
+                splitting_mols = [datapoint.mol for datapoint in splitting_data]
+            train_indices, val_indices, test_indices = make_split_indices(
+                splitting_mols, args.split, args.split_sizes, args.data_seed, args.num_replicates
+            )
+
+        train_data, val_data, test_data = split_data_by_indices(
+            all_data, train_indices, val_indices, test_indices
+        )
+        for i_split in range(len(train_data)):
+            sizes = [len(train_data[i_split][0]), len(val_data[i_split][0]), len(test_data[i_split][0])]
+            logger.info(f"train/val/test split_{i_split} sizes: {sizes}")
 
     return train_data, val_data, test_data
 

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -126,7 +126,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
         "--data-path",
         type=Path,
         nargs="*",
-        help="Path to an input CSV file containing SMILES and the associated target values",
+        help="Path to one, two, or three input CSV file containing SMILES and the associated target values. If one data file is supplied, it will undergo train-val-test split; if two are supplied, the first will undergo train-val split and the second will be taken as test data; if three are supplied, they will be taken as train, val, test data respectively",
     )
     parser.add_argument(
         "-o",

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -700,25 +700,3 @@ def test_custom_activation_quick(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
-
-
-def test_empty_testset(monkeypatch, data_path):
-    input_path, *_ = data_path
-    args = [
-        "chemprop",
-        "train",
-        "-i",
-        input_path,
-        "--smiles-columns",
-        "smiles",
-        "--target-columns",
-        "lipo",
-        "--split-sizes",
-        "0.5",
-        "0.5",
-        "0",
-    ]
-
-    with monkeypatch.context() as m:
-        m.setattr("sys.argv", args)
-        main()

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -700,3 +700,25 @@ def test_custom_activation_quick(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+
+def test_empty_testset(monkeypatch, data_path):
+    input_path, *_ = data_path
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        "smiles",
+        "--target-columns",
+        "lipo",
+        "--split-sizes",
+        "0.5",
+        "0.5",
+        "0",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -727,26 +727,13 @@ def test_empty_testset(monkeypatch, data_path):
 def test_multiple_data_files(monkeypatch, data_path):
     input_path, *_ = data_path
 
-    args = [
-        "chemprop",
-        "train",
-        "-i",
-        input_path,
-        input_path,
-        input_path,
-    ]
+    args = ["chemprop", "train", "-i", input_path, input_path, input_path]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
 
-    args = [
-        "chemprop",
-        "train",
-        "-i",
-        input_path,
-        input_path,
-    ]
+    args = ["chemprop", "train", "-i", input_path, input_path]
 
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -722,3 +722,32 @@ def test_empty_testset(monkeypatch, data_path):
     with monkeypatch.context() as m:
         m.setattr("sys.argv", args)
         main()
+
+
+def test_multiple_data_files(monkeypatch, data_path):
+    input_path, *_ = data_path
+
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        input_path,
+        input_path,
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        input_path,
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()


### PR DESCRIPTION
## Description
Allow the --data-path flag for training to take in 1, 2, or 3 paths, such that users can supply train+val and test data in separate files, or train, val, and test each separately.

## Example / Current workflow
The current workflow requires users to have train, val, test data all in one file, while per issue #1080 users might have test data that are separate from their train/val data.

## Bugfix / Desired workflow
The new workflow allows users to input paths to up to 3 different files. If 3 paths are provided, the corresponding files will be processed into train, val, test data, respectively; if 2 paths are provided, the first will undergo train-val split, and the second will be taken as test data; if 1 path is provided, we simply follow the original workflow.

## Questions
The support for multiple paths described above is not expanded to common flags like --atom-descriptors-path and --bond-descriptors-path, as they are already set to take in an optional second argument. As a result, users would have to follow the original workflow (ie. collecting train/val/test into same file) if they want to apply bond/atom descriptors through a separate path. Depending on user needs, we should potentially also refactor these descriptor flags to expand the scope of the multiple data paths support.

## Relevant issues
#1080 

## Checklist
- [Yes] linted with flake8?
- [Yes] unit tests added?
