### PR TITLE
Capture stderr in --logfile so terminal stays silent (#1357)

### DIFF
--- a/chemprop/cli/main.py
+++ b/chemprop/cli/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 import sys
 
@@ -50,6 +51,97 @@ def construct_parser():
     return parser
 
 
+def _resolve_log_path(logfile: str, mode: str) -> Path:
+    if logfile == "default":
+        (LOG_DIR / mode).mkdir(parents=True, exist_ok=True)
+        return LOG_DIR / mode / f"{NOW}.log"
+    log_path = Path(logfile)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    return log_path
+
+
+def _safe_fileno(stream) -> int | None:
+    try:
+        return stream.fileno()
+    except (AttributeError, OSError, ValueError):
+        return None
+
+
+def _redirect_streams_to(log_path: Path) -> dict:
+    """Redirect Python and OS-level stdout/stderr to ``log_path``.
+
+    Returns the state needed to restore them. The OS-level ``os.dup2`` is
+    required so that Lightning's rich progress bar (which captures
+    ``sys.stderr`` at import time) writes into the log file too. See
+    chemprop#1357.
+
+    If a stream has no underlying OS file descriptor (e.g. when pytest is
+    capturing at ``sys`` level, or sys.stdout has been replaced with a
+    StringIO), the fd-level redirect for that stream is skipped. Setup is
+    rollback-safe: if any step fails, partial redirects are undone and the
+    log file is closed before the exception propagates.
+    """
+    log_stream = open(log_path, "a", encoding="utf-8", errors="backslashreplace", buffering=1)
+
+    saved_stdout_fd: int | None = None
+    saved_stderr_fd: int | None = None
+    saved_stdout, saved_stderr = sys.stdout, sys.stderr
+    stdout_fd: int | None = None
+    stderr_fd: int | None = None
+    stdout_redirected = False
+    stderr_redirected = False
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        stdout_fd = _safe_fileno(sys.stdout)
+        stderr_fd = _safe_fileno(sys.stderr)
+        if stdout_fd is not None:
+            saved_stdout_fd = os.dup(stdout_fd)
+            os.dup2(log_stream.fileno(), stdout_fd)
+            stdout_redirected = True
+        if stderr_fd is not None:
+            saved_stderr_fd = os.dup(stderr_fd)
+            os.dup2(log_stream.fileno(), stderr_fd)
+            stderr_redirected = True
+        sys.stdout = log_stream
+        sys.stderr = log_stream
+    except BaseException:
+        if stdout_redirected and saved_stdout_fd is not None:
+            os.dup2(saved_stdout_fd, stdout_fd)
+        if stderr_redirected and saved_stderr_fd is not None:
+            os.dup2(saved_stderr_fd, stderr_fd)
+        if saved_stdout_fd is not None:
+            os.close(saved_stdout_fd)
+        if saved_stderr_fd is not None:
+            os.close(saved_stderr_fd)
+        log_stream.close()
+        raise
+
+    return {
+        "stream": log_stream,
+        "saved_stdout": saved_stdout,
+        "saved_stderr": saved_stderr,
+        "saved_stdout_fd": saved_stdout_fd,
+        "saved_stderr_fd": saved_stderr_fd,
+        "stdout_fd": stdout_fd,
+        "stderr_fd": stderr_fd,
+    }
+
+
+def _restore_streams(state: dict) -> None:
+    log_stream = state["stream"]
+    log_stream.flush()
+    if state["saved_stdout_fd"] is not None:
+        os.dup2(state["saved_stdout_fd"], state["stdout_fd"])
+        os.close(state["saved_stdout_fd"])
+    if state["saved_stderr_fd"] is not None:
+        os.dup2(state["saved_stderr_fd"], state["stderr_fd"])
+        os.close(state["saved_stderr_fd"])
+    sys.stdout = state["saved_stdout"]
+    sys.stderr = state["saved_stderr"]
+    log_stream.close()
+
+
 def main():
     parser = construct_parser()
     args = parser.parse_args()
@@ -60,26 +152,42 @@ def main():
     if v_flag and q_count:
         parser.error("The -v and -q options cannot be used together.")
 
-    match logfile:
-        case None:
+    # When --logfile is set, redirect output to the log file at both the
+    # Python and OS level. The OS-level dup2 is required because Lightning's
+    # ``rich``-based progress bar captures ``sys.stderr`` when its console
+    # is constructed (at import time), so a pure ``sys.stderr = ...``
+    # reassignment misses progress-bar output. See chemprop#1357.
+    redirect_state = None
+    handler = None
+    if logfile is not None:
+        log_path = _resolve_log_path(logfile, mode)
+        redirect_state = _redirect_streams_to(log_path)
+
+    try:
+        if redirect_state is None:
             handler = logging.StreamHandler(sys.stderr)
-        case "default":
-            (LOG_DIR / mode).mkdir(parents=True, exist_ok=True)
-            handler = logging.FileHandler(str(LOG_DIR / mode / f"{NOW}.log"))
-        case _:
-            Path(logfile).parent.mkdir(parents=True, exist_ok=True)
-            handler = logging.FileHandler(logfile)
+        else:
+            handler = logging.StreamHandler(redirect_state["stream"])
 
-    verbosity = q_count * -1 if q_count else (1 if v_flag else 0)
-    logging_level = LOG_LEVELS.get(verbosity, logging.ERROR)
-    logging.basicConfig(
-        handlers=[handler],
-        format="%(asctime)s - %(levelname)s:%(name)s - %(message)s",
-        level=logging_level,
-        datefmt="%Y-%m-%dT%H:%M:%S",
-        force=True,
-    )
+        verbosity = q_count * -1 if q_count else (1 if v_flag else 0)
+        logging_level = LOG_LEVELS.get(verbosity, logging.ERROR)
+        logging.basicConfig(
+            handlers=[handler],
+            format="%(asctime)s - %(levelname)s:%(name)s - %(message)s",
+            level=logging_level,
+            datefmt="%Y-%m-%dT%H:%M:%S",
+            force=True,
+        )
 
-    logger.info(f"Running in mode '{mode}' with args: {vars(args)}")
+        logger.info(f"Running in mode '{mode}' with args: {vars(args)}")
 
-    func(args)
+        func(args)
+    finally:
+        if redirect_state is not None:
+            # Detach and close the file-backed handler, restore streams, and
+            # close the file even if anything above raised, so later
+            # in-process invocations of main() start fresh.
+            if handler is not None:
+                logging.root.removeHandler(handler)
+                handler.close()
+            _restore_streams(redirect_state)

--- a/tests/cli/test_logfile.py
+++ b/tests/cli/test_logfile.py
@@ -1,0 +1,116 @@
+"""Tests for ``--logfile`` stream handling (chemprop#1357)."""
+
+import logging
+import sys
+
+import pytest
+
+from chemprop.cli.main import main
+
+
+@pytest.fixture
+def data_path(data_dir):
+    return str(data_dir / "regression" / "mol" / "mol.csv")
+
+
+def _train_args(input_path, save_dir, extra=()):
+    return [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--epochs",
+        "3",
+        "--num-workers",
+        "0",
+        "--save-dir",
+        str(save_dir),
+        *extra,
+    ]
+
+
+@pytest.mark.CLI
+def test_logfile_captures_stderr_writes_through_main(
+    monkeypatch, tmp_path, data_path, capfd
+):
+    """A run with --logfile must write all stderr output (including
+    Lightning's rich-based banner that historically leaked to the console)
+    to the file and leave the console silent. This is the regression
+    reported in chemprop#1357."""
+    log_path = tmp_path / "run.log"
+    args = _train_args(data_path, tmp_path / "out", ("--logfile", str(log_path)))
+
+    capfd.readouterr()  # discard anything captured before this test
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+    captured = capfd.readouterr()
+
+    assert log_path.exists() and log_path.stat().st_size > 0
+    content = log_path.read_text()
+    assert "Running in mode 'train'" in content
+    # Lightning's rank-zero banner is written to ``sys.stderr`` via a
+    # rich.Console captured at import time; without the fd-level redirect
+    # it would still appear on the terminal even when --logfile is set.
+    assert "GPU available" in content or "TPU available" in content
+    # And the terminal must stay silent.
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+@pytest.mark.CLI
+def test_logfile_restores_streams_after_main(monkeypatch, tmp_path, data_path):
+    """main() must restore sys.stdout/sys.stderr so a later invocation without
+    --logfile does not keep writing to the previous log file."""
+    log_path = tmp_path / "run.log"
+    saved_stdout, saved_stderr = sys.stdout, sys.stderr
+    args = _train_args(data_path, tmp_path / "out", ("--logfile", str(log_path)))
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+    assert sys.stdout is saved_stdout
+    assert sys.stderr is saved_stderr
+
+
+@pytest.mark.CLI
+def test_logfile_then_no_logfile_does_not_pollute(monkeypatch, tmp_path, data_path):
+    """Reentrancy: a second main() call without --logfile must not append to
+    the first run's log file."""
+    log_path = tmp_path / "first.log"
+    args1 = _train_args(data_path, tmp_path / "out1", ("--logfile", str(log_path)))
+    args2 = _train_args(data_path, tmp_path / "out2")
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args1)
+        main()
+
+    size_after_first = log_path.stat().st_size
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args2)
+        main()
+
+    assert log_path.stat().st_size == size_after_first
+
+
+@pytest.mark.CLI
+def test_logfile_default_branch_creates_file(monkeypatch, tmp_path, data_path):
+    """The bare ``--log`` form (logfile=='default') must produce a writable
+    log file under LOG_DIR/<mode>/."""
+    from chemprop.cli.conf import LOG_DIR
+
+    args = _train_args(data_path, tmp_path / "out", ("--log",))
+
+    before = {p for p in (LOG_DIR / "train").glob("*.log")} if (LOG_DIR / "train").exists() else set()
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+    after = {p for p in (LOG_DIR / "train").glob("*.log")}
+    new_logs = after - before
+
+    assert new_logs, "expected --log to create a new log file under LOG_DIR/train/"
+    new_log = next(iter(new_logs))
+    assert "Running in mode 'train'" in new_log.read_text()
+    new_log.unlink()


