### PR TITLE
Feature/point quantile loss

### DIFF
--- a/chemprop/nn/metrics.py
+++ b/chemprop/nn/metrics.py
@@ -49,6 +49,7 @@ __all__ = [
     "SID",
     "Wasserstein",
     "QuantileLoss",
+    "PointQuantileLoss",
 ]
 
 
@@ -582,11 +583,14 @@ class QuantileLoss(ChempropMetric):
         return f"alpha={self.alpha}"
 
 
-@LossFunctionRegistry.register(["quantile_single", "pinball_single"])
-class QuantileSingleLoss(ChempropMetric):
+@LossFunctionRegistry.register(["quantile_point", "pinball_point"])
+class PointQuantileLoss(ChempropMetric):
     """
-    Single-output pinball (quantile) loss operating on one prediction per task.
+    Point-based pinball (quantile) loss operating on one prediction per task.
     Expects preds and targets shaped [batch, num_tasks].
+
+    This is distinct from :class:`QuantileLoss` which uses interval-based predictions
+    (mean + interval, shape [batch, num_tasks, 2]).
     """
 
     def __init__(self, task_weights: ArrayLike = 1.0, alpha: float = 0.1):

--- a/tests/unit/nn/test_loss_functions.py
+++ b/tests/unit/nn/test_loss_functions.py
@@ -14,6 +14,7 @@ from chemprop.nn.metrics import (
     EvidentialLoss,
     MulticlassMCCLoss,
     MVELoss,
+    PointQuantileLoss,
     Wasserstein,
 )
 
