### PR TITLE
Fix `--descriptors-columns` compat with `pandas>=3`

### DIFF
--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -64,7 +64,7 @@ def parse_csv(
         input_cols = [df.columns[0]]
 
     descriptor_cols = list(descriptor_cols or [])
-    X_d_extra = df[descriptor_cols].to_numpy(np.single) if descriptor_cols else None
+    X_d_extra = df[descriptor_cols].to_numpy(np.single, copy=True) if descriptor_cols else None
 
     if target_cols is None:
         target_cols = list(

--- a/tests/cli/test_cli_regression_mol.py
+++ b/tests/cli/test_cli_regression_mol.py
@@ -934,6 +934,27 @@ def test_save_data_splits(monkeypatch, data_path, tmp_path):
     assert (tmp_path / "test_atom_feat_0.npz").exists()
 
 
+def test_descriptors_column(monkeypatch, data_with_descriptors_path):
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        data_with_descriptors_path,
+        "--target-columns",
+        "y",
+        "--descriptors-columns",
+        "temperature",
+        "--splits-column",
+        "split",
+        "--epochs",
+        "3",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
 def test_descriptors_columns(monkeypatch, data_with_descriptors_path):
     args = [
         "chemprop",


### PR DESCRIPTION
This line of code worked with previous versions of `pandas` because it would (unintentionally) return a copy, but in modern pandas it returns a view which is not writeable, causing this error during execution:

```
Wrote config file to output/fold_0/config.toml
Traceback (most recent call last):
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/bin/chemprop", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/cli/main.py", line 85, in main
    func(args)
    ~~~~^^^^^^
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/cli/train.py", line 116, in func
    main(args)
    ~~~~^^^^^^
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/cli/train.py", line 2206, in main
    splits = build_splits(args, format_kwargs, featurization_kwargs)
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/cli/train.py", line 1114, in build_splits
    train_data = [make_data(args.data_path[0])]
                  ~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/cli/train.py", line 1096, in make_data
    return build_data_from_files(
        data_path,
    ...<7 lines>...
        **featurization_kwargs,
    )
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/cli/utils/parsing.py", line 470, in build_data_from_files
    mol_data, rxn_data = make_datapoints(
                         ~~~~~~~~~~~~~~~^
        smiss,
        ^^^^^^
    ...<10 lines>...
        **featurization_kwargs,
        ^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/cli/utils/parsing.py", line 387, in make_datapoints
    MoleculeDatapoint(
    ~~~~~~~~~~~~~~~~~^
        mol=molss[mol_idx][i],
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
        V_d=V_dss[mol_idx][i],
        ^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "<string>", line 14, in __init__
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/data/datapoints.py", line 113, in __post_init__
    super().__post_init__()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jackson/miniconda3/envs/chemeleon_atropisomers/lib/python3.13/site-packages/chemprop/data/datapoints.py", line 37, in __post_init__
    self.x_d[np.isnan(self.x_d)] = NAN_TOKEN
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^
ValueError: assignment destination is read-only
```

This fixes it, and is backwards compatible with pandas 2 (which had this argument, but did not always returns views)