### PR TITLE
fix: validate bond_predictor input_dim accounts for reverse-edge concatenation (Fixes #1356)

### DIFF
--- a/chemprop/models/mol_atom_bond.py
+++ b/chemprop/models/mol_atom_bond.py
@@ -135,6 +135,31 @@ class MolAtomBondMPNN(pl.LightningModule):
         self.atom_predictor = atom_predictor
         self.atom_constrainer = atom_constrainer
 
+        # Validate predictor input dimensions match message passing output dimensions.
+        # Note: bond fingerprints are doubled via concatenation with reverse-edge embeddings
+        # in fingerprint(), so bond_predictor.input_dim must be 2 * output_dims[1].
+        mp_v_dim, mp_e_dim = message_passing.output_dims
+        if mol_predictor is not None and mp_v_dim is not None and mol_predictor.input_dim != mp_v_dim:
+            raise ValueError(
+                f"mol_predictor input_dim ({mol_predictor.input_dim}) does not match "
+                f"message passing vertex output dim ({mp_v_dim})."
+            )
+        if atom_predictor is not None and mp_v_dim is not None and atom_predictor.input_dim != mp_v_dim:
+            raise ValueError(
+                f"atom_predictor input_dim ({atom_predictor.input_dim}) does not match "
+                f"message passing vertex output dim ({mp_v_dim})."
+            )
+        if bond_predictor is not None and mp_e_dim is not None:
+            expected_bond_dim = mp_e_dim * 2
+            if bond_predictor.input_dim != expected_bond_dim:
+                raise ValueError(
+                    f"bond_predictor input_dim ({bond_predictor.input_dim}) does not match "
+                    f"the expected bond fingerprint dim ({expected_bond_dim}). "
+                    f"fingerprint() concatenates forward and reverse edge embeddings, "
+                    f"doubling the edge dimension from {mp_e_dim} to {expected_bond_dim}. "
+                    f"Set bond_predictor input_dim={expected_bond_dim}."
+                )
+
         if bond_predictor is not None:
 
             def wrapped_bond_fn(m, fn):

--- a/tests/unit/models/test_mol_atom_bond.py
+++ b/tests/unit/models/test_mol_atom_bond.py
@@ -20,16 +20,21 @@ def ffn():
 
 
 @pytest.fixture
-def full_model(mp, agg, ffn):
+def bond_ffn(mp):
+    return RegressionFFN(input_dim=mp.output_dims[1] * 2)
+
+
+@pytest.fixture
+def full_model(mp, agg, ffn, bond_ffn):
     return MolAtomBondMPNN(
-        message_passing=mp, agg=agg, mol_predictor=ffn, atom_predictor=ffn, bond_predictor=ffn
+        message_passing=mp, agg=agg, mol_predictor=ffn, atom_predictor=ffn, bond_predictor=bond_ffn
     )
 
 
 @pytest.fixture
-def partial_model(mp, agg, ffn):
+def partial_model(mp, agg, ffn, bond_ffn):
     return MolAtomBondMPNN(
-        message_passing=mp, agg=agg, mol_predictor=ffn, atom_predictor=None, bond_predictor=ffn
+        message_passing=mp, agg=agg, mol_predictor=ffn, atom_predictor=None, bond_predictor=bond_ffn
     )
 
 
@@ -53,3 +58,13 @@ def test_criterions_lists(full_model, partial_model):
     assert isinstance(partial_model.criterions[0], MSE)
     assert partial_model.criterions[1] is None
     assert isinstance(partial_model.criterions[2], MSE)
+
+
+def test_bond_predictor_dim_validation(mp, agg, ffn):
+    """bond_predictor with wrong input_dim should raise ValueError."""
+    wrong_bond_ffn = RegressionFFN()  # default input_dim=300, expects 600
+    with pytest.raises(ValueError, match="bond_predictor input_dim"):
+        MolAtomBondMPNN(
+            message_passing=mp, agg=agg, mol_predictor=ffn,
+            atom_predictor=ffn, bond_predictor=wrong_bond_ffn
+        )


### PR DESCRIPTION
Fixes #1356

## Problem

When creating `MolAtomBondMPNN` programmatically with a `bond_predictor` that uses the default `input_dim` (300), training fails with a cryptic `RuntimeError`:

```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (610x600 and 300x300)
```

This happens because `fingerprint()` concatenates forward and reverse edge embeddings via `torch.cat([H_e, H_e[bmg.rev_edge_index]], dim=1)`, doubling the bond dimension from 300 to 600. But the `bond_predictor`'s FFN expects 300-dim input.

The CLI code at `train.py:1720` correctly uses `input_dim=(mp.output_dims[1] * 2)`, but the `__init__` had no validation to catch this mismatch for programmatic usage.

## Solution

Add input dimension validation for all three predictor types in `MolAtomBondMPNN.__init__`. When the `bond_predictor.input_dim` doesn't match the expected `2 * output_dims[1]`, raise a clear `ValueError` explaining the dimension doubling and the correct `input_dim` value.

Also fix the unit test fixture which had the same bug (using default `input_dim=300` for the bond FFN).

## Verification

**Before fix** — user gets a cryptic RuntimeError deep in PyTorch:
```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (610x600 and 300x300)
```

**After fix** — user gets an actionable ValueError at construction time:
```
ValueError: bond_predictor input_dim (300) does not match the expected bond fingerprint dim (600).
fingerprint() concatenates forward and reverse edge embeddings, doubling the edge dimension
from 300 to 600. Set bond_predictor input_dim=600.
```

**All unit tests pass:**
```
tests/unit/models/test_mol_atom_bond.py::test_output_dimss PASSED
tests/unit/models/test_mol_atom_bond.py::test_n_taskss PASSED
tests/unit/models/test_mol_atom_bond.py::test_n_targetss PASSED
tests/unit/models/test_mol_atom_bond.py::test_criterions_lists PASSED
tests/unit/models/test_mol_atom_bond.py::test_bond_predictor_dim_validation PASSED
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
