### PR TITLE
Focal loss

### DIFF
--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -7,6 +7,7 @@ from torch.nn import functional as F
 import torchmetrics
 from torchmetrics.utilities.compute import auc
 from torchmetrics.utilities.data import dim_zero_cat
+from torchvision.ops import sigmoid_focal_loss
 
 from chemprop.utils.registry import ClassRegistry
 
@@ -618,16 +619,7 @@ class FocalLoss(ChempropMetric):
     def _calc_unreduced_loss(self, preds: Tensor, targets: Tensor, *args) -> Tensor:
         alpha = self.alpha if self.alpha is not None else 0.25 if self.alpha_mode == "auto" else self.alpha_mode
 
-        p = torch.sigmoid(preds)
-        bce = F.binary_cross_entropy_with_logits(preds, targets, reduction="none")
-
-        p_t = torch.where(targets == 1, p, 1 - p)
-        focal_weight = (1 - p_t) ** self.gamma
-
-        alpha_weight = torch.where(targets == 1, alpha, 1 - alpha)
-        focal_loss = alpha_weight * focal_weight * bce
-
-        return focal_loss
+        return sigmoid_focal_loss(preds, targets, alpha=alpha, gamma=self.gamma, reduction="none")
 
     def extra_repr(self) -> str:
         alpha_str = f"{self.alpha:.3f}" if self.alpha is not None else self.alpha_mode

--- a/tests/unit/nn/test_loss_functions.py
+++ b/tests/unit/nn/test_loss_functions.py
@@ -503,8 +503,21 @@ def test_Wasserstein(
 
 
 @pytest.mark.parametrize(
-    "preds,targets,mask,weights,task_weights,lt_mask,gt_mask,alpha_mode,expected_type",
+    "preds,targets,mask,weights,task_weights,lt_mask,gt_mask,alpha_mode,gamma,expected_loss",
     [
+
+        (
+            torch.tensor([2.0, -2.0], dtype=torch.float),
+            torch.tensor([1.0, 0.0], dtype=torch.float),
+            torch.ones([2], dtype=torch.bool),
+            torch.ones(1),
+            torch.ones(2),
+            torch.zeros([2], dtype=torch.bool),
+            torch.zeros([2], dtype=torch.bool),
+            0.25,
+            2.0,
+            torch.tensor(0.000902, dtype=torch.float),
+        ),
         (
             torch.tensor([2.0, -2.0], dtype=torch.float),
             torch.tensor([1.0, 0.0], dtype=torch.float),
@@ -514,7 +527,8 @@ def test_Wasserstein(
             torch.zeros([2], dtype=torch.bool),
             torch.zeros([2], dtype=torch.bool),
             "auto",
-            float,
+            2.0,
+            torch.tensor(0.000902, dtype=torch.float),
         ),
         (
             torch.tensor([2.0, -2.0, 1.0, -1.0], dtype=torch.float),
@@ -525,20 +539,21 @@ def test_Wasserstein(
             torch.zeros([4], dtype=torch.bool),
             torch.zeros([4], dtype=torch.bool),
             0.3,
-            float,
+            2.0,
+            torch.tensor(0.006115, dtype=torch.float),
         ),
     ],
 )
 def test_FocalLoss(
-    preds, targets, mask, weights, task_weights, lt_mask, gt_mask, alpha_mode, expected_type
+    preds, targets, mask, weights, task_weights, lt_mask, gt_mask, alpha_mode, gamma, expected_loss
 ):
     """
     Test on the FocalLoss function with automatic and manual alpha.
+    Values have been manually calculated for the first test case.
     """
-    focal_loss = FocalLoss(task_weights=task_weights, alpha=alpha_mode, gamma=2.0)
+    focal_loss = FocalLoss(task_weights=task_weights, alpha=alpha_mode, gamma=gamma)
     loss = focal_loss(preds, targets, mask, weights, lt_mask, gt_mask)
-    assert isinstance(loss.item(), expected_type)
-    assert loss.item() >= 0
+    torch.testing.assert_close(loss, expected_loss, rtol=1e-4, atol=1e-5)
 
 
 # TODO: Add quantile loss tests


### PR DESCRIPTION
Hi Chemprop team! 

# Add Focal Loss for Class Imbalance Handling

## Description
Focal loss down-weights easy examples and focuses training on hard misclassified samples, which is especially useful for imbalanced datasets where the positive class is rare.

## Example / Current workflow
Training with Binary Cross-Entropy (BCE) on imbalanced data (e.g., 10:1 negative:positive ratio):

```python
from chemprop.nn.metrics import BCELoss

loss_fn = BCELoss()
# Model trains equally on all samples, easy negatives dominate training
# Poor performance on minority (positive) class
```

## Desired workflow
Using Focal Loss with automatic alpha adaptation:

```python
from chemprop.nn.metrics import FocalLoss

# Auto alpha calculated from class frequencies
loss_fn = FocalLoss(alpha="auto", gamma=2.0)
# For 10:1 imbalance → alpha ≈ 0.09 (weights positive class appropriately)
# Hard examples (misclassifications) get higher loss
# Better minority class performance
```

Or with manual alpha specification:

```python
loss_fn = FocalLoss(alpha=0.25, gamma=2.0)  # Standard focal loss configuration
```

## Implementation Details

### Key Features
- **Automatic alpha calculation**: Computes `alpha = (1 - pos_ratio) / (1 + pos_ratio)` from training data on first batch
- **Manual alpha mode**: Accepts fixed alpha values (0.0-1.0) for fine-grained control
- **Configurable gamma**: Controls focusing strength to downweight easy examples (default 2.0, typical range 1.5-2.0)
- **Drop-in replacement**: Uses identical interface as other chemprop loss functions (BCE, MCC, etc.)

## Reference
[Pytorch](https://docs.pytorch.org/vision/stable/_modules/torchvision/ops/focal_loss.html)
[Blog](https://www.baeldung.com/cs/focal-loss)

## Checklist
- [X] linted with flake8?
- [X] (if appropriate) unit tests added?