@@ -501,4 +502,221 @@ def test_Wasserstein(
     torch.testing.assert_close(loss, expected_loss)
 
 
-# TODO: Add quantile loss tests
+@pytest.mark.parametrize(
+    "preds,targets,mask,weights,task_weights,lt_mask,gt_mask,alpha,expected_loss",
+    [
+        # Basic test: prediction below target (diff > 0)
+        (
+            torch.tensor([[1.0], [2.0]], dtype=torch.float),
+            torch.tensor([[2.0], [3.0]], dtype=torch.float),
+            torch.ones([2, 1], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([1]),
+            torch.zeros([2, 1], dtype=torch.bool),
+            torch.zeros([2, 1], dtype=torch.bool),
+            0.1,
+            torch.tensor(0.1, dtype=torch.float),  # alpha * (2-1) = 0.1
+        ),
+        # Basic test: prediction above target (diff < 0)
+        (
+            torch.tensor([[2.0], [3.0]], dtype=torch.float),
+            torch.tensor([[1.0], [2.0]], dtype=torch.float),
+            torch.ones([2, 1], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([1]),
+            torch.zeros([2, 1], dtype=torch.bool),
+            torch.zeros([2, 1], dtype=torch.bool),
+            0.1,
+            torch.tensor(0.9, dtype=torch.float),  # (1-alpha) * (2-1) = 0.9
+        ),
+        # Perfect prediction (diff = 0)
+        (
+            torch.tensor([[1.0], [2.0]], dtype=torch.float),
+            torch.tensor([[1.0], [2.0]], dtype=torch.float),
+            torch.ones([2, 1], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([1]),
+            torch.zeros([2, 1], dtype=torch.bool),
+            torch.zeros([2, 1], dtype=torch.bool),
+            0.1,
+            torch.tensor(0.0, dtype=torch.float),
+        ),
+        # Mixed case: one above, one below
+        (
+            torch.tensor([[1.0], [3.0]], dtype=torch.float),
+            torch.tensor([[2.0], [2.0]], dtype=torch.float),
+            torch.ones([2, 1], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([1]),
+            torch.zeros([2, 1], dtype=torch.bool),
+            torch.zeros([2, 1], dtype=torch.bool),
+            0.1,
+            torch.tensor(0.5, dtype=torch.float),  # (0.1*1.0 + 0.9*1.0)/2 = 0.5
+        ),
+        # Different alpha value (median regression, alpha=0.5)
+        (
+            torch.tensor([[1.0], [3.0]], dtype=torch.float),
+            torch.tensor([[2.0], [2.0]], dtype=torch.float),
+            torch.ones([2, 1], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([1]),
+            torch.zeros([2, 1], dtype=torch.bool),
+            torch.zeros([2, 1], dtype=torch.bool),
+            0.5,
+            torch.tensor(0.5, dtype=torch.float),  # (0.5*1 + 0.5*1)/2 = 0.5
+        ),
+        # Multiple tasks
+        (
+            torch.tensor([[1.0, 2.0], [3.0, 1.0]], dtype=torch.float),
+            torch.tensor([[2.0, 1.0], [2.0, 2.0]], dtype=torch.float),
+            torch.ones([2, 2], dtype=torch.bool),
+            torch.ones([2]),
+            torch.ones([2]),
+            torch.zeros([2, 2], dtype=torch.bool),
+            torch.zeros([2, 2], dtype=torch.bool),
+            0.1,
+            torch.tensor(0.5, dtype=torch.float),  # Average across all tasks
+        ),
+    ],
+)
+def test_PointQuantileLoss(
+    preds, targets, mask, weights, task_weights, lt_mask, gt_mask, alpha, expected_loss
+):
+    """
+    Test the PointQuantileLoss (pinball loss) function.
+    The pinball loss is: alpha * max(0, target - pred) + (1-alpha) * max(0, pred - target)
+    """
+    quantile_loss = PointQuantileLoss(task_weights=task_weights, alpha=alpha)
+    loss = quantile_loss(preds, targets, mask, weights, lt_mask, gt_mask)
+    torch.testing.assert_close(loss, expected_loss, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "preds,targets,mask,weights,task_weights,lt_mask,gt_mask,alpha",
+    [
+        # Test with mask
+        (
+            torch.tensor([[1.0], [2.0], [3.0]], dtype=torch.float),
+            torch.tensor([[2.0], [3.0], [4.0]], dtype=torch.float),
+            torch.tensor([[1], [1], [0]], dtype=torch.bool),
+            torch.ones([3]),
+            torch.ones([1]),
+            torch.zeros([3, 1], dtype=torch.bool),
+            torch.zeros([3, 1], dtype=torch.bool),
+            0.1,
+        ),
+        # Test with sample weights
+        (
+            torch.tensor([[1.0], [2.0]], dtype=torch.float),
+            torch.tensor([[2.0], [3.0]], dtype=torch.float),
+            torch.ones([2, 1], dtype=torch.bool),
+            torch.tensor([0.5, 2.0]),
+            torch.ones([1]),
+            torch.zeros([2, 1], dtype=torch.bool),
+            torch.zeros([2, 1], dtype=torch.bool),
+            0.1,
+        ),
+        # Test with task weights
+        (
+            torch.tensor([[1.0, 2.0]], dtype=torch.float),
+            torch.tensor([[2.0, 3.0]], dtype=torch.float),
+            torch.ones([1, 2], dtype=torch.bool),
+            torch.ones([1]),
+            torch.tensor([0.5, 2.0]),
+            torch.zeros([1, 2], dtype=torch.bool),
+            torch.zeros([1, 2], dtype=torch.bool),
+            0.1,
+        ),
+    ],
+)
+def test_PointQuantileLoss_with_masks_and_weights(
+    preds, targets, mask, weights, task_weights, lt_mask, gt_mask, alpha
+):
+    """
+    Test PointQuantileLoss with masks and weights.
+    The loss should be properly weighted and masked.
+    """
+    quantile_loss = PointQuantileLoss(task_weights=task_weights, alpha=alpha)
+    loss = quantile_loss(preds, targets, mask, weights, lt_mask, gt_mask)
+
+    # Loss should be a scalar (averaged)
+    assert loss.numel() == 1
+    assert loss.item() >= 0  # Loss should be non-negative
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0],
+)
+def test_PointQuantileLoss_alpha_values(alpha):
+    """
+    Test PointQuantileLoss with different alpha values.
+    Alpha should be in [0, 1] and represents the quantile level.
+    """
+    preds = torch.tensor([[1.0], [3.0]], dtype=torch.float)
+    targets = torch.tensor([[2.0], [2.0]], dtype=torch.float)
+    mask = torch.ones([2, 1], dtype=torch.bool)
+    weights = torch.ones([2])
+    task_weights = torch.ones([1])
+    lt_mask = torch.zeros([2, 1], dtype=torch.bool)
+    gt_mask = torch.zeros([2, 1], dtype=torch.bool)
+
+    quantile_loss = PointQuantileLoss(task_weights=task_weights, alpha=alpha)
+    loss = quantile_loss(preds, targets, mask, weights, lt_mask, gt_mask)
+
+    # Loss should be non-negative
+    assert loss.item() >= 0
+
+    # For alpha=0.5 (median), loss should be symmetric
+    if alpha == 0.5:
+        # Swapping preds should give same loss
+        preds_swapped = torch.tensor([[3.0], [1.0]], dtype=torch.float)
+        loss_swapped = quantile_loss(preds_swapped, targets, mask, weights, lt_mask, gt_mask)
+        torch.testing.assert_close(loss, loss_swapped, rtol=1e-5, atol=1e-5)
+
+
+def test_PointQuantileLoss_extra_repr():
+    """
+    Test that extra_repr returns the correct string representation.
+    """
+    quantile_loss = PointQuantileLoss(alpha=0.25)
+    repr_str = quantile_loss.extra_repr()
+    assert "alpha=0.25" in repr_str
+
+
+def test_PointQuantileLoss_mathematical_correctness():
+    """
+    Test mathematical correctness of the pinball loss formula.
+    For a given alpha and difference d = target - pred:
+    - If d > 0: loss = alpha * d
+    - If d <= 0: loss = (1 - alpha) * (-d)
+    """
+    alpha = 0.2
+    quantile_loss = PointQuantileLoss(alpha=alpha)
+
+    # Case 1: pred < target (d > 0)
+    preds = torch.tensor([[1.0]], dtype=torch.float)
+    targets = torch.tensor([[3.0]], dtype=torch.float)
+    mask = torch.ones([1, 1], dtype=torch.bool)
+    weights = torch.ones([1])
+    lt_mask = torch.zeros([1, 1], dtype=torch.bool)
+    gt_mask = torch.zeros([1, 1], dtype=torch.bool)
+
+    loss = quantile_loss(preds, targets, mask, weights, lt_mask, gt_mask)
+    expected = alpha * (targets - preds).item()  # alpha * 2.0 = 0.4
+    torch.testing.assert_close(loss, torch.tensor(expected), rtol=1e-5, atol=1e-5)
+
+    # Case 2: pred > target (d < 0)
+    preds = torch.tensor([[3.0]], dtype=torch.float)
+    targets = torch.tensor([[1.0]], dtype=torch.float)
+
+    loss = quantile_loss(preds, targets, mask, weights, lt_mask, gt_mask)
+    expected = (1 - alpha) * (preds - targets).item()  # 0.8 * 2.0 = 1.6
+    torch.testing.assert_close(loss, torch.tensor(expected), rtol=1e-5, atol=1e-5)
+
+    # Case 3: pred == target (d = 0)
+    preds = torch.tensor([[2.0]], dtype=torch.float)
+    targets = torch.tensor([[2.0]], dtype=torch.float)
+
+    loss = quantile_loss(preds, targets, mask, weights, lt_mask, gt_mask)
+    torch.testing.assert_close(loss, torch.tensor(0.0), rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Description
This PR adds `PointQuantileLoss`, a single-output quantile (pinball) loss function for regression tasks. This addresses the limitation that the existing `QuantileLoss` requires interval-based predictions (mean + interval, shape `[batch, num_tasks, 2]`), which is not suitable for models that output single point predictions per task.

## Example / Current workflow

**Current limitation with `QuantileLoss`:**
```python
from chemprop.nn.metrics import QuantileLoss

# QuantileLoss requires predictions with shape [batch, num_tasks, 2]
# First dimension is mean, second is interval
preds = torch.tensor([[[2.0, 0.5], [3.0, 0.8]]])  # Shape: [1, 2, 2]
targets = torch.tensor([[2.0, 3.0]])  # Shape: [1, 2]

loss_fn = QuantileLoss(alpha=0.1)
loss = loss_fn(preds, targets, mask, weights, lt_mask, gt_mask)
```

**Problem:** If your model outputs single point predictions (shape `[batch, num_tasks]`), you cannot use `QuantileLoss` without modifying your model architecture to output intervals.

## Bugfix / Desired workflow

**New `PointQuantileLoss` for point predictions:**
```python
from chemprop.nn.metrics import PointQuantileLoss

# PointQuantileLoss works with standard point predictions
preds = torch.tensor([[2.0, 3.0]])  # Shape: [1, 2] - single prediction per task
targets = torch.tensor([[2.0, 3.0]])  # Shape: [1, 2]

loss_fn = PointQuantileLoss(alpha=0.1)
loss = loss_fn(preds, targets, mask, weights, lt_mask, gt_mask)
```

**Via registry (CLI usage):**
```bash
chemprop train --loss-function quantile_point --alpha 0.1 ...
# or
chemprop train --loss-function pinball_point --alpha 0.1 ...
```

**Key differences:**
- `QuantileLoss`: Requires `[batch, num_tasks, 2]` predictions (mean + interval)
- `PointQuantileLoss`: Works with `[batch, num_tasks]` predictions (single point per task)

**Implementation details:**
- Implements standard quantile loss (pinball loss) formula:
  - When `pred < target`: `loss = alpha * (target - pred)`
  - When `pred >= target`: `loss = (1 - alpha) * (pred - target)`
- Supports all standard ChempropMetric features:
  - Task weights
  - Sample weights
  - Masking
  - Multi-task regression

## Questions
None

## Relevant issues
Fixes #1324 - "[v2 FEATURE]: Add single-output quantile/pinball loss for regression"

This PR implements the requested single-output quantile loss function as described [here](https://towardsdatascience.com/quantile-loss-and-quantile-regression-b0689c13f54d/) that operates on point predictions rather than interval-based predictions.

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?

**Test coverage:**
- 18 unit tests covering:
  - Basic functionality (predictions above/below target, perfect predictions)
  - Different alpha values (0.0 to 1.0, including median regression at 0.5)
  - Mask and weight handling
  - Mathematical correctness
- All tests passing
- Code formatted and linted (flake8, isort)
