### PR TITLE
Allow overriding automatic `drop_last` Detection

### DIFF
--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -162,7 +162,7 @@ def make_fingerprint_for_model(
     else:
         test_dset = test_dsets[0]
 
-    test_loader = data.build_dataloader(test_dset, args.batch_size, args.num_workers, shuffle=False)
+    test_loader = data.build_dataloader(test_dset, args.batch_size, args.num_workers, shuffle=False, drop_last=False)
 
     logger.info(model)
 

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -162,7 +162,9 @@ def make_fingerprint_for_model(
     else:
         test_dset = test_dsets[0]
 
-    test_loader = data.build_dataloader(test_dset, args.batch_size, args.num_workers, shuffle=False, drop_last=False)
+    test_loader = data.build_dataloader(
+        test_dset, args.batch_size, args.num_workers, shuffle=False, drop_last=False
+    )
 
     logger.info(model)
 

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -271,7 +271,9 @@ def prepare_data_loader(
     ]
     dset = data.MulticomponentDataset(dsets) if multicomponent else dsets[0]
 
-    return data.build_dataloader(dset, args.batch_size, args.num_workers, shuffle=False, drop_last=False)
+    return data.build_dataloader(
+        dset, args.batch_size, args.num_workers, shuffle=False, drop_last=False
+    )
 
 
 def make_prediction_for_models(

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -271,7 +271,7 @@ def prepare_data_loader(
     ]
     dset = data.MulticomponentDataset(dsets) if multicomponent else dsets[0]
 
-    return data.build_dataloader(dset, args.batch_size, args.num_workers, shuffle=False)
+    return data.build_dataloader(dset, args.batch_size, args.num_workers, shuffle=False, drop_last=False)
 
 
 def make_prediction_for_models(

--- a/chemprop/data/dataloader.py
+++ b/chemprop/data/dataloader.py
@@ -31,6 +31,7 @@ def build_dataloader(
     class_balance: bool = False,
     seed: int | None = None,
     shuffle: bool = True,
+    drop_last: bool | None = None,
     **kwargs,
 ):
     """Return a :obj:`~torch.utils.data.DataLoader` for :class:`MolGraphDataset`\s
@@ -51,6 +52,9 @@ def build_dataloader(
         the random seed to use for shuffling (only used when `shuffle` is `True`).
     shuffle : bool, default=False
         whether to shuffle the data during sampling.
+    drop_last : bool, default=None
+        Whether to drop the last batch if it is of size 1 (needed if using batchnorm during training).
+        If None, this will be set automatically.
     """
 
     if class_balance:
@@ -69,14 +73,15 @@ def build_dataloader(
     else:
         collate_fn = collate_batch
 
-    if len(dataset) % batch_size == 1:
-        logger.warning(
-            f"Dropping last batch of size 1 to avoid issues with batch normalization \
-(dataset size = {len(dataset)}, batch_size = {batch_size})"
-        )
-        drop_last = True
-    else:
-        drop_last = False
+    if drop_last is None:
+        if len(dataset) % batch_size == 1:
+            logger.warning(
+                f"Dropping last batch of size 1 to avoid issues with batch normalization \
+    (dataset size = {len(dataset)}, batch_size = {batch_size})"
+            )
+            drop_last = True
+        else:
+            drop_last = False
 
     return DataLoader(
         dataset,


### PR DESCRIPTION
## Description
See #1298 - running fingerprinting on a single compound fails because `drop_last` will be set to `true` automatically.

## Bugfix / Desired workflow
This CLI-exclusive change overrides the automatic `drop_last` detection during inference and fingerprint (the latter was reported as broken, but I realized the former will also be broken).

## Relevant issues
Resolves #1298 

## Checklist
- [x] linted with flake8?
~~- [ ] (if appropriate) unit tests added?~~ N/A
