### PR TITLE
V_ds is never None in multi

### DIFF
--- a/chemprop/models/multi.py
+++ b/chemprop/models/multi.py
@@ -44,7 +44,7 @@ class MulticomponentMPNN(MPNN):
     def fingerprint(
         self,
         bmgs: Iterable[BatchMolGraph],
-        V_ds: Iterable[Tensor | None],
+        V_ds: Iterable[Tensor | None] | None = None,
         X_d: Tensor | None = None,
     ) -> Tensor:
         H_vs: list[Tensor] = self.message_passing(bmgs, V_ds)

--- a/chemprop/nn/message_passing/multi.py
+++ b/chemprop/nn/message_passing/multi.py
@@ -60,13 +60,15 @@ class MulticomponentMessagePassing(nn.Module, HasHParams):
 
         return d_o
 
-    def forward(self, bmgs: Iterable[BatchMolGraph], V_ds: Iterable[Tensor | None]) -> list[Tensor]:
+    def forward(
+        self, bmgs: Iterable[BatchMolGraph], V_ds: Iterable[Tensor | None] | None = None
+    ) -> list[Tensor]:
         """Encode the multicomponent inputs
 
         Parameters
         ----------
         bmgs : Iterable[BatchMolGraph]
-        V_ds : Iterable[Tensor | None]
+        V_ds : Iterable[Tensor | None] | None
 
         Returns
         -------


### PR DESCRIPTION
I noticed the type hint for V_ds here is `Iterable[Tensor | None]`, but we check `if V_ds is None`. The relevant line in collate.py is `[tb.V_d for tb in tbs]`, so the type hint is correct. This means our if statement is always false and can be removed. 