### PR TITLE
Make MAB with missing values work in pandas 3

### DIFF
--- a/chemprop/cli/utils/MAB_parsing.py
+++ b/chemprop/cli/utils/MAB_parsing.py
@@ -106,10 +106,11 @@ def build_MAB_data_from_files(
         bonds_ys = df[bond_target_cols] if bond_target_cols is not None else None
 
         if mol_ys is not None:
-            mol_ys = mol_ys.astype(str)
-            lt_mask = mol_ys.map(lambda x: "<" in x).to_numpy()
-            gt_mask = mol_ys.map(lambda x: ">" in x).to_numpy()
-            mol_ys = mol_ys.map(lambda x: x.strip("<").strip(">")).to_numpy(np.single)
+            lt_mask = mol_ys.apply(lambda x: x.str.contains("<", na=False), axis=1).to_numpy()
+            gt_mask = mol_ys.apply(lambda x: x.str.contains(">", na=False), axis=1).to_numpy()
+            mol_ys = mol_ys.apply(lambda x: x.str.strip("<").str.strip(">"), axis=1).to_numpy(
+                np.single
+            )
         else:
             mol_ys = [None] * n_datapoints
 

--- a/tests/integration/test_bounded_MAB.py
+++ b/tests/integration/test_bounded_MAB.py
@@ -20,10 +20,9 @@ def dataloader():
     atoms_ys = df_input.loc[:, columns[3:5]]
     bonds_ys = df_input.loc[:, columns[5:7]]
 
-    mol_ys = mol_ys.astype(str)
-    lt_mask = mol_ys.map(lambda x: "<" in x).to_numpy()
-    gt_mask = mol_ys.map(lambda x: ">" in x).to_numpy()
-    mol_ys = mol_ys.map(lambda x: x.strip("<").strip(">")).to_numpy(np.single)
+    lt_mask = mol_ys.apply(lambda x: x.str.contains("<", na=False), axis=1).to_numpy()
+    gt_mask = mol_ys.apply(lambda x: x.str.contains(">", na=False), axis=1).to_numpy()
+    mol_ys = mol_ys.apply(lambda x: x.str.strip("<").str.strip(">"), axis=1).to_numpy(np.single)
 
     atoms_ys = atoms_ys.map(ast.literal_eval)
     atom_lt_masks = atoms_ys.map(lambda L: ["<" in v if v else False for v in L])


### PR DESCRIPTION
Tests are failing because pandas has updated to 3.0.0 which changes how nans are handled in string Series. They are now converted to float("nan") instead of left as "nan". 

This means using `"<" in x` won't work. I have updated our parsing to use `Series.str.contains` which has the `na=False` option. 

The atom and bond versions don't need to change because they already use an `if v` statement. Perhaps they could be also changed to use `Series.str.contains`, but I haven't actually tested to confirm it is faster (I just assume it is) and that would be more work for something that doesn't need to be optimized. 

To test the changes I ran this code:
```
import pandas as pd
from pathlib import Path
import numpy as np

data_dir = Path("tests") / "data" / "mol_atom_bond"
df_input = pd.read_csv(data_dir / "bounded.csv")
columns = ["smiles", "mol_y1", "mol_y2", "atom_y1", "atom_y2", "bond_y1", "bond_y2", "weight"]
smis = df_input.loc[:, columns[0]].values
mol_ys = df_input.loc[:, columns[1:3]]
atoms_ys = df_input.loc[:, columns[3:5]]
bonds_ys = df_input.loc[:, columns[5:7]]

mol_ys_1 = mol_ys.astype(str)
lt_mask_1 = mol_ys_1.map(lambda x: "<" in x).to_numpy()
mol_ys_1 = mol_ys_1.map(lambda x: x.strip("<").strip(">")).to_numpy(np.single)
mol_ys_1, lt_mask_1

lt_mask_2 = mol_ys.apply(lambda x: x.str.contains("<", na=False), axis=1).to_numpy()
mol_ys_2 = mol_ys.apply(lambda x: x.str.strip("<").str.strip(">"), axis=1).to_numpy(np.single)
mol_ys_2, lt_mask_2

assert np.array_equal(mol_ys_1, mol_ys_2, equal_nan=True)
assert np.array_equal(lt_mask_1, lt_mask_2)
```