### PR TITLE
Fix Windows failures from torch._C import * missing DLL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         # test on all platforms with both supported versions of Python
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [windows-latest]
         python-version: [3.11, 3.12]
     steps:
       - uses: actions/checkout@v4
@@ -93,6 +93,7 @@ jobs:
       - name: Test with pytest
         shell: bash -l {0}
         run: |
+          conda list
           pytest -v tests
       - name: Test notebooks 
         shell: bash -l {0}


### PR DESCRIPTION
The tests on windows started failing two days ago https://github.com/chemprop/chemprop/actions/runs/17261484960/job/48983809506

Previously they worked
https://github.com/chemprop/chemprop/actions/runs/17232561235/job/48889827741

My first commit is just to see if package versions changed.