### PR TITLE
feat: parse CXSMILES wD/wU tags to distinguish atropisomers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+## Project
+
+Chemprop v2.2.3 — message passing neural networks for molecular property prediction. CLI tool + Python library backed by PyTorch Lightning.
+
+## Quick Start
+
+```
+pip install -e ".[dev,test]"
+pytest tests                          # runs unit + CLI tests with coverage
+pytest tests -m integration           # runs integration tests (overfit checks, slower)
+```
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Install editable | `pip install -e ".[dev,test]"` |
+| Format check | `black --check .` |
+| Format fix | `black .` |
+| Import sort check | `isort --check .` |
+| Import sort fix | `isort .` |
+| Lint | `flake8 .` |
+| Run tests | `pytest` (runs with `--cov chemprop` by default) |
+| Tests without coverage | `pytest --no-cov` |
+| Only unit tests | `pytest tests/unit` |
+| Only CLI tests | `pytest tests/cli` |
+| Only integration tests | `pytest tests/integration` |
+| Single test file | `pytest tests/unit/nn/test_metrics.py -v` |
+| Single test by name | `pytest tests/unit/nn/test_metrics.py::test_name -v` |
+| Build package | `python -m build .` |
+
+CI pipeline order: build -> lint (black, flake8, isort) -> test.
+
+## Formatting Rules
+
+- **black**: v23 required, `line-length = 100`, `skip-magic-trailing-comma = true`, target py311
+- **isort**: profile = "black", `line_length = 100`, `force_sort_within_sections = true`
+- **flake8**: `max-line-length = 100`, ignores E203 E266 E501 F403 E741 W503 W605; `__init__.py` ignores F401; see `.flake8` for per-file ignores
+
+## Architecture
+
+```
+chemprop/
+  cli/          # CLI subcommands: train, predict, convert, fingerprint, hpopt
+  data/         # Dataset/Datapoint classes, dataloaders, splits
+  featurizers/  # Molecule/reaction featurization (RDKit-based)
+  models/       # MPNN, MolAtomBondMPNN, MulticomponentMPNN
+  nn/           # Message passing layers, FFNs, aggregations, metrics, predictors
+  schedulers/   # Learning rate schedulers
+  uncertainty/  # Uncertainty quantification methods
+  utils/        # Shared utilities
+```
+
+Entrypoint: `chemprop.cli.main:main` (registered as `chemprop` console script).
+
+## Testing Gotchas
+
+- `tests/conftest.py` defines shared fixtures: `smis`, `mols`, `targets`, `data_dir`, regression/classification data fixtures
+- `tests/integration/conftest.py` defines session-scoped MPNN model fixtures (parametrized by message passing type + aggregation)
+- Integration tests verify overfitting on small datasets — they train real models, expect `accelerator="cpu"`
+- Pre-trained model files (`*.pt`, `*.ckpt`) live in `tests/data/` and are gitignored except under `!tests/data/*` in `.gitignore`. Regenerate with `tests/regenerate_models.sh <conda_env> <repo_path>`.
+- pytest markers: `integration`, `CLI`
+- Default pytest `addopts = "--cov chemprop"` — use `--no-cov` when running integration tests or notebooks for speed
+
+## Python Constraints
+
+- `requires-python = ">=3.11,<3.15"` — supports 3.11, 3.12, 3.13, 3.14
+- Core deps: `torch >= 2.1`, `lightning >= 2.0`, `rdkit`, `astartes[molecules]`
+
+## Known Inconsistency
+
+The edge update function in all versions uses preactivation instead of postactivation initial edge hidden states (documented in v2 paper SI).

--- a/chemprop/cli/common.py
+++ b/chemprop/cli/common.py
@@ -97,6 +97,11 @@ def add_common_args(parser: ArgumentParser) -> ArgumentParser:
         action="store_true",
         help="Reorder atoms in the Chem.Mol object using the specified atom map numbers",
     )