### PR DESCRIPTION
Fixes #1357.

## Summary

When `--logfile` is set, output written outside the python `logging`
framework — most visibly Lightning's `rich`-based progress bar and the
`GPU available` / `TPU available` rank-zero banner — still leaked to
the console because the existing `FileHandler` only wired up python
logging.

This redirects `sys.stdout`/`sys.stderr` at both the Python level and
the OS level (via `os.dup2`) when `--logfile` is provided. The
OS-level redirect is what makes Lightning's banner land in the file:
its `rich.Console` is constructed at import time and captures the
original `sys.stderr` object by reference, so a pure Python-level
reassignment misses it.

A `try/finally` in `main()` restores both streams (and removes/closes
the file-backed logging handler) on every exit path, so a later
in-process call to `main()` — which already happens across the test
suite — starts fresh. `_redirect_streams_to` is rollback-safe: if a
mid-setup `dup2` fails, prior redirects are undone and the log file
is closed before the exception propagates. Streams without an
underlying OS fd (e.g. pytest's `sys`-level capture, `StringIO`) fall
back to Python-only redirect.

JacksonBurns flagged in #1357 that the previous behavior was
intentional under older Lightning versions that used `tqdm` (where
including stderr in the logfile would render it unreadable), but that
Lightning now uses `rich` and this could be revisited — that's what
this PR does.

## Verification

End-to-end with `--logfile`:

```
$ chemprop train -i tests/data/regression/mol/mol.csv --epochs 3 \
      --num-workers 0 --save-dir out --logfile run.log \
      > term.out 2> term.err
$ wc -l term.out term.err run.log
       0 term.out
       0 term.err
     402 run.log
$ grep -E "GPU available|max_epochs.*reached" run.log
GPU available: True (mps), used: True
`Trainer.fit` stopped: `max_epochs=3` reached.
```

Without `--logfile` everything still streams to the terminal as before.

## Tests

`tests/cli/test_logfile.py` adds 4 integration tests through `main()`:

- `test_logfile_captures_stderr_writes_through_main` — uses `capfd` to
  assert the terminal stays silent and the Lightning banner lands in
  the log file (this is the regression in #1357).
- `test_logfile_restores_streams_after_main` — `sys.stdout`/`sys.stderr`
  are the original objects after `main()` returns.
- `test_logfile_then_no_logfile_does_not_pollute` — a second `main()`
  call without `--logfile` does not append to the first run's file.
- `test_logfile_default_branch_creates_file` — bare `--log` writes to
  `LOG_DIR/<mode>/<timestamp>.log`.

```
$ pytest -q tests/cli/test_logfile.py tests/cli/test_parsing.py \
         tests/cli/test_cli_utils.py tests/cli/test_cli_classification_mol.py
43 passed
```

## Test plan

- [x] All 4 new tests pass locally
- [x] `tests/cli/test_parsing.py`, `test_cli_utils.py`,
  `test_cli_classification_mol.py` still pass (43 total)
- [x] End-to-end manual verification (`--logfile` keeps terminal silent;
  no `--logfile` prints to terminal as before)
- [ ] CI green on PR