### PR TITLE
Remove exit line mistake

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1387,7 +1387,6 @@ def build_model(
                 raise ValueError(
                     f"Inconsistent number of components ({train_dset.n_components}) and number of --depth arguments ({len(args.depth)}, {args.depth})."
                 )
-            exit
             mp_blocks = [
                 mp_cls(
                     train_dset.datasets[i].featurizer.atom_fdim,


### PR DESCRIPTION
In #1280, I accidently left in a line of debugging code: `exit`. This didn't get caught by our tests because `exit` is automatically added to the script's namespace by the `site` module. In this case `exit` is just a no-op.
```
$ python
Python 3.11.14 | packaged by conda-forge | (main, Oct 22 2025, 22:46:25) [GCC 14.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
Ctrl click to launch VS Code Native REPL
>>> type(exit)
<class '_sitebuiltins.Quitter'>
>>> exit
Use exit() or Ctrl-D (i.e. EOF) to exit
>>> 
```
But if you use the CLI code from a jupyter notebook `from chemprop.cli.train import build_model`, then `exit` is not in the namespace of the imported module and you get an error [like this](https://github.com/chemprop/chemprop-contrib/actions/runs/22829096397/job/68091364646?pr=5) `NameError: name 'exit' is not defined`. We purposefully don't use the CLI code from a notebook in the chemprop repo, but some people do so we should fix it. But I don't think we need to add a test to check if the CLI code works from a notebook...

[This PR](https://github.com/chemprop/chemprop-contrib/pull/5) on `chemprop-contrib` at least needs this fix, so we should probably push v2.2.3 after merging this. I have verified that this change fixes the error seen on that PR. 