+    data_args.add_argument(
+        "--cxsmiles-stereo",
+        action="store_true",
+        help="Parse CXSMILES |wD/wU| metadata and set chiral tags on atropisomer axis atoms so they produce different molecular representations",
+    )
     featurization_args.add_argument(
         "--molecule-featurizers",
         "--features-generators",

--- a/chemprop/cli/fingerprint.py
+++ b/chemprop/cli/fingerprint.py
@@ -111,6 +111,7 @@ def make_fingerprint_for_model(
         add_h=args.add_h,
         ignore_stereo=args.ignore_stereo,
         reorder_atoms=args.reorder_atoms,
+        cxsmiles_stereo=args.cxsmiles_stereo,
     )
 
     if mol_atom_bond:

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -569,6 +569,7 @@ def main(args: Namespace):
         ignore_stereo=args.ignore_stereo,
         reorder_atoms=args.reorder_atoms,
         use_cuikmolmaker_featurization=args.use_cuikmolmaker_featurization,
+        cxsmiles_stereo=args.cxsmiles_stereo,
     )
 
     train_data, val_data, test_data = build_splits(args, format_kwargs, featurization_kwargs)

--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -302,6 +302,7 @@ def prepare_data_loader(
         add_h=args.add_h,
         ignore_stereo=args.ignore_stereo,
         reorder_atoms=args.reorder_atoms,
+        cxsmiles_stereo=args.cxsmiles_stereo,
     )
 
     if mol_atom_bond:

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -2201,6 +2201,7 @@ def main(args):
         ignore_stereo=args.ignore_stereo,
         reorder_atoms=args.reorder_atoms,
         use_cuikmolmaker_featurization=args.use_cuikmolmaker_featurization,
