### PR TITLE
Fix dynamic graph sizes in message passing exports

### DIFF
--- a/chemprop/nn/message_passing/base.py
+++ b/chemprop/nn/message_passing/base.py
@@ -206,7 +206,7 @@ class _MessagePassingBase(MessagePassing, HyperparametersMixin):
             H = self.update(M, H_0)
 
         index_torch = bmg.edge_index[1].unsqueeze(1).repeat(1, H.shape[1])
-        M = torch.zeros(len(bmg.V), H.shape[1], dtype=H.dtype, device=H.device).scatter_reduce_(
+        M = torch.zeros(bmg.V.shape[0], H.shape[1], dtype=H.dtype, device=H.device).scatter_reduce_(
             0, index_torch, H, reduce="sum", include_self=False
         )
         return self.finalize(M, bmg.V, V_d)

--- a/chemprop/nn/message_passing/mixins.py
+++ b/chemprop/nn/message_passing/mixins.py
@@ -10,9 +10,9 @@ class _BondMessagePassingMixin:
 
     def message(self, H: Tensor, bmg: BatchMolGraph) -> Tensor:
         index_torch = bmg.edge_index[1].unsqueeze(1).repeat(1, H.shape[1])
-        M_all = torch.zeros(len(bmg.V), H.shape[1], dtype=H.dtype, device=H.device).scatter_reduce_(
-            0, index_torch, H, reduce="sum", include_self=False
-        )[bmg.edge_index[0]]
+        M_all = torch.zeros(
+            bmg.V.shape[0], H.shape[1], dtype=H.dtype, device=H.device
+        ).scatter_reduce_(0, index_torch, H, reduce="sum", include_self=False)[bmg.edge_index[0]]
         M_rev = H[bmg.rev_edge_index]
 
         return M_all - M_rev
@@ -25,6 +25,6 @@ class _AtomMessagePassingMixin:
     def message(self, H: Tensor, bmg: BatchMolGraph):
         H = torch.cat((H, bmg.E), dim=1)
         index_torch = bmg.edge_index[1].unsqueeze(1).repeat(1, H.shape[1])
-        return torch.zeros(len(bmg.V), H.shape[1], dtype=H.dtype, device=H.device).scatter_reduce_(
-            0, index_torch, H, reduce="sum", include_self=False
-        )[bmg.edge_index[0]]
+        return torch.zeros(
+            bmg.V.shape[0], H.shape[1], dtype=H.dtype, device=H.device
+        ).scatter_reduce_(0, index_torch, H, reduce="sum", include_self=False)[bmg.edge_index[0]]

--- a/chemprop/nn/message_passing/mol_atom_bond.py
+++ b/chemprop/nn/message_passing/mol_atom_bond.py
@@ -296,7 +296,7 @@ class _MABMessagePassingBase(MABMessagePassing, HyperparametersMixin):
             H = self.update(M, H_0)
 
         index_torch = bmg.edge_index[1].unsqueeze(1).repeat(1, H.shape[1])
-        M = torch.zeros(len(bmg.V), H.shape[1], dtype=H.dtype, device=H.device).scatter_reduce_(
+        M = torch.zeros(bmg.V.shape[0], H.shape[1], dtype=H.dtype, device=H.device).scatter_reduce_(
             0, index_torch, H, reduce="sum", include_self=False
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ import numpy as np
 import pandas as pd
 import pytest
 from rdkit import Chem
+from torch.utils._pytree import GetAttrKey, register_pytree_node
+
+from chemprop.data import BatchMolGraph
 
 _DATA_DIR = Path(__file__).parent / "data"
 _DF = pd.read_csv(_DATA_DIR / "smis.csv")
@@ -12,6 +15,42 @@ _DF["mol"] = _DF["smiles"].map(Chem.MolFromSmiles)
 _DF["smi"] = _DF["mol"].map(Chem.MolToSmiles)
 # Ensure atom numbering is consistent between mol and smi for `test_same_featurization`
 _DF["mol"] = _DF["smi"].map(Chem.MolFromSmiles)
+
+
+@pytest.fixture(scope="session")
+def batch_mol_graph_pytree():
+    def flatten(bmg: BatchMolGraph):
+        return [bmg.V, bmg.E, bmg.edge_index, bmg.rev_edge_index, bmg.batch], len(bmg)
+
+    def unflatten(children, size):
+        V, E, edge_index, rev_edge_index, batch = children
+        bmg = object.__new__(BatchMolGraph)
+        bmg.V = V
+        bmg.E = E
+        bmg.edge_index = edge_index
+        bmg.rev_edge_index = rev_edge_index
+        bmg.batch = batch
+        bmg._BatchMolGraph__size = size
+        return bmg
+
+    def flatten_with_keys(bmg: BatchMolGraph):
+        children, context = flatten(bmg)
+        keys = [
+            GetAttrKey("V"),
+            GetAttrKey("E"),
+            GetAttrKey("edge_index"),
+            GetAttrKey("rev_edge_index"),
+            GetAttrKey("batch"),
+        ]
+        return list(zip(keys, children)), context
+
+    register_pytree_node(
+        BatchMolGraph,
+        flatten,
+        unflatten,
+        flatten_with_keys_fn=flatten_with_keys,
+        serialized_type_name="chemprop.data.collate.BatchMolGraph",
+    )
 
 
 @pytest.fixture

--- a/tests/integration/test_export.py
+++ b/tests/integration/test_export.py
@@ -1,0 +1,44 @@
+import torch
+
+from chemprop.data import BatchMolGraph, MoleculeDatapoint, MoleculeDataset, collate_batch
+from chemprop.models import MPNN
+from chemprop.nn import BondMessagePassing, RegressionFFN, SumAggregation
+
+
+def make_batch(smiles: list[str]) -> BatchMolGraph:
+    dataset = MoleculeDataset([MoleculeDatapoint.from_smi(smi) for smi in smiles])
+    return collate_batch(dataset)[0]
+
+
+def test_mpnn_export_dynamic_graph_sizes(batch_mol_graph_pytree):
+    export_graph = make_batch(["C", "CC"])
+    inference_graph = make_batch(["c1ccccc1", "CCCCCC"])
+    assert export_graph.V.shape[0] != inference_graph.V.shape[0]
+    assert export_graph.E.shape[0] != inference_graph.E.shape[0]
+
+    message_passing = BondMessagePassing()
+    model = MPNN(
+        message_passing, SumAggregation(), RegressionFFN(input_dim=message_passing.output_dim)
+    ).eval()
+    num_atoms = torch.export.Dim("num_atoms", min=1)
+    num_edges = torch.export.Dim("num_edges", min=1)
+    dynamic_shapes = {
+        "bmg": [{0: num_atoms}, {0: num_edges}, {1: num_edges}, {0: num_edges}, {0: num_atoms}],
+        "V_d": None,
+        "X_d": None,
+    }
+
+    with torch.inference_mode():
+        expected = model(inference_graph)
+
+    exported = torch.export.export(
+        model,
+        (export_graph,),
+        kwargs={"V_d": None, "X_d": None},
+        dynamic_shapes=dynamic_shapes,
+        strict=False,
+    )
+
+    with torch.inference_mode():
+        actual = exported.module()(inference_graph, V_d=None, X_d=None)
+    torch.testing.assert_close(actual, expected)

--- a/tests/integration/test_export.py
+++ b/tests/integration/test_export.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from chemprop.data import BatchMolGraph, MoleculeDatapoint, MoleculeDataset, collate_batch
@@ -10,18 +11,19 @@ def make_batch(smiles: list[str]) -> BatchMolGraph:
     return collate_batch(dataset)[0]
 
 
-def test_mpnn_export_dynamic_graph_sizes(batch_mol_graph_pytree):
-    export_graph = make_batch(["C", "CC"])
-    inference_graph = make_batch(["c1ccccc1", "CCCCCC"])
+@pytest.mark.usefixtures("batch_mol_graph_pytree")
+def test_mpnn_export_dynamic_graph_sizes():
+    export_graph = make_batch(["C", "CC", "CCC", "CCCC"])
+    inference_graph = make_batch(["C", "S", "N", "O"])
     assert export_graph.V.shape[0] != inference_graph.V.shape[0]
-    assert export_graph.E.shape[0] != inference_graph.E.shape[0]
+    assert inference_graph.E.shape[0] == 0
 
     message_passing = BondMessagePassing()
     model = MPNN(
         message_passing, SumAggregation(), RegressionFFN(input_dim=message_passing.output_dim)
     ).eval()
-    num_atoms = torch.export.Dim("num_atoms", min=1)
-    num_edges = torch.export.Dim("num_edges", min=1)
+    num_atoms = torch.export.Dim("num_atoms")
+    num_edges = torch.export.Dim("num_edges")
     dynamic_shapes = {
         "bmg": [{0: num_atoms}, {0: num_edges}, {1: num_edges}, {0: num_edges}, {0: num_atoms}],
         "V_d": None,

--- a/tests/unit/nn/test_message_passing.py
+++ b/tests/unit/nn/test_message_passing.py
@@ -1,9 +1,9 @@
-from typing import NamedTuple
-
+import numpy as np
 import pytest
 import torch
-from torch import Tensor
 
+from chemprop.data import BatchMolGraph
+from chemprop.data.molgraph import MolGraph
 from chemprop.nn import (
     AtomMessagePassing,
     BondMessagePassing,
@@ -12,42 +12,31 @@ from chemprop.nn import (
 )
 
 
-class MockBatchMolGraph(NamedTuple):
-    V: Tensor
-    E: Tensor
-    edge_index: Tensor
-    rev_edge_index: Tensor
-    batch: Tensor
-
-
-def make_chain_graph(num_atoms: int) -> MockBatchMolGraph:
-    src = torch.arange(num_atoms - 1)
+def make_chain_graph(num_atoms: int) -> BatchMolGraph:
+    src = np.arange(num_atoms - 1)
     dst = src + 1
-    edge_index = torch.stack((torch.cat((src, dst)), torch.cat((dst, src))))
+    edge_index = np.stack((np.concatenate((src, dst)), np.concatenate((dst, src))))
     num_edges = edge_index.shape[1]
-
-    return MockBatchMolGraph(
-        V=torch.randn(num_atoms, 72),
-        E=torch.randn(num_edges, 14),
+    mol_graph = MolGraph(
+        V=np.ones((num_atoms, 72), dtype=np.float32),
+        E=np.ones((num_edges, 14), dtype=np.float32),
         edge_index=edge_index,
-        rev_edge_index=torch.cat((torch.arange(num_atoms - 1, num_edges), src)),
-        batch=torch.zeros(num_atoms, dtype=torch.long),
+        rev_edge_index=np.concatenate((np.arange(num_atoms - 1, num_edges), src)),
     )
+    return BatchMolGraph([mol_graph])
 
 
 @pytest.mark.parametrize(
     "message_passing",
     [AtomMessagePassing(), BondMessagePassing(), MABAtomMessagePassing(), MABBondMessagePassing()],
 )
-def test_message_passing_export_dynamic_graph_sizes(message_passing):
+def test_message_passing_export_dynamic_graph_sizes(message_passing, batch_mol_graph_pytree):
     export_graph = make_chain_graph(3)
     inference_graph = make_chain_graph(5)
     num_atoms = torch.export.Dim("num_atoms", min=2)
     num_edges = torch.export.Dim("num_edges", min=2)
     dynamic_shapes = {
-        "bmg": MockBatchMolGraph(
-            {0: num_atoms}, {0: num_edges}, {1: num_edges}, {0: num_edges}, {0: num_atoms}
-        )
+        "bmg": [{0: num_atoms}, {0: num_edges}, {1: num_edges}, {0: num_edges}, {0: num_atoms}]
     }
 
     exported = torch.export.export(

--- a/tests/unit/nn/test_message_passing.py
+++ b/tests/unit/nn/test_message_passing.py
@@ -1,0 +1,59 @@
+from typing import NamedTuple
+
+import pytest
+import torch
+from torch import Tensor
+
+from chemprop.nn import (
+    AtomMessagePassing,
+    BondMessagePassing,
+    MABAtomMessagePassing,
+    MABBondMessagePassing,
+)
+
+
+class MockBatchMolGraph(NamedTuple):
+    V: Tensor
+    E: Tensor
+    edge_index: Tensor
+    rev_edge_index: Tensor
+    batch: Tensor
+
+
+def make_chain_graph(num_atoms: int) -> MockBatchMolGraph:
+    src = torch.arange(num_atoms - 1)
+    dst = src + 1
+    edge_index = torch.stack((torch.cat((src, dst)), torch.cat((dst, src))))
+    num_edges = edge_index.shape[1]
+
+    return MockBatchMolGraph(
+        V=torch.randn(num_atoms, 72),
+        E=torch.randn(num_edges, 14),
+        edge_index=edge_index,
+        rev_edge_index=torch.cat((torch.arange(num_atoms - 1, num_edges), src)),
+        batch=torch.zeros(num_atoms, dtype=torch.long),
+    )
+
+
+@pytest.mark.parametrize(
+    "message_passing",
+    [AtomMessagePassing(), BondMessagePassing(), MABAtomMessagePassing(), MABBondMessagePassing()],
+)
+def test_message_passing_export_dynamic_graph_sizes(message_passing):
+    export_graph = make_chain_graph(3)
+    inference_graph = make_chain_graph(5)
+    num_atoms = torch.export.Dim("num_atoms", min=2)
+    num_edges = torch.export.Dim("num_edges", min=2)
+    dynamic_shapes = {
+        "bmg": MockBatchMolGraph(
+            {0: num_atoms}, {0: num_edges}, {1: num_edges}, {0: num_edges}, {0: num_atoms}
+        )
+    }
+
+    exported = torch.export.export(
+        message_passing, (export_graph,), dynamic_shapes=dynamic_shapes, strict=False
+    )
+
+    expected = message_passing(inference_graph)
+    actual = exported.module()(inference_graph)
+    torch.testing.assert_close(actual, expected)

--- a/tests/unit/nn/test_message_passing.py
+++ b/tests/unit/nn/test_message_passing.py
@@ -30,7 +30,8 @@ def make_chain_graph(num_atoms: int) -> BatchMolGraph:
     "message_passing",
     [AtomMessagePassing(), BondMessagePassing(), MABAtomMessagePassing(), MABBondMessagePassing()],
 )
-def test_message_passing_export_dynamic_graph_sizes(message_passing, batch_mol_graph_pytree):
+@pytest.mark.usefixtures("batch_mol_graph_pytree")
+def test_message_passing_export_dynamic_graph_sizes(message_passing):
     export_graph = make_chain_graph(3)
     inference_graph = make_chain_graph(5)
     num_atoms = torch.export.Dim("num_atoms", min=2)


### PR DESCRIPTION
## Bug report

Addresses the dynamic graph-size portion of #1335.

Message-passing layers allocate scatter-reduction outputs with `len(bmg.V)`. During `torch.export`, that Python length is specialized to the number of atoms in the export example. Running the exported model on a molecular graph with a different atom count then fails with an out-of-bounds scatter or a dynamic-shape constraint violation.

This change uses the symbolic tensor dimension `bmg.V.shape[0]` for those allocations. The same specialization was present in the shared bond/atom mixins and in both standard and Mol-Atom-Bond final aggregation paths, so all four paths are updated consistently.

`MeanAggregation` is intentionally unchanged, following the performance concern discussed in #1335.

## Example

The regression test exports each message-passing implementation using a three-atom chain and executes the exported program using a five-atom chain. Before this patch, export rejects the atom dimension as specialized to `3`; with this patch, the exported and eager outputs match for:

- `AtomMessagePassing`
- `BondMessagePassing`
- `MABAtomMessagePassing`
- `MABBondMessagePassing`

A separate end-to-end check through ONNX Runtime, using `BondMessagePassing` and `SumAggregation`, changed from an out-of-bounds `ScatterElements` failure to successful inference with a maximum PyTorch/ONNX absolute difference of `4.47e-08`.

## Questions

None. This patch is limited to preserving dynamic graph dimensions and adds no public API, checkpoint, or user-facing behavior changes.

## Checklist

- [x] `black --check`, `isort --check-only`, and `flake8` pass on all changed files
- [x] Dynamic export regression test passes on PyTorch 2.7.0 and 2.13.0
- [x] 128 related unit and integration tests pass on PyTorch 2.7.0
- [x] Appropriate unit tests added
