### PR TITLE
Update 2.2.2_requirements.txt

### DIFF
--- a/requirements/2.2.1_requirements.txt
+++ b/requirements/2.2.1_requirements.txt
@@ -9,10 +9,9 @@ chemprop==2.2.1
 colorama==0.4.6
 ConfigArgParse==1.7.1
 contourpy==1.3.3
-cuik_molmaker==0.1
 cycler==0.12.1
 darkdetect==0.8.0
-descriptastorus==2.7.0
+descriptastorus==2.7.0.5
 dill==0.4.0
 et_xmlfile==2.0.0
 filelock==3.18.0

--- a/requirements/2.2.2_requirements.txt
+++ b/requirements/2.2.2_requirements.txt
@@ -13,11 +13,8 @@ chemprop==2.2.2
 colorama==0.4.6
 ConfigArgParse==1.7.1
 contourpy==1.3.3
-# cuik_molmaker only has two releases: 0.1a1 and 0.2; 0.2 fails to install
-cuik_molmaker==0.1a1
 cycler==0.12.1
 darkdetect==0.8.0
-# descriptastorus==2.7.0 is a yanked version
 descriptastorus==2.7.0.5
 dill==0.4.0
 et_xmlfile==2.0.0
@@ -58,7 +55,6 @@ pandas==2.3.3
 pandas-flavor==0.8.1
 patsy==1.0.2
 pillow==12.1.0
-# latest pip
 pip==26.0.1
 plotly==6.5.2
 propcache==0.3.1
@@ -75,8 +71,7 @@ python-dateutil==2.9.0.post0
 pytorch-lightning==2.6.0
 pytz==2025.2
 PyYAML==6.0.3
-# cuik_molmaker==0.1a1 requires rdkit==2024.03.4
-rdkit==2024.03.4
+rdkit==2025.3.2
 reportlab==4.4.9
 requests==2.32.5
 rich==14.2.0
@@ -88,7 +83,6 @@ setuptools==75.8.2
 six==1.17.0
 SQLAlchemy==2.0.45
 statsmodels==0.14.6
-# sympy==1.13.1 is required by torch==2.6.0
 sympy==1.13.1
 tabulate==0.9.0
 threadpoolctl==3.6.0


### PR DESCRIPTION
some changes are required so that pip can install w/o any error chemprop-2.2.2 in a python-3.11.14 env

## Relevant issues

related to https://github.com/chemprop/chemprop/issues/1331