### PR TITLE
make `hpopt` use `--tracking-metric`

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -387,8 +387,7 @@ def train_model(config, args, train_dset, val_dset, logger, output_transform, in
         else:
             T_tracking_metric = model.criterion.__class__
     else:
-        T_tracking_metric = MetricRegistry[args.tracking_metric]
-        args.tracking_metric = "val/" + args.tracking_metric
+        T_tracking_metric = MetricRegistry[args.tracking_metric.split("/")[1]]
 
     monitor_mode = "max" if T_tracking_metric.higher_is_better else "min"
     logger.debug(f"Evaluation metric: '{T_tracking_metric.alias}', mode: '{monitor_mode}'")
@@ -585,6 +584,7 @@ def main(args: Namespace):
 
     if args.tracking_metric != "val_loss":  # i.e. non-default
         T_tracking_metric = MetricRegistry[args.tracking_metric]
+        args.tracking_metric = "val/" + args.tracking_metric
         monitor_mode = "max" if T_tracking_metric.higher_is_better else "min"
     else:
         if isinstance(train_loader.dataset, MolAtomBondDataset):

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -582,7 +582,7 @@ def main(args: Namespace):
     train_loader = build_dataloader(
         train_dset, args.batch_size, args.num_workers, seed=args.data_seed
     )
-    
+
     if args.tracking_metric != "val_loss":  # i.e. non-default
         T_tracking_metric = MetricRegistry[args.tracking_metric]
         monitor_mode = "max" if T_tracking_metric.higher_is_better else "min"
@@ -590,7 +590,9 @@ def main(args: Namespace):
         if isinstance(train_loader.dataset, MolAtomBondDataset):
             model = build_MAB_model(args, train_loader.dataset, output_transform, input_transforms)
             monitor_mode = (
-                "max" if next(m[0].higher_is_better for m in model.metricss if m is not None) else "min"
+                "max"
+                if next(m[0].higher_is_better for m in model.metricss if m is not None)
+                else "min"
             )
         else:
             model = build_model(args, train_loader.dataset, output_transform, input_transforms)

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -582,15 +582,20 @@ def main(args: Namespace):
     train_loader = build_dataloader(
         train_dset, args.batch_size, args.num_workers, seed=args.data_seed
     )
-
-    if isinstance(train_loader.dataset, MolAtomBondDataset):
-        model = build_MAB_model(args, train_loader.dataset, output_transform, input_transforms)
-        monitor_mode = (
-            "max" if next(m[0].higher_is_better for m in model.metricss if m is not None) else "min"
-        )
+    
+    if args.tracking_metric != "val_loss":  # i.e. non-default
+        T_tracking_metric = MetricRegistry[args.tracking_metric]
+        args.tracking_metric = "val/" + args.tracking_metric
+        monitor_mode = "max" if T_tracking_metric.higher_is_better else "min"
     else:
-        model = build_model(args, train_loader.dataset, output_transform, input_transforms)
-        monitor_mode = "max" if model.metrics[0].higher_is_better else "min"
+        if isinstance(train_loader.dataset, MolAtomBondDataset):
+            model = build_MAB_model(args, train_loader.dataset, output_transform, input_transforms)
+            monitor_mode = (
+                "max" if next(m[0].higher_is_better for m in model.metricss if m is not None) else "min"
+            )
+        else:
+            model = build_model(args, train_loader.dataset, output_transform, input_transforms)
+            monitor_mode = "max" if model.metrics[0].higher_is_better else "min"
 
     results = tune_model(
         args, train_dset, val_dset, logger, monitor_mode, output_transform, input_transforms

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -583,6 +583,17 @@ def main(args: Namespace):
     )
 
     if args.tracking_metric != "val_loss":  # i.e. non-default
+        if any(
+            cols is not None
+            for cols in [
+                args.mol_target_columns,
+                args.atom_target_columns,
+                args.bond_target_columns,
+            ]
+        ):
+            raise NotImplementedError(
+                "`val_loss` is the only implemented tracking metric for hpopt when training on atom and bond targets. Open an issue on the GitHub repo if you would like us to add support for other tracking metrics in hpopt: https://github.com/chemprop/chemprop/issues"
+            )
         T_tracking_metric = MetricRegistry[args.tracking_metric]
         args.tracking_metric = "val/" + args.tracking_metric
         monitor_mode = "max" if T_tracking_metric.higher_is_better else "min"

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -585,7 +585,6 @@ def main(args: Namespace):
     
     if args.tracking_metric != "val_loss":  # i.e. non-default
         T_tracking_metric = MetricRegistry[args.tracking_metric]
-        args.tracking_metric = "val/" + args.tracking_metric
         monitor_mode = "max" if T_tracking_metric.higher_is_better else "min"
     else:
         if isinstance(train_loader.dataset, MolAtomBondDataset):

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -468,7 +468,7 @@ def add_train_args(parser: ArgumentParser) -> ArgumentParser:
     train_args.add_argument(
         "--tracking-metric",
         default="val_loss",
-        help="The metric to track for early stopping and checkpointing. Defaults to the criterion used during training. When training on two or three of molecule, atom, and bond targets, and not tracking the default ('val_loss'), you must append '-mol', '-atom', or '-bond' to the metric name to specify which individual metric to track. For example, 'val_loss-bond' will track the criterion value of the bond predictions and 'rmse-atom' will track the RMSE of the atom predictions.",
+        help="The metric to track for early stopping, checkpointing, and hyperparameter optimization. Defaults to the criterion used during training. When training on two or three of molecule, atom, and bond targets, and not tracking the default ('val_loss'), you must append '-mol', '-atom', or '-bond' to the metric name to specify which individual metric to track. For example, 'val_loss-bond' will track the criterion value of the bond predictions and 'rmse-atom' will track the RMSE of the atom predictions.",
     )
     train_args.add_argument(
         "--show-individual-scores",


### PR DESCRIPTION
## Description
Changes hyperparameter optimization to use the given `--tracking-metric` to decide on the best trial, rather than using the metric used for training.

## Example / Current workflow
Currently, the `--tracking-metric` is used to control early stopping and model checkpointing, but is not used to decide which hyperparameter configuration during hyperparameter optimization is the best (`hpopt` instead uses the training metric).

## Bugfix / Desired workflow
The above is changed by moving some of the logic checking the tracking metric around.

## Questions
Works locally (I was able to set the hpopt tracking metric via the CLI) just need to get CI running.

## Relevant issues
Closes #1254

## Checklist
- [x] linted with flake8?
- [ ] (if appropriate) unit tests added?