+        cxsmiles_stereo=args.cxsmiles_stereo,
     )
 
     splits = build_splits(args, format_kwargs, featurization_kwargs)

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -142,6 +142,7 @@ def make_datapoints(
     ignore_stereo: bool,
     reorder_atoms: bool,
     use_cuikmolmaker_featurization: bool,
+    cxsmiles_stereo: bool,
     n_workers: int = 0,
 ) -> tuple[
     list[list[MoleculeDatapoint]] | list[list[LazyMoleculeDatapoint]], list[list[ReactionDatapoint]]
@@ -252,6 +253,7 @@ def make_datapoints(
                 _add_h=add_h,
                 _ignore_stereo=ignore_stereo,
                 _reorder_atoms=reorder_atoms,
+                _cxsmiles_stereo=cxsmiles_stereo,
                 name=smiss[0][i],
                 y=Y[i],
                 weight=weights[i],
@@ -287,7 +289,10 @@ def make_datapoints(
         molss = [
             parallel_execute(
                 make_mol,
-                [(smi, keep_h, add_h, ignore_stereo, reorder_atoms) for smi in smis],
+                [
+                    (smi, keep_h, add_h, ignore_stereo, reorder_atoms, cxsmiles_stereo)
+                    for smi in smis
+                ],
                 n_workers=n_workers,
             )
             for smis in smiss
@@ -304,6 +309,7 @@ def make_datapoints(
                         add_h,
                         ignore_stereo,
                         reorder_atoms,
+                        cxsmiles_stereo,
                     )
                     for rct_smi, agt_smi, _ in (rxn.split(">") for rxn in rxns)
                 ],
@@ -316,7 +322,7 @@ def make_datapoints(
             parallel_execute(
                 make_mol,
                 [
-                    (pdt_smi, keep_h, add_h, ignore_stereo, reorder_atoms)
+                    (pdt_smi, keep_h, add_h, ignore_stereo, reorder_atoms, cxsmiles_stereo)
                     for _, _, pdt_smi in (rxn.split(">") for rxn in rxns)
                 ],
                 n_workers=n_workers,

--- a/chemprop/data/datapoints.py
+++ b/chemprop/data/datapoints.py
@@ -55,9 +55,10 @@ class _MoleculeDatapointMixin:
         add_h: bool = False,
         ignore_stereo: bool = False,
         reorder_atoms: bool = False,
+        cxsmiles_stereo: bool = False,
         **kwargs,
     ) -> _MoleculeDatapointMixin:
-        mol = make_mol(smi, keep_h, add_h, ignore_stereo, reorder_atoms)
+        mol = make_mol(smi, keep_h, add_h, ignore_stereo, reorder_atoms, cxsmiles_stereo)
 
         kwargs["name"] = smi if "name" not in kwargs else kwargs["name"]
 
@@ -72,6 +73,7 @@ class _LazyMoleculeDatapointMixin:
     _add_h: bool = False
     _ignore_stereo: bool = False
     _reorder_atoms: bool = False
+    _cxsmiles_stereo: bool = False
     _mol_cache: Chem.Mol = field(default=None, repr=False, compare=False)
 
     @property
@@ -79,7 +81,12 @@ class _LazyMoleculeDatapointMixin:
         """Lazily compute the molecule only when accessed"""
         if self._mol_cache is None:
             self._mol_cache = make_mol(
-                self.smiles, self._keep_h, self._add_h, self._ignore_stereo, self._reorder_atoms
+                self.smiles,
+                self._keep_h,
+                self._add_h,
+                self._ignore_stereo,
+                self._reorder_atoms,
+                self._cxsmiles_stereo,
             )
         return self._mol_cache
 
@@ -194,9 +201,17 @@ class MolAtomBondDatapoint(MoleculeDatapoint):
         add_h: bool = False,
         ignore_stereo: bool = False,
         reorder_atoms: bool = True,
+        cxsmiles_stereo: bool = False,
         **kwargs,
     ) -> MolAtomBondDatapoint:
-        mol = make_mol(smi, keep_h, add_h, ignore_stereo, reorder_atoms=reorder_atoms)
+        mol = make_mol(
+            smi,
+            keep_h,
+            add_h,
+            ignore_stereo,
+            reorder_atoms=reorder_atoms,
+            cxsmiles_stereo=cxsmiles_stereo,
+        )
 
         kwargs["name"] = smi if "name" not in kwargs else kwargs["name"]
 
@@ -218,6 +233,7 @@ class _ReactionDatapointMixin:
         keep_h: bool = False,
         add_h: bool = False,
         ignore_stereo: bool = False,
+        cxsmiles_stereo: bool = False,
         **kwargs,
     ) -> _ReactionDatapointMixin:
         match rxn_or_smis:
@@ -234,8 +250,8 @@ class _ReactionDatapointMixin:
                     " a product SMILES strings!"
                 )
 
-        rct = make_mol(rct_smi, keep_h, add_h, ignore_stereo)
-        pdt = make_mol(pdt_smi, keep_h, add_h, ignore_stereo)
+        rct = make_mol(rct_smi, keep_h, add_h, ignore_stereo, cxsmiles_stereo=cxsmiles_stereo)
+        pdt = make_mol(pdt_smi, keep_h, add_h, ignore_stereo, cxsmiles_stereo=cxsmiles_stereo)
 
         kwargs["name"] = name if "name" not in kwargs else kwargs["name"]
 

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 import os
+import re
 from typing import Any, Callable, Iterable, Iterator, Type
 
 import multiprocess
@@ -73,6 +74,9 @@ def make_mol(
     if mol is None:
         raise RuntimeError(f"SMILES {smi} is invalid! (RDKit returned None)")
 
+    if "|" in smi:
+        _apply_cxsmiles_stereo(mol, smi)
+
     if add_h:
         mol = Chem.AddHs(mol)
 
@@ -88,6 +92,51 @@ def make_mol(
         mol = Chem.rdmolops.RenumberAtoms(mol, new_order)
 
     return mol
+
+
+def _apply_cxsmiles_stereo(mol: Chem.Mol, cxsmiles: str) -> None:
+    """Parse CXSMILES wD/wU tags and set chiral tags on atropisomer axis atoms.
+
+    CXSMILES |wD:X.Y| and |wU:X.Y| tags encode bond stereochemistry for 2D rendering.
+    For atropisomers (restricted rotation around single bonds between aromatic rings),
+    these tags distinguish different 3D conformations that standard SMILES cannot encode.
+
+    This function sets tetrahedral chiral tags on the two atoms of the atropisomeric bond
+    to make them distinguishable to Chemprop's atom featurizer. wD bonds get CW/CCW tags
+    (different atoms), while wU bonds remain unspecified.
+
+    Parameters
+    ----------
+    mol : Chem.Mol
+        The RDKit molecule to modify.
+    cxsmiles : str
+        The original CXSMILES string containing |wD/wU| metadata.
+    """
+    if " |" not in cxsmiles:
+        return
+
+    _, metadata = cxsmiles.split(" |", 1)
+    metadata = metadata.strip("||")
+
+    for match in re.finditer(r"(wD|wU):(\d+)\.(\d+)", metadata):
+        kind = match.group(1)
+        atom_a, atom_b = int(match.group(2)), int(match.group(3))
+
+        if atom_a >= mol.GetNumAtoms() or atom_b >= mol.GetNumAtoms():
+            continue
+
+        if kind == "wD":
+            # wD (wedge down): set different chiral tags to distinguish the two atoms
+            # Only set tags on atoms that are currently UNSPECIFIED to avoid overwriting
+            # existing stereochemistry from the SMILES (e.g., [C@]/[C@@])
+            atom_a_obj = mol.GetAtomWithIdx(atom_a)
+            atom_b_obj = mol.GetAtomWithIdx(atom_b)
+
+            if atom_a_obj.GetChiralTag() == Chem.ChiralType.CHI_UNSPECIFIED:
+                atom_a_obj.SetChiralTag(Chem.ChiralType.CHI_TETRAHEDRAL_CW)
+            if atom_b_obj.GetChiralTag() == Chem.ChiralType.CHI_UNSPECIFIED:
+                atom_b_obj.SetChiralTag(Chem.ChiralType.CHI_TETRAHEDRAL_CCW)
+        # wU (unspecified): leave as CHI_UNSPECIFIED (default)
 
 
 def create_and_call_object(

--- a/chemprop/utils/utils.py
+++ b/chemprop/utils/utils.py
@@ -43,6 +43,7 @@ def make_mol(
     add_h: bool = False,
     ignore_stereo: bool = False,
     reorder_atoms: bool = False,
+    cxsmiles_stereo: bool = False,
 ) -> Chem.Mol:
     """build an RDKit molecule from a SMILES string.
 
@@ -61,6 +62,9 @@ def make_mol(
         whether to reorder the atoms in the molecule by their atom map numbers. This is useful when
         the order of atoms in the SMILES string does not match the atom mapping, e.g. '[F:2][Cl:1]'.
         Default is False. NOTE: This does not reorder the bonds.
+    cxsmiles_stereo : bool, optional
+        whether to parse CXSMILES |wD/wU| metadata and set chiral tags on atropisomer axis atoms
+        so they produce different molecular representations. Default is False.
 
     Returns
     -------
@@ -74,7 +78,7 @@ def make_mol(
     if mol is None:
         raise RuntimeError(f"SMILES {smi} is invalid! (RDKit returned None)")
 
-    if "|" in smi:
+    if cxsmiles_stereo:
         _apply_cxsmiles_stereo(mol, smi)
 
     if add_h:

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -51,7 +51,7 @@ def test_make_mol_invalid_smiles():
 def test_cxsmiles_wd_sets_chiral_tags():
     """wD (wedge down) sets CW/CCW chiral tags on atropisomer axis atoms."""
     cxsmiles = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wD:14.16|"
-    mol = make_mol(cxsmiles)
+    mol = make_mol(cxsmiles, cxsmiles_stereo=True)
 
     assert mol.GetAtomWithIdx(14).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CW
     assert mol.GetAtomWithIdx(16).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CCW
@@ -60,7 +60,7 @@ def test_cxsmiles_wd_sets_chiral_tags():
 def test_cxsmiles_wu_leaves_unspecified():
     """wU (wedge unspecified) leaves atropisomer axis atoms as CHI_UNSPECIFIED."""
     cxsmiles = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wU:14.16|"
-    mol = make_mol(cxsmiles)
+    mol = make_mol(cxsmiles, cxsmiles_stereo=True)
 
     assert mol.GetAtomWithIdx(14).GetChiralTag() == ChiralType.CHI_UNSPECIFIED
     assert mol.GetAtomWithIdx(16).GetChiralTag() == ChiralType.CHI_UNSPECIFIED
@@ -75,8 +75,8 @@ def test_cxsmiles_wd_produces_different_features_than_wu():
     cxsmiles_wd = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wD:14.16|"
     cxsmiles_wu = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wU:14.16|"
 
-    mol_wd = make_mol(cxsmiles_wd)
-    mol_wu = make_mol(cxsmiles_wu)
+    mol_wd = make_mol(cxsmiles_wd, cxsmiles_stereo=True)
+    mol_wu = make_mol(cxsmiles_wu, cxsmiles_stereo=True)
 
     mg_featurizer = SimpleMoleculeMolGraphFeaturizer()
     graph_wd = mg_featurizer(mol_wd)
@@ -91,7 +91,7 @@ def test_cxsmiles_preserves_existing_chiral_tags():
     """CXSMILES wD does not overwrite existing chiral tags from SMILES."""
     # C[C@@H](O) has a tetrahedral chiral center at atom 1
     cxsmiles = "C[C@@H](O)CC1=CC=C(C)C=C1 |wD:1.2|"
-    mol = make_mol(cxsmiles)
+    mol = make_mol(cxsmiles, cxsmiles_stereo=True)
 
     # Atom 1 should keep its original chiral tag from [C@@H]
     assert mol.GetAtomWithIdx(1).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CW
@@ -103,7 +103,7 @@ def test_cxsmiles_multiple_constraints():
     """Multiple wD/wU constraints on the same SMILES are all processed."""
     # wD:14.15 sets tags on atoms 14,15; wU:7.7 leaves atoms 7,7 unspecified
     cxsmiles = "O=C1C=CNC(=O)N1C(=C)[C@]([C@H](C)Br)([C@@H](F)C)[C@H](Cl)C |wD:14.15,wU:7.7|"
-    mol = make_mol(cxsmiles)
+    mol = make_mol(cxsmiles, cxsmiles_stereo=True)
 
     # wD:14.15 should set CW on atom 14, CCW on atom 15
     assert mol.GetAtomWithIdx(14).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CW
@@ -113,7 +113,7 @@ def test_cxsmiles_multiple_constraints():
 def test_cxsmiles_invalid_atom_indices_ignored():
     """CXSMILES with atom indices beyond the molecule size are silently ignored."""
     cxsmiles = "CCO |wD:99.100|"
-    mol = make_mol(cxsmiles)
+    mol = make_mol(cxsmiles, cxsmiles_stereo=True)
 
     # Should parse successfully, no chiral tags set (atoms 99,100 don't exist)
     assert mol.GetNumAtoms() == 3
@@ -130,6 +130,16 @@ def test_cxsmiles_no_metadata_unchanged():
         assert atom.GetChiralTag() == ChiralType.CHI_UNSPECIFIED
 
 
+def test_cxsmiles_disabled_by_default():
+    """CXSMILES wD/wU tags are NOT processed by default (backwards compatibility)."""
+    cxsmiles = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wD:14.16|"
+    mol = make_mol(cxsmiles)
+
+    # Without cxsmiles_stereo=True, chiral tags should NOT be set
+    for atom in mol.GetAtoms():
+        assert atom.GetChiralTag() == ChiralType.CHI_UNSPECIFIED
+
+
 def test_cxsmiles_wd_different_pairs():
     """Different wD atom pairs produce different molecular representations."""
     import numpy as np
@@ -139,8 +149,8 @@ def test_cxsmiles_wd_different_pairs():
     cxsmiles_1 = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wD:14.16|"
     cxsmiles_2 = "C1=C(C2=CC(Cl)=CC(F)=C2)C(F)=CC=C1CCCCC |wD:2.9|"
 
-    mol_1 = make_mol(cxsmiles_1)
-    mol_2 = make_mol(cxsmiles_2)
+    mol_1 = make_mol(cxsmiles_1, cxsmiles_stereo=True)
+    mol_2 = make_mol(cxsmiles_2, cxsmiles_stereo=True)
 
     mg_featurizer = SimpleMoleculeMolGraphFeaturizer()
     graph_1 = mg_featurizer(mol_1)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from rdkit.Chem import ChiralType
 
 from chemprop.utils import make_mol
 
@@ -42,3 +43,109 @@ def test_reorder_atoms_no_atom_map():
 def test_make_mol_invalid_smiles():
     with pytest.raises(RuntimeError):
         make_mol("chemprop")
+
+
+# CXSMILES wD/wU tests
+
+
+def test_cxsmiles_wd_sets_chiral_tags():
+    """wD (wedge down) sets CW/CCW chiral tags on atropisomer axis atoms."""
+    cxsmiles = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wD:14.16|"
+    mol = make_mol(cxsmiles)
+
+    assert mol.GetAtomWithIdx(14).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CW
+    assert mol.GetAtomWithIdx(16).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CCW
+
+
+def test_cxsmiles_wu_leaves_unspecified():
+    """wU (wedge unspecified) leaves atropisomer axis atoms as CHI_UNSPECIFIED."""
+    cxsmiles = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wU:14.16|"
+    mol = make_mol(cxsmiles)
+
+    assert mol.GetAtomWithIdx(14).GetChiralTag() == ChiralType.CHI_UNSPECIFIED
+    assert mol.GetAtomWithIdx(16).GetChiralTag() == ChiralType.CHI_UNSPECIFIED
+
+
+def test_cxsmiles_wd_produces_different_features_than_wu():
+    """wD and wU on the same bond produce different molecular representations."""
+    import numpy as np
+
+    from chemprop.featurizers.molgraph.molecule import SimpleMoleculeMolGraphFeaturizer
+
+    cxsmiles_wd = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wD:14.16|"
+    cxsmiles_wu = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wU:14.16|"
+
+    mol_wd = make_mol(cxsmiles_wd)
+    mol_wu = make_mol(cxsmiles_wu)
+
+    mg_featurizer = SimpleMoleculeMolGraphFeaturizer()
+    graph_wd = mg_featurizer(mol_wd)
+    graph_wu = mg_featurizer(mol_wu)
+
+    sum_wd = graph_wd.V.sum(axis=0)
+    sum_wu = graph_wu.V.sum(axis=0)
+    assert not np.array_equal(sum_wd, sum_wu)
+
+
+def test_cxsmiles_preserves_existing_chiral_tags():
+    """CXSMILES wD does not overwrite existing chiral tags from SMILES."""
+    # C[C@@H](O) has a tetrahedral chiral center at atom 1
+    cxsmiles = "C[C@@H](O)CC1=CC=C(C)C=C1 |wD:1.2|"
+    mol = make_mol(cxsmiles)
+
+    # Atom 1 should keep its original chiral tag from [C@@H]
+    assert mol.GetAtomWithIdx(1).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CW
+    # Atom 2 should get the CCW tag from wD
+    assert mol.GetAtomWithIdx(2).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CCW
+
+
+def test_cxsmiles_multiple_constraints():
+    """Multiple wD/wU constraints on the same SMILES are all processed."""
+    # wD:14.15 sets tags on atoms 14,15; wU:7.7 leaves atoms 7,7 unspecified
+    cxsmiles = "O=C1C=CNC(=O)N1C(=C)[C@]([C@H](C)Br)([C@@H](F)C)[C@H](Cl)C |wD:14.15,wU:7.7|"
+    mol = make_mol(cxsmiles)
+
+    # wD:14.15 should set CW on atom 14, CCW on atom 15
+    assert mol.GetAtomWithIdx(14).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CW
+    assert mol.GetAtomWithIdx(15).GetChiralTag() == ChiralType.CHI_TETRAHEDRAL_CCW
+
+
+def test_cxsmiles_invalid_atom_indices_ignored():
+    """CXSMILES with atom indices beyond the molecule size are silently ignored."""
+    cxsmiles = "CCO |wD:99.100|"
+    mol = make_mol(cxsmiles)
+
+    # Should parse successfully, no chiral tags set (atoms 99,100 don't exist)
+    assert mol.GetNumAtoms() == 3
+    for atom in mol.GetAtoms():
+        assert atom.GetChiralTag() == ChiralType.CHI_UNSPECIFIED
+
+
+def test_cxsmiles_no_metadata_unchanged():
+    """SMILES without CXSMILES metadata are unaffected."""
+    smi = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl"
+    mol = make_mol(smi)
+
+    for atom in mol.GetAtoms():
+        assert atom.GetChiralTag() == ChiralType.CHI_UNSPECIFIED
+
+
+def test_cxsmiles_wd_different_pairs():
+    """Different wD atom pairs produce different molecular representations."""
+    import numpy as np
+
+    from chemprop.featurizers.molgraph.molecule import SimpleMoleculeMolGraphFeaturizer
+
+    cxsmiles_1 = "C1(Cl)=C2C(F)=CC=C1CCCCCC1=C2C=C(F)C=C1Cl |wD:14.16|"
+    cxsmiles_2 = "C1=C(C2=CC(Cl)=CC(F)=C2)C(F)=CC=C1CCCCC |wD:2.9|"
+
+    mol_1 = make_mol(cxsmiles_1)
+    mol_2 = make_mol(cxsmiles_2)
+
+    mg_featurizer = SimpleMoleculeMolGraphFeaturizer()
+    graph_1 = mg_featurizer(mol_1)
+    graph_2 = mg_featurizer(mol_2)
+
+    sum_1 = graph_1.V.sum(axis=0)
+    sum_2 = graph_2.V.sum(axis=0)
+    assert not np.array_equal(sum_1, sum_2)


### PR DESCRIPTION
> [!NOTE]
> This PR was handled entirely by Qwen 3.6 27b running locally via `opencode` with @JacksonBurns' supervision

## Description

CXSMILES |wD:X.Y| and |wU:X.Y| tags encode bond stereochemistry for 2D rendering. For atropisomers (restricted rotation around single bonds between aromatic rings), these tags distinguish different 3D conformations that standard SMILES cannot encode.

## Workaround

This change adds `_apply_cxsmiles_stereo()` to `make_mol()` which:
- Parses CXSMILES wD/wU metadata from SMILES strings
- For wD: sets CHI_TETRAHEDRAL_CW/CCW on the two axis atoms
- For wU: leaves atoms as CHI_UNSPECIFIED (no distinction)
- Preserves existing chiral tags from SMILES (e.g., [C@]/[C@@])

Chemprop's atom featurizer captures chiral tags, so different tags produce different atom features and different molecular representations.

This enables Chemprop to distinguish atropisomers that would otherwise be treated as identical molecules (same canonical SMILES, different 3D conformational metadata in CXSMILES format).

## Questions

(1) This is currently 'on by default' - would impact the backwards compatibility of this option. Going to have the agent change this and add a CLI flag, but curious our thoughts
(2) This introduces atom-level stereochemistry as a workaround, though it is not physical - do we want to do that? May interfere with the model's ability to learn it (though right now, it can't learn bond level at all...)

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
