### PR TITLE
Add cuik-molmaker support for MolAtomBond train/predict/hpopt

### DIFF
--- a/chemprop/cli/predict.py
+++ b/chemprop/cli/predict.py
@@ -321,6 +321,7 @@ def prepare_data_loader(
     )
 
     if mol_atom_bond:
+        featurization_kwargs["use_cuikmolmaker_featurization"] = args.use_cuikmolmaker_featurization
         datas = build_MAB_data_from_files(
             data_path,
             **format_kwargs,

--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1111,7 +1111,6 @@ def build_splits(args, format_kwargs, featurization_kwargs):
         ):
             for key in ["no_header_row", "rxn_cols", "ignore_cols", "splits_col", "target_cols"]:
                 format_kwargs.pop(key, None)
-            featurization_kwargs.pop("use_cuikmolmaker_featurization", None)
             return build_MAB_data_from_files(
                 data_path,
                 p_descriptors=args.descriptors_path,

--- a/chemprop/cli/utils/MAB_parsing.py
+++ b/chemprop/cli/utils/MAB_parsing.py
@@ -5,7 +5,7 @@ from typing import Sequence
 import numpy as np
 import pandas as pd
 
-from chemprop.data import MolAtomBondDatapoint
+from chemprop.data import LazyMolAtomBondDatapoint, MolAtomBondDatapoint
 from chemprop.featurizers.molecule import MoleculeFeaturizerRegistry
 from chemprop.utils import create_and_call_object, make_mol, parallel_execute
 
@@ -28,6 +28,7 @@ def build_MAB_data_from_files(
     molecule_featurizers: Sequence[str] | None,
     descriptor_cols: Sequence[str] | None = None,
     n_workers: int = 0,
+    use_cuikmolmaker_featurization: bool = False,
     **make_mol_kwargs,
 ):
     df = pd.read_csv(p_data, index_col=False)
@@ -35,10 +36,19 @@ def build_MAB_data_from_files(
     X_d_extra = df[descriptor_cols] if descriptor_cols else None
 
     smis = df[smiles_cols[0]].values if smiles_cols is not None else df.iloc[:, 0].values
-    mols = parallel_execute(
-        make_mol, [(smi,) + tuple(make_mol_kwargs.values()) for smi in smis], n_workers=n_workers
-    )
-    n_datapoints = len(mols)
+    n_datapoints = len(smis)
+
+    if use_cuikmolmaker_featurization:
+        # Molecules are featurized lazily (and in batch) by cuik-molmaker from the SMILES
+        # strings directly, so building `Chem.Mol`s eagerly here would defeat the memory savings
+        # that motivate the cuik-molmaker path in the first place.
+        mols = None
+    else:
+        mols = parallel_execute(
+            make_mol,
+            [(smi,) + tuple(make_mol_kwargs.values()) for smi in smis],
+            n_workers=n_workers,
+        )
 
     weights = (
         df[weight_col].values if weight_col is not None else np.ones(n_datapoints, dtype=np.single)
@@ -78,12 +88,24 @@ def build_MAB_data_from_files(
 
     if molecule_featurizers is not None:
         molecule_featurizers = [MoleculeFeaturizerRegistry[mf]() for mf in molecule_featurizers]
+        # `LazyMolAtomBondDatapoint` builds the `Chem.Mol` when its `mol` attribute is accessed
+        # instead of accepting it as an argument, so molecules must be (re-)built here to compute
+        # molecule featurizer descriptors, even under `use_cuikmolmaker_featurization`.
+        featurizer_mols = (
+            mols
+            if mols is not None
+            else parallel_execute(
+                make_mol,
+                [(smi,) + tuple(make_mol_kwargs.values()) for smi in smis],
+                n_workers=n_workers,
+            )
+        )
         mol_descriptors = np.hstack(
             [
                 np.vstack(
                     parallel_execute(
                         create_and_call_object,
-                        [(mf.__class__, (mol,)) for mol in mols],
+                        [(mf.__class__, (mol,)) for mol in featurizer_mols],
                         n_workers=n_workers,
                     )
                 )
@@ -180,6 +202,14 @@ def build_MAB_data_from_files(
                 for bond_ys in bonds_ys
             ]
             if bonds_ys[0].ndim == 3:
+                if use_cuikmolmaker_featurization:
+                    raise ValueError(
+                        "Bond targets given as a full adjacency matrix are not supported when "
+                        "using `--use-cuikmolmaker-featurization`, as flattening them to "
+                        "per-bond values requires building an RDKit `Mol` for every molecule. "
+                        "Provide bond targets as a flat list ordered by RDKit bond index instead, "
+                        "or omit `--use-cuikmolmaker-featurization`."
+                    )
                 bonds_ys_1D = []
                 for mol, bonds_y in zip(mols, bonds_ys):
                     bond_vals = [0] * mol.GetNumBonds()
@@ -232,29 +262,59 @@ def build_MAB_data_from_files(
                 ]
             )
 
-    datapoints = [
-        MolAtomBondDatapoint(
-            mol=mols[i],
-            name=smis[i],
-            y=mol_ys[i],
-            atom_y=atoms_ys[i],
-            bond_y=bonds_ys[i],
-            weight=weights[i],
-            x_d=X_ds[i],
-            V_f=V_fs[i],
-            V_d=V_ds[i],
-            E_f=E_fs[i],
-            E_d=E_ds[i],
-            lt_mask=lt_mask[i],
-            gt_mask=gt_mask[i],
-            atom_lt_mask=atom_lt_masks[i],
-            atom_gt_mask=atom_gt_masks[i],
-            bond_lt_mask=bond_lt_masks[i],
-            bond_gt_mask=bond_gt_masks[i],
-            atom_constraint=atom_constraints[i],
-            bond_constraint=bond_constraints[i],
-        )
-        for i in range(n_datapoints)
-    ]
+    if use_cuikmolmaker_featurization:
+        datapoints = [
+            LazyMolAtomBondDatapoint(
+                smiles=smis[i],
+                _keep_h=make_mol_kwargs["keep_h"],
+                _add_h=make_mol_kwargs["add_h"],
+                _ignore_stereo=make_mol_kwargs["ignore_stereo"],
+                _reorder_atoms=make_mol_kwargs["reorder_atoms"],
+                name=smis[i],
+                y=mol_ys[i],
+                atom_y=atoms_ys[i],
+                bond_y=bonds_ys[i],
+                weight=weights[i],
+                x_d=X_ds[i],
+                V_f=V_fs[i],
+                V_d=V_ds[i],
+                E_f=E_fs[i],
+                E_d=E_ds[i],
+                lt_mask=lt_mask[i],
+                gt_mask=gt_mask[i],
+                atom_lt_mask=atom_lt_masks[i],
+                atom_gt_mask=atom_gt_masks[i],
+                bond_lt_mask=bond_lt_masks[i],
+                bond_gt_mask=bond_gt_masks[i],
+                atom_constraint=atom_constraints[i],
+                bond_constraint=bond_constraints[i],
+            )
+            for i in range(n_datapoints)
+        ]
+    else:
+        datapoints = [
+            MolAtomBondDatapoint(
+                mol=mols[i],
+                name=smis[i],
+                y=mol_ys[i],
+                atom_y=atoms_ys[i],
+                bond_y=bonds_ys[i],
+                weight=weights[i],
+                x_d=X_ds[i],
+                V_f=V_fs[i],
+                V_d=V_ds[i],
+                E_f=E_fs[i],
+                E_d=E_ds[i],
+                lt_mask=lt_mask[i],
+                gt_mask=gt_mask[i],
+                atom_lt_mask=atom_lt_masks[i],
+                atom_gt_mask=atom_gt_masks[i],
+                bond_lt_mask=bond_lt_masks[i],
+                bond_gt_mask=bond_gt_masks[i],
+                atom_constraint=atom_constraints[i],
+                bond_constraint=bond_constraints[i],
+            )
+            for i in range(n_datapoints)
+        ]
 
     return [datapoints]

--- a/chemprop/cli/utils/parsing.py
+++ b/chemprop/cli/utils/parsing.py
@@ -7,6 +7,7 @@ import pandas as pd
 from torch import nn
 
 from chemprop.data.datapoints import (
+    LazyMolAtomBondDatapoint,
     LazyMoleculeDatapoint,
     MolAtomBondDatapoint,
     MoleculeDatapoint,
@@ -14,6 +15,7 @@ from chemprop.data.datapoints import (
 )
 from chemprop.data.datasets import (
     CuikmolmakerDataset,
+    CuikmolmakerMolAtomBondDataset,
     MolAtomBondDataset,
     MoleculeDataset,
     ReactionDataset,
@@ -532,7 +534,13 @@ def make_dataset(
     multi_hot_atom_featurizer_mode: Literal["V1", "V2", "ORGANIC", "RIGR"] = "V2",
     cuikmolmaker_featurization: bool = False,
     n_workers: int = 0,
-) -> MoleculeDataset | CuikmolmakerDataset | MolAtomBondDataset | ReactionDataset:
+) -> (
+    MoleculeDataset
+    | CuikmolmakerDataset
+    | MolAtomBondDataset
+    | CuikmolmakerMolAtomBondDataset
+    | ReactionDataset
+):
     atom_featurizer = get_multi_hot_atom_featurizer(multi_hot_atom_featurizer_mode)
     match multi_hot_atom_featurizer_mode:
         case "RIGR":
@@ -543,6 +551,17 @@ def make_dataset(
             raise TypeError(
                 f"Unsupported atom featurizer mode '{multi_hot_atom_featurizer_mode=}'!"
             )
+
+    if isinstance(data[0], LazyMolAtomBondDatapoint):
+        extra_atom_fdim = data[0].V_f.shape[1] if data[0].V_f is not None else 0
+        extra_bond_fdim = data[0].E_f.shape[1] if data[0].E_f is not None else 0
+        featurizer = CuikmolmakerMolGraphFeaturizer(
+            atom_featurizer_mode=multi_hot_atom_featurizer_mode,
+            extra_atom_fdim=extra_atom_fdim,
+            extra_bond_fdim=extra_bond_fdim,
+            add_h=data[0]._add_h,
+        )
+        return CuikmolmakerMolAtomBondDataset(data, featurizer)
 
     if isinstance(data[0], MolAtomBondDatapoint):
         extra_atom_fdim = data[0].V_f.shape[1] if data[0].V_f is not None else 0

--- a/chemprop/data/__init__.py
+++ b/chemprop/data/__init__.py
@@ -5,11 +5,13 @@ from .collate import (
     MulticomponentTrainingBatch,
     TrainingBatch,
     collate_batch,
+    collate_cuik_mol_atom_bond_batch,
     collate_mol_atom_bond_batch,
     collate_multicomponent,
 )
 from .dataloader import build_dataloader
 from .datapoints import (
+    LazyMolAtomBondDatapoint,
     LazyMoleculeDatapoint,
     MolAtomBondDatapoint,
     MoleculeDatapoint,
@@ -17,6 +19,7 @@ from .datapoints import (
 )
 from .datasets import (
     CuikmolmakerDataset,
+    CuikmolmakerMolAtomBondDataset,
     Datum,
     MolAtomBondDataset,
     MolAtomBondDatum,
@@ -36,15 +39,18 @@ __all__ = [
     "collate_batch",
     "MolAtomBondTrainingBatch",
     "collate_mol_atom_bond_batch",
+    "collate_cuik_mol_atom_bond_batch",
     "MulticomponentTrainingBatch",
     "collate_multicomponent",
     "build_dataloader",
     "LazyMoleculeDatapoint",
+    "LazyMolAtomBondDatapoint",
     "MoleculeDatapoint",
     "MolAtomBondDatapoint",
     "ReactionDatapoint",
     "MoleculeDataset",
     "CuikmolmakerDataset",
+    "CuikmolmakerMolAtomBondDataset",
     "ReactionDataset",
     "Datum",
     "MolAtomBondDatum",

--- a/chemprop/data/collate.py
+++ b/chemprop/data/collate.py
@@ -5,9 +5,14 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from chemprop.data.datasets import CuikBatchedDatum, Datum, MolAtomBondDatum
+from chemprop.data.datasets import (
+    CuikBatchedDatum,
+    CuikBatchedMolAtomBondDatum,
+    Datum,
+    MolAtomBondDatum,
+)
 from chemprop.data.molgraph import MolGraph
-from chemprop.featurizers.molgraph.molecule import BatchCuikMolGraph
+from chemprop.featurizers.molgraph.molecule import BatchCuikMolAtomBondGraph, BatchCuikMolGraph
 
 
 @dataclass(repr=False, eq=False, slots=True)
@@ -131,7 +136,7 @@ class BatchMolAtomBondGraph(BatchMolGraph):
 
 
 class MolAtomBondTrainingBatch(NamedTuple):
-    bmg: BatchMolAtomBondGraph
+    bmg: BatchMolAtomBondGraph | BatchCuikMolAtomBondGraph
     V_d: Tensor | None
     E_d: Tensor | None
     X_d: Tensor | None
@@ -180,6 +185,29 @@ def collate_mol_atom_bond_batch(batch: Iterable[MolAtomBondDatum]) -> MolAtomBon
             for gt_masks in zip(*gt_maskss)
         ],
         constraintss,
+    )
+
+
+def collate_cuik_mol_atom_bond_batch(
+    batch: CuikBatchedMolAtomBondDatum,
+) -> MolAtomBondTrainingBatch:
+    bmg, V_d, E_d, X_d, Ys, weights, lt_masks, gt_masks, constraints = batch
+
+    return MolAtomBondTrainingBatch(
+        bmg,
+        None if V_d is None else torch.from_numpy(V_d).float(),
+        None if E_d is None else torch.from_numpy(E_d).float(),
+        None if X_d is None else torch.from_numpy(X_d).float(),
+        [None if y is None else torch.from_numpy(y).float() for y in Ys],
+        [None if w is None else torch.tensor(w, dtype=torch.float).unsqueeze(1) for w in weights],
+        [None if lt_mask is None else torch.from_numpy(lt_mask) for lt_mask in lt_masks],
+        [None if gt_mask is None else torch.from_numpy(gt_mask) for gt_mask in gt_masks],
+        None
+        if constraints is None
+        else [
+            None if constraint is None else torch.from_numpy(constraint).float()
+            for constraint in constraints
+        ],
     )
 
 

--- a/chemprop/data/dataloader.py
+++ b/chemprop/data/dataloader.py
@@ -5,11 +5,13 @@ from torch.utils.data import DataLoader
 from chemprop.data.collate import (
     collate_batch,
     collate_cuik_batch,
+    collate_cuik_mol_atom_bond_batch,
     collate_mol_atom_bond_batch,
     collate_multicomponent,
 )
 from chemprop.data.datasets import (
     CuikmolmakerDataset,
+    CuikmolmakerMolAtomBondDataset,
     MolAtomBondDataset,
     MoleculeDataset,
     MulticomponentDataset,
@@ -66,6 +68,8 @@ def build_dataloader(
 
     if isinstance(dataset, MulticomponentDataset):
         collate_fn = collate_multicomponent
+    elif isinstance(dataset, CuikmolmakerMolAtomBondDataset):
+        collate_fn = collate_cuik_mol_atom_bond_batch
     elif isinstance(dataset, CuikmolmakerDataset):
         collate_fn = collate_cuik_batch
     elif isinstance(dataset, MolAtomBondDataset):

--- a/chemprop/data/datapoints.py
+++ b/chemprop/data/datapoints.py
@@ -204,6 +204,46 @@ class MolAtomBondDatapoint(MoleculeDatapoint):
 
 
 @dataclass
+class LazyMolAtomBondDatapoint(LazyMoleculeDatapoint):
+    """A :class:`LazyMolAtomBondDatapoint` contains a single SMILES string and all attributes
+    needed to form a `rdkit.Chem.Mol` object, plus atom- and bond-level targets. The molecule is
+    computed lazily when the attribute `mol` is accessed."""
+
+    E_d: np.ndarray | None = None
+    """A numpy array of shape ``E x d_ed``, where ``E`` is the number of bonds in the molecule, and
+    ``d_ed`` is the number of additional descriptors that will be concatenated to edge-level
+    descriptors *after* message passing"""
+    atom_y: np.ndarray | None = None
+    """A numpy array of shape ``V x v_t``, where ``V`` is the number of atoms in the molecule, and
+    ``v_t`` is the number of atom targets. The order of atoms in the array should match the order of
+    atoms in the mol. Unknown targets are indicated by `nan`s."""
+    atom_gt_mask: np.ndarray | None = None
+    """Indicates whether the atom targets are an inequality regression target of the form `<x`"""
+    atom_lt_mask: np.ndarray | None = None
+    """Indicates whether the atom targets are an inequality regression target of the form `>x`"""
+    bond_y: np.ndarray | None = None
+    """A numpy array of shape ``E x e_t``, where ``V`` is the number of bonds in the molecule, and
+    ``e_t`` is the number of bond targets. The order of bonds in the array should match the order of
+    bonds in the mol. Unknown targets are indicated by `nan`s."""
+    bond_gt_mask: np.ndarray | None = None
+    """Indicates whether the bond targets are an inequality regression target of the form `<x`"""
+    bond_lt_mask: np.ndarray | None = None
+    """Indicates whether the bond targets are an inequality regression target of the form `>x`"""
+    atom_constraint: np.ndarray | None = None
+    """A numpy array of shape ``1 x v_t`` containing the values that the atom property predictions
+    should be constrained to sum to, with np.nan indicating no constraint for that property"""
+    bond_constraint: np.ndarray | None = None
+    """A numpy array of shape ``1 x e_t`` containing the values that the bond property predictions
+    should be constrained to sum to, with np.nan indicating no constraint for that property"""
+
+    def __post_init__(self):
+        super().__post_init__()
+        NAN_TOKEN = 0
+        if self.E_d is not None:
+            self.E_d[np.isnan(self.E_d)] = NAN_TOKEN
+
+
+@dataclass
 class _ReactionDatapointMixin:
     rct: Chem.Mol
     """the reactant associated with this datapoint"""

--- a/chemprop/data/datasets.py
+++ b/chemprop/data/datasets.py
@@ -11,6 +11,7 @@ from sklearn.preprocessing import StandardScaler
 from torch.utils.data import Dataset
 
 from chemprop.data.datapoints import (
+    LazyMolAtomBondDatapoint,
     LazyMoleculeDatapoint,
     MolAtomBondDatapoint,
     MoleculeDatapoint,
@@ -19,6 +20,7 @@ from chemprop.data.datapoints import (
 from chemprop.data.molgraph import MolGraph
 from chemprop.featurizers.base import Featurizer
 from chemprop.featurizers.molgraph import (
+    BatchCuikMolAtomBondGraph,
     BatchCuikMolGraph,
     CGRFeaturizer,
     CuikmolmakerMolGraphFeaturizer,
@@ -66,6 +68,20 @@ class CuikBatchedDatum(NamedTuple):
     weights: np.ndarray
     lt_mask: np.ndarray
     gt_mask: np.ndarray
+
+
+class CuikBatchedMolAtomBondDatum(NamedTuple):
+    """a cuik-molmaker batch of data points that supports atom and bond level targets"""
+
+    bmg: BatchCuikMolAtomBondGraph
+    V_d: np.ndarray | None
+    E_d: np.ndarray | None
+    X_d: np.ndarray | None
+    Ys: tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]
+    weights: tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]
+    lt_masks: tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]
+    gt_masks: tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]
+    constraints: tuple[np.ndarray | None, np.ndarray | None]
 
 
 MolGraphDataset: TypeAlias = Dataset[Datum]
@@ -363,8 +379,26 @@ class MoleculeDataset(_MolGraphDatasetMixin, MolGraphDataset):
         self.__V_ds = self._V_ds
 
 
+class _CuikmolmakerDatasetMixin:
+    """Shared behavior for cuik-molmaker-backed datasets: featurization is always performed
+    on-the-fly (never cached), and ``smiles`` returns the original input SMILES directly rather
+    than re-deriving it from an RDKit ``Mol`` (which would canonicalize and reorder atoms)."""
+
+    @MoleculeDataset.cache.setter
+    def cache(self, cache: bool = False):
+        if cache:
+            raise NotImplementedError(f"{type(self).__name__} is meant to be used without caching!")
+
+    def _init_cache(self):
+        pass
+
+    @property
+    def smiles(self) -> list[str]:
+        return [d.smiles for d in self.data]
+
+
 @dataclass
-class CuikmolmakerDataset(MoleculeDataset):
+class CuikmolmakerDataset(_CuikmolmakerDatasetMixin, MoleculeDataset):
     r"""A :class:`CuikmolmakerDataset` composed of :class:`LazyMoleculeDatapoint`\s and a
     :class:`CuikmolmakerMolGraphFeaturizer`
 
@@ -385,18 +419,6 @@ class CuikmolmakerDataset(MoleculeDataset):
     featurizer: CuikmolmakerMolGraphFeaturizer = field(
         default_factory=CuikmolmakerMolGraphFeaturizer
     )
-
-    @MoleculeDataset.cache.setter
-    def cache(self, cache: bool = False):
-        if cache:
-            raise NotImplementedError("CuikmolmakerDataset is meant to be used without caching!")
-
-    def _init_cache(self):
-        pass
-
-    @property
-    def smiles(self) -> list[str]:
-        return [d.smiles for d in self.data]
 
     def __getitem__(self, idx: int) -> Datum:
         d = self.data[idx]
@@ -635,6 +657,132 @@ class MolAtomBondDataset(MoleculeDataset, MolAtomBondGraphDataset):
         self.__bond_Y = self._bond_Y
         self.__atom_constraints = self._atom_constraints
         self.__bond_constraints = self._bond_constraints
+
+
+@dataclass
+class CuikmolmakerMolAtomBondDataset(_CuikmolmakerDatasetMixin, MolAtomBondDataset):
+    r"""A :class:`CuikmolmakerMolAtomBondDataset` composed of :class:`LazyMolAtomBondDatapoint`\s
+    and a :class:`CuikmolmakerMolGraphFeaturizer`
+
+    A :class:`CuikmolmakerMolAtomBondDataset` produces featurized data for a batch of molecules
+    with atom- and/or bond-level targets for ingestion by a :class:`MolAtomBondMPNN` model. Data
+    featurization is always performed on-the-fly and using the cuik-molmaker package.
+
+    Parameters
+    ----------
+    data : Iterable[LazyMolAtomBondDatapoint]
+        the data from which to create a dataset
+    featurizer : CuikmolmakerMolGraphFeaturizer
+        the featurizer with which to generate MolGraphs of the molecules
+    """
+
+    data: list[LazyMolAtomBondDatapoint]
+    featurizer: CuikmolmakerMolGraphFeaturizer = field(
+        default_factory=CuikmolmakerMolGraphFeaturizer
+    )
+
+    def __getitem__(self, idx: int) -> MolAtomBondDatum:
+        d = self.data[idx]
+        bmg = self.featurizer([d.smiles], self.V_fs[idx], self.E_fs[idx])
+        mg = MolGraph(
+            bmg.V.numpy(), bmg.E.numpy(), bmg.edge_index.numpy(), bmg.rev_edge_index.numpy()
+        )
+
+        return MolAtomBondDatum(
+            mg,
+            self.V_ds[idx],
+            self.E_ds[idx],
+            self.X_d[idx],
+            [
+                self.Y[idx] if isinstance(self.Y[idx], np.ndarray) else None,
+                self.atom_Y[idx] if self.atom_Y[idx] is not None else None,
+                self.bond_Y[idx] if self.bond_Y[idx] is not None else None,
+            ],
+            d.weight,
+            [d.lt_mask, d.atom_lt_mask, d.bond_lt_mask],
+            [d.gt_mask, d.atom_gt_mask, d.bond_gt_mask],
+            [d.atom_constraint, d.bond_constraint],
+        )
+
+    def __getitems__(self, indexes: list[int]) -> CuikBatchedMolAtomBondDatum:
+        data = [self.data[idx] for idx in indexes]
+        smiles_list = [d.smiles for d in data]
+        V_f = np.concat([self.V_fs[idx] for idx in indexes]) if self.V_fs[0] is not None else None
+        E_f = np.concat([self.E_fs[idx] for idx in indexes]) if self.E_fs[0] is not None else None
+
+        plain_bmg = self.featurizer(smiles_list, V_f, E_f)
+        bmg = BatchCuikMolAtomBondGraph(
+            V=plain_bmg.V,
+            E=plain_bmg.E,
+            edge_index=plain_bmg.edge_index,
+            rev_edge_index=plain_bmg.rev_edge_index,
+            batch=plain_bmg.batch,
+        )
+
+        V_d = np.concat([self.V_ds[idx] for idx in indexes]) if self.V_ds[0] is not None else None
+        E_d = np.concat([self.E_ds[idx] for idx in indexes]) if self.E_ds[0] is not None else None
+        X_d = self.X_d[indexes] if self.X_d[0] is not None else None
+
+        Y = self.Y[indexes] if isinstance(self.Y[0], np.ndarray) else None
+        atom_Y = (
+            None if self.atom_Y[0] is None else np.vstack([self.atom_Y[idx] for idx in indexes])
+        )
+        bond_Y = (
+            None if self.bond_Y[0] is None else np.vstack([self.bond_Y[idx] for idx in indexes])
+        )
+
+        weights = self.weights[indexes]
+        mol_weights = None if Y is None else weights
+        atom_weights = (
+            None
+            if atom_Y is None
+            else np.repeat(weights, [len(self.atom_Y[idx]) for idx in indexes])
+        )
+        bond_weights = (
+            None
+            if bond_Y is None
+            else np.repeat(weights, [len(self.bond_Y[idx]) for idx in indexes])
+        )
+
+        lt_mask = None if data[0].lt_mask is None else np.vstack([d.lt_mask for d in data])
+        atom_lt_mask = (
+            None if data[0].atom_lt_mask is None else np.vstack([d.atom_lt_mask for d in data])
+        )
+        bond_lt_mask = (
+            None if data[0].bond_lt_mask is None else np.vstack([d.bond_lt_mask for d in data])
+        )
+
+        gt_mask = None if data[0].gt_mask is None else np.vstack([d.gt_mask for d in data])
+        atom_gt_mask = (
+            None if data[0].atom_gt_mask is None else np.vstack([d.atom_gt_mask for d in data])
+        )
+        bond_gt_mask = (
+            None if data[0].bond_gt_mask is None else np.vstack([d.bond_gt_mask for d in data])
+        )
+
+        atom_constraint = (
+            None if data[0].atom_constraint is None else np.array([d.atom_constraint for d in data])
+        )
+        bond_constraint = (
+            None if data[0].bond_constraint is None else np.array([d.bond_constraint for d in data])
+        )
+        constraints = (
+            None
+            if atom_constraint is None and bond_constraint is None
+            else [atom_constraint, bond_constraint]
+        )
+
+        return CuikBatchedMolAtomBondDatum(
+            bmg,
+            V_d,
+            E_d,
+            X_d,
+            [Y, atom_Y, bond_Y],
+            [mol_weights, atom_weights, bond_weights],
+            [lt_mask, atom_lt_mask, bond_lt_mask],
+            [gt_mask, atom_gt_mask, bond_gt_mask],
+            constraints,
+        )
 
 
 @dataclass

--- a/chemprop/featurizers/__init__.py
+++ b/chemprop/featurizers/__init__.py
@@ -13,6 +13,7 @@ from .molecule import (
     V1RDKit2DNormalizedFeaturizer,
 )
 from .molgraph import (
+    BatchCuikMolAtomBondGraph,
     BatchCuikMolGraph,
     CGRFeaturizer,
     CondensedGraphOfReactionFeaturizer,
@@ -39,6 +40,7 @@ __all__ = [
     "MolGraphCacheOnTheFly",
     "SimpleMoleculeMolGraphFeaturizer",
     "BatchCuikMolGraph",
+    "BatchCuikMolAtomBondGraph",
     "CondensedGraphOfReactionFeaturizer",
     "CuikmolmakerMolGraphFeaturizer",
     "CGRFeaturizer",

--- a/chemprop/featurizers/molgraph/__init__.py
+++ b/chemprop/featurizers/molgraph/__init__.py
@@ -1,5 +1,6 @@
 from .cache import MolGraphCache, MolGraphCacheFacade, MolGraphCacheOnTheFly
 from .molecule import (
+    BatchCuikMolAtomBondGraph,
     BatchCuikMolGraph,
     CuikmolmakerMolGraphFeaturizer,
     SimpleMoleculeMolGraphFeaturizer,
@@ -12,6 +13,7 @@ __all__ = [
     "MolGraphCacheOnTheFly",
     "SimpleMoleculeMolGraphFeaturizer",
     "CuikmolmakerMolGraphFeaturizer",
+    "BatchCuikMolAtomBondGraph",
     "CondensedGraphOfReactionFeaturizer",
     "CGRFeaturizer",
     "RxnMode",

--- a/chemprop/featurizers/molgraph/molecule.py
+++ b/chemprop/featurizers/molgraph/molecule.py
@@ -123,6 +123,23 @@ class BatchCuikMolGraph:
         self.batch = self.batch.to(device)
 
 
+@dataclass(repr=False, eq=False, slots=True)
+class BatchCuikMolAtomBondGraph(BatchCuikMolGraph):
+    """A :class:`BatchCuikMolAtomBondGraph` is a :class:`BatchCuikMolGraph` with the addition of
+    the ``bond_batch`` attribute, for use with atom/bond-level targets."""
+
+    bond_batch: Tensor = field(init=False)
+    """A tensor of indices that show which molecule each (directed) bond belongs to in the batch"""
+
+    def __post_init__(self):
+        super(BatchCuikMolAtomBondGraph, self).__post_init__()
+        self.bond_batch = self.batch[self.edge_index[0]]
+
+    def to(self, device: str | torch.device):
+        super(BatchCuikMolAtomBondGraph, self).to(device)
+        self.bond_batch = self.bond_batch.to(device)
+
+
 @dataclass
 class CuikmolmakerMolGraphFeaturizer(Featurizer[list[str], BatchCuikMolGraph]):
     """A :class:`CuikmolmakerMolGraphFeaturizer` featurizes a list of molecules at once instead of

--- a/docs/source/tutorial/cli/mol_atom_bond.rst
+++ b/docs/source/tutorial/cli/mol_atom_bond.rst
@@ -41,6 +41,12 @@ Reordering the atoms does not change the order of bonds, but the bond targets ca
 The model predictions are still returned as a list of values which follow the order of the bonds in the input SMILES string.
 
 
+Performant Training
+--------------------
+
+As with regular molecule training, atom and bond property training can be accelerated with the :code:`--use-cuikmolmaker-featurization` flag (see :ref:`performant-training`). The same restrictions apply: :code:`--keep-h`, :code:`--reorder-atoms`, and :code:`--ignore-stereo` are not supported, and bond targets given as a full adjacency matrix (rather than a flat list ordered by RDKit bond index) are not supported, since flattening them requires building an RDKit :code:`Mol` for every molecule.
+
+
 Constrained Prediction
 ----------------------
 

--- a/docs/source/tutorial/cli/train.rst
+++ b/docs/source/tutorial/cli/train.rst
@@ -270,7 +270,7 @@ By default, graph featurization occurs a single time at the beginning of the tra
 .. note::
   Setting :code:`num_workers` to a value greater than 0 can cause hangs on Windows and MacOS
 
-Training can be further accelerated using a molecular featurizer package called ``cuik-molmaker``. This package is a required dependency and is installed automatically with Chemprop (see :ref:`installation`). In order to enable the accelerated featurizer, use the :code:`--use-cuikmolmaker-featurization` flag. This featurizer also performs on-the-fly featurization of molecules and reduces memory usage which is particularly useful for large datasets.
+Training can be further accelerated using a molecular featurizer package called ``cuik-molmaker``. This package is a required dependency and is installed automatically with Chemprop (see :ref:`installation`). In order to enable the accelerated featurizer, use the :code:`--use-cuikmolmaker-featurization` flag. This featurizer also performs on-the-fly featurization of molecules and reduces memory usage which is particularly useful for large datasets. This flag is also supported for :ref:`mol_atom_bond` training and prediction, with the same restrictions on :code:`--keep-h`, :code:`--reorder-atoms`, :code:`--ignore-stereo`, and multi-component data described above.
 
 
 .. _train-on-reactions:

--- a/tests/cli/test_cli_MAB_cuikmolmaker.py
+++ b/tests/cli/test_cli_MAB_cuikmolmaker.py
@@ -1,0 +1,217 @@
+"""Tests for `--use-cuikmolmaker-featurization` combined with MolAtomBond (atom/bond target)
+training and prediction.
+"""
+import pandas as pd
+import pytest
+
+from chemprop.cli.main import main
+
+pytestmark = pytest.mark.CLI
+
+# `regression.csv` and `constrained_regression.csv` both include a `[H][H]` datapoint (which
+# requires `--keep-h`) and an atom-mapped datapoint (which requires `--reorder-atoms`). Both flags
+# are incompatible with `--use-cuikmolmaker-featurization`, so those rows are filtered out here.
+_INCOMPATIBLE_SMIS = ["[H][H]", "[CH2:3]=[N+:1]([H:4])[H:2]"]
+
+
+@pytest.fixture
+def cuik_regression_data_path(data_dir, tmp_path):
+    src = data_dir / "mol_atom_bond" / "regression.csv"
+    df = pd.read_csv(src)
+    df = df[~df["smiles"].isin(_INCOMPATIBLE_SMIS)]
+    dst = tmp_path / "regression_cuik.csv"
+    df.to_csv(dst, index=False)
+
+    return (
+        str(dst),
+        "smiles",
+        ["mol_y1", "mol_y2"],
+        ["atom_y1", "atom_y2"],
+        ["bond_y1", "bond_y2"],
+        "weight",
+    )
+
+
+@pytest.fixture
+def cuik_constrained_data_path(data_dir, tmp_path):
+    src = data_dir / "mol_atom_bond" / "constrained_regression.csv"
+    src_constraints = data_dir / "mol_atom_bond" / "constrained_regression_constraints.csv"
+    df = pd.read_csv(src)
+    df_constraints = pd.read_csv(src_constraints)
+
+    keep_mask = ~df["smiles"].isin(_INCOMPATIBLE_SMIS)
+    df = df[keep_mask]
+    df_constraints = df_constraints[keep_mask.to_numpy()]
+
+    dst = tmp_path / "constrained_regression_cuik.csv"
+    dst_constraints = tmp_path / "constrained_regression_constraints_cuik.csv"
+    df.to_csv(dst, index=False)
+    df_constraints.to_csv(dst_constraints, index=False)
+
+    return (
+        str(dst),
+        str(dst_constraints),
+        ["atom_y1", "atom_y2", "bond_y2"],
+        "smiles",
+        ["mol_y"],
+        ["atom_y1", "atom_y2"],
+        ["bond_y1", "bond_y2"],
+    )
+
+
+def test_train_quick_cuikmolmaker(monkeypatch, cuik_regression_data_path):
+    input_path, smiles, mol_targets, atom_targets, bond_targets, weight = cuik_regression_data_path
+
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        smiles,
+        "--mol-target-columns",
+        *mol_targets,
+        "--atom-target-columns",
+        *atom_targets,
+        "--bond-target-columns",
+        *bond_targets,
+        "--weight-column",
+        weight,
+        "--epochs",
+        "3",
+        "--use-cuikmolmaker-featurization",
+        "--split-sizes",
+        "0.4",
+        "0.3",
+        "0.3",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
+def test_train_predict_quick_cuikmolmaker(monkeypatch, cuik_regression_data_path, tmp_path):
+    input_path, smiles, mol_targets, atom_targets, bond_targets, weight = cuik_regression_data_path
+    save_dir = tmp_path / "cuik_mab_model"
+
+    train_args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        smiles,
+        "--mol-target-columns",
+        *mol_targets,
+        "--atom-target-columns",
+        *atom_targets,
+        "--bond-target-columns",
+        *bond_targets,
+        "--weight-column",
+        weight,
+        "--epochs",
+        "3",
+        "--use-cuikmolmaker-featurization",
+        "--save-dir",
+        str(save_dir),
+        "--split-sizes",
+        "0.4",
+        "0.3",
+        "0.3",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", train_args)
+        main()
+
+    model_path = save_dir / "model_0" / "best.pt"
+    assert model_path.exists()
+
+    predict_args = [
+        "chemprop",
+        "predict",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        smiles,
+        "--model-paths",
+        str(model_path),
+        "--use-cuikmolmaker-featurization",
+        "--output",
+        str(tmp_path / "cuik_mab_preds.csv"),
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", predict_args)
+        main()
+
+    assert (tmp_path / "cuik_mab_preds.csv").exists()
+
+
+def test_train_only_atom_cuikmolmaker(monkeypatch, cuik_regression_data_path):
+    input_path, smiles, mol_targets, atom_targets, bond_targets, weight = cuik_regression_data_path
+
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        smiles,
+        "--atom-target-columns",
+        *atom_targets,
+        "--epochs",
+        "3",
+        "--use-cuikmolmaker-featurization",
+        "--split-sizes",
+        "0.4",
+        "0.3",
+        "0.3",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()
+
+
+def test_train_constrained_quick_cuikmolmaker(monkeypatch, cuik_constrained_data_path):
+    (
+        input_path,
+        constraints_path,
+        constraints_to_targets,
+        smiles,
+        mol_targets,
+        atom_targets,
+        bond_targets,
+    ) = cuik_constrained_data_path
+
+    args = [
+        "chemprop",
+        "train",
+        "-i",
+        input_path,
+        "--smiles-columns",
+        smiles,
+        "--mol-target-columns",
+        *mol_targets,
+        "--atom-target-columns",
+        *atom_targets,
+        "--bond-target-columns",
+        *bond_targets,
+        "--constraints-path",
+        constraints_path,
+        "--constraints-to-targets",
+        *constraints_to_targets,
+        "--epochs",
+        "3",
+        "--use-cuikmolmaker-featurization",
+        "--split-sizes",
+        "0.4",
+        "0.3",
+        "0.3",
+    ]
+
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", args)
+        main()

--- a/tests/cli/test_parsing.py
+++ b/tests/cli/test_parsing.py
@@ -160,6 +160,32 @@ def test_MAB_parsing_constrained_error(data_dir):
         )
 
 
+def test_MAB_parsing_cuikmolmaker_matrix_bond_targets_error(data_dir):
+    with pytest.raises(ValueError, match="adjacency matrix"):
+        build_MAB_data_from_files(
+            data_dir / "mol_atom_bond/atomic_bond_regression.csv",
+            ["smiles"],
+            None,
+            None,
+            ["bond_index_matrix"],
+            None,
+            False,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            use_cuikmolmaker_featurization=True,
+            keep_h=False,
+            add_h=False,
+            reorder_atoms=False,
+            ignore_stereo=False,
+        )
+
+
 def test_preds_stay_same(monkeypatch, tmp_path):
     args = [
         "chemprop",

--- a/tests/unit/data/test_cuik_MAB_dataset.py
+++ b/tests/unit/data/test_cuik_MAB_dataset.py
@@ -1,0 +1,209 @@
+"""Parity tests between the pure-python and cuik-molmaker MolAtomBond featurization paths.
+
+Atom and bond targets are matched positionally to rows of ``V``/``E``, so an ordering mismatch
+between the two featurizers would train silently on misaligned data. These tests pin that ordering.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from chemprop.data.collate import collate_cuik_mol_atom_bond_batch, collate_mol_atom_bond_batch
+from chemprop.data.datapoints import LazyMolAtomBondDatapoint, MolAtomBondDatapoint
+from chemprop.data.datasets import CuikmolmakerMolAtomBondDataset, MolAtomBondDataset
+from chemprop.featurizers.molgraph import (
+    CuikmolmakerMolGraphFeaturizer,
+    SimpleMoleculeMolGraphFeaturizer,
+)
+from chemprop.utils import make_mol
+
+# "C" (methane) has zero bonds and "CC" (ethane) has exactly one, the cases most likely to break
+# per-bond batching (`bond_batch`, weights repeated per bond). `test_edge_case_smis_coverage`
+# guards this so the coverage can't be dropped by a later edit.
+EDGE_CASE_SMIS = ["C", "CC", "CCO", "c1ccccc1", "CC(=O)O"]
+
+EXTRA_ATOM_FDIM = 3
+EXTRA_BOND_FDIM = 2
+
+
+def test_edge_case_smis_coverage():
+    n_bondss = {make_mol(smi, False, False, False, False).GetNumBonds() for smi in EDGE_CASE_SMIS}
+    assert {0, 1} <= n_bondss, "parity fixtures must keep a zero-bond and a single-bond molecule"
+
+
+@pytest.fixture(params=[EDGE_CASE_SMIS, None], ids=["edge_case_smis", "sampled_smis"])
+def smis_list(smis, request):
+    return request.param if request.param is not None else smis.sample(6).to_list()
+
+
+@pytest.fixture
+def mols(smis_list):
+    return [make_mol(smi, False, False, False, False) for smi in smis_list]
+
+
+@pytest.fixture
+def targets(mols):
+    rng = np.random.default_rng(0)
+    return (
+        rng.random((len(mols), 2)),
+        [rng.random((mol.GetNumAtoms(), 2)) for mol in mols],
+        [rng.random((mol.GetNumBonds(), 2)) for mol in mols],
+    )
+
+
+@pytest.fixture
+def weights(mols):
+    return np.random.default_rng(1).random(len(mols))
+
+
+@pytest.fixture(params=[False, True], ids=["no_extras", "extras"])
+def extras(mols, request):
+    """The extra features/descriptors that ride alongside the graph. ``E_d`` is duplicated per
+    bond direction, mirroring what ``build_MAB_data_from_files`` does at parse time."""
+    if not request.param:
+        return [dict() for _ in mols]
+
+    rng = np.random.default_rng(2)
+    return [
+        dict(
+            x_d=rng.random(2),
+            V_f=rng.random((mol.GetNumAtoms(), EXTRA_ATOM_FDIM)),
+            E_f=rng.random((mol.GetNumBonds(), EXTRA_BOND_FDIM)),
+            V_d=rng.random((mol.GetNumAtoms(), 4)),
+            E_d=np.repeat(rng.random((mol.GetNumBonds(), 5)), repeats=2, axis=0),
+        )
+        for mol in mols
+    ]
+
+
+@pytest.fixture
+def datapoint_kwargs(targets, weights, extras):
+    mol_ys, atom_ys, bond_ys = targets
+    return [
+        dict(
+            y=mol_ys[i], atom_y=atom_ys[i], bond_y=bond_ys[i], weight=float(weights[i]), **extras[i]
+        )
+        for i in range(len(weights))
+    ]
+
+
+@pytest.fixture
+def pp_dataset(mols, datapoint_kwargs, extras):
+    data = [MolAtomBondDatapoint(mol=mol, **datapoint_kwargs[i]) for i, mol in enumerate(mols)]
+    featurizer = SimpleMoleculeMolGraphFeaturizer(
+        extra_atom_fdim=EXTRA_ATOM_FDIM if "V_f" in extras[0] else 0,
+        extra_bond_fdim=EXTRA_BOND_FDIM if "E_f" in extras[0] else 0,
+    )
+    return MolAtomBondDataset(data, featurizer)
+
+
+@pytest.fixture
+def cuik_dataset(smis_list, datapoint_kwargs, extras):
+    data = [
+        LazyMolAtomBondDatapoint(smiles=smi, **datapoint_kwargs[i])
+        for i, smi in enumerate(smis_list)
+    ]
+    featurizer = CuikmolmakerMolGraphFeaturizer(
+        atom_featurizer_mode="V2",
+        extra_atom_fdim=EXTRA_ATOM_FDIM if "V_f" in extras[0] else 0,
+        extra_bond_fdim=EXTRA_BOND_FDIM if "E_f" in extras[0] else 0,
+    )
+    return CuikmolmakerMolAtomBondDataset(data, featurizer)
+
+
+def _assert_optional_close(a, b):
+    if a is None or b is None:
+        assert a is None and b is None
+    else:
+        torch.testing.assert_close(a, b)
+
+
+def _assert_batches_match(pp_batch, cuik_batch):
+    torch.testing.assert_close(pp_batch.bmg.V, cuik_batch.bmg.V)
+    torch.testing.assert_close(pp_batch.bmg.E, cuik_batch.bmg.E)
+    assert torch.equal(pp_batch.bmg.edge_index, cuik_batch.bmg.edge_index)
+    assert torch.equal(pp_batch.bmg.rev_edge_index, cuik_batch.bmg.rev_edge_index)
+    assert torch.equal(pp_batch.bmg.batch, cuik_batch.bmg.batch)
+    assert torch.equal(pp_batch.bmg.bond_batch, cuik_batch.bmg.bond_batch)
+
+    _assert_optional_close(pp_batch.V_d, cuik_batch.V_d)
+    _assert_optional_close(pp_batch.E_d, cuik_batch.E_d)
+    _assert_optional_close(pp_batch.X_d, cuik_batch.X_d)
+
+    for attr in ("Ys", "w", "lt_masks", "gt_masks"):
+        for pp_x, cuik_x in zip(getattr(pp_batch, attr), getattr(cuik_batch, attr)):
+            _assert_optional_close(pp_x, cuik_x)
+
+
+def _collate_both(pp_dataset, cuik_dataset):
+    indexes = list(range(len(pp_dataset)))
+    return (
+        collate_mol_atom_bond_batch([pp_dataset[i] for i in indexes]),
+        collate_cuik_mol_atom_bond_batch(cuik_dataset.__getitems__(indexes)),
+    )
+
+
+def test_parity_full_batch(pp_dataset, cuik_dataset):
+    _assert_batches_match(*_collate_both(pp_dataset, cuik_dataset))
+
+
+def test_single_item_getitem_parity(pp_dataset, cuik_dataset):
+    for idx in range(len(pp_dataset)):
+        pp_item = pp_dataset[idx]
+        cuik_item = cuik_dataset[idx]
+
+        np.testing.assert_allclose(pp_item.mg.V, cuik_item.mg.V)
+        np.testing.assert_allclose(pp_item.mg.E, cuik_item.mg.E)
+        np.testing.assert_array_equal(pp_item.mg.edge_index, cuik_item.mg.edge_index)
+        np.testing.assert_array_equal(pp_item.mg.rev_edge_index, cuik_item.mg.rev_edge_index)
+
+
+def test_add_h_parity():
+    """cuik-molmaker appends hydrogens internally when ``add_h=True``; their order must match
+    RDKit's own ``AddHs`` order for atom targets to stay aligned with features."""
+    smis_list = ["CCO", "c1ccccc1", "C"]
+    mols = [make_mol(smi, False, True, False, False) for smi in smis_list]
+
+    rng = np.random.default_rng(42)
+    kwargs = [
+        dict(
+            y=rng.random(2),
+            atom_y=rng.random((mol.GetNumAtoms(), 2)),
+            bond_y=rng.random((mol.GetNumBonds(), 2)),
+            weight=float(rng.random()),
+        )
+        for mol in mols
+    ]
+
+    pp_dataset = MolAtomBondDataset(
+        [MolAtomBondDatapoint(mol=mol, **kwargs[i]) for i, mol in enumerate(mols)],
+        SimpleMoleculeMolGraphFeaturizer(),
+    )
+    cuik_dataset = CuikmolmakerMolAtomBondDataset(
+        [
+            LazyMolAtomBondDatapoint(smiles=smi, _add_h=True, **kwargs[i])
+            for i, smi in enumerate(smis_list)
+        ],
+        CuikmolmakerMolGraphFeaturizer(atom_featurizer_mode="V2", add_h=True),
+    )
+
+    _assert_batches_match(*_collate_both(pp_dataset, cuik_dataset))
+
+
+def test_cache_is_rejected(cuik_dataset):
+    with pytest.raises(NotImplementedError, match="without caching"):
+        cuik_dataset.cache = True
+
+
+def test_smiles_returns_input_verbatim():
+    """`MoleculeDataset.smiles` round-trips through `Chem.MolToSmiles`, which canonicalizes and so
+    would reorder atoms relative to the atom targets. The cuik dataset must hand the *input* SMILES
+    to the featurizer instead. These inputs are deliberately non-canonical ('OCC' -> 'CCO'), so
+    this fails if the override is dropped."""
+    smis_list = ["OCC", "C(C)O"]
+    dataset = CuikmolmakerMolAtomBondDataset(
+        [LazyMolAtomBondDatapoint(smiles=smi) for smi in smis_list],
+        CuikmolmakerMolGraphFeaturizer(atom_featurizer_mode="V2"),
+    )
+
+    assert dataset.smiles == smis_list


### PR DESCRIPTION
> [!NOTE]
> This PR was handled entirely by Claude Code using Opus 4.8 for planning, Sonnet 5 for implementation, and Opus 4.8 again for review, all under @craabreu's supervision

## Summary

`--use-cuikmolmaker-featurization` accelerates featurization and reduces memory usage by batching atom/bond featurization through the `cuik_molmaker` extension instead of looping over RDKit `Mol` objects in Python, and by keeping datapoints as lazy SMILES strings rather than materialized/cached molecules. It was previously unavailable for MolAtomBond (atom/bond target) training: `build_splits` dropped the flag before reaching the MAB data-loading path, and `make_dataset` had no cuik branch for MAB datapoints. MAB users therefore paid full RDKit featurization cost even though their datasets — per-atom and per-bond targets over large molecule sets — are exactly the ones where the memory savings matter most.

This PR wires the cuik-molmaker path through `chemprop train` and `chemprop predict` for MolAtomBond models.

## What changed

- **`LazyMolAtomBondDatapoint`** (`chemprop/data/datapoints.py`) holds the SMILES string and builds the `Chem.Mol` lazily on access, mirroring `LazyMoleculeDatapoint`. It preserves the *original* SMILES rather than the canonical form: `MoleculeDataset.smiles` round-trips through `Chem.MolToSmiles`, which reorders atoms and would silently misalign atom/bond targets against their features.
- **`CuikmolmakerMolAtomBondDataset`** (`chemprop/data/datasets.py`) featurizes a whole batch at once via `__getitems__`, returning an already-collated `CuikBatchedMolAtomBondDatum`. It subclasses `MolAtomBondDataset`, so every existing `isinstance(..., MolAtomBondDataset)` check across `train.py`/`hpopt.py` continues to route it correctly.
- **`BatchCuikMolAtomBondGraph`** (`chemprop/featurizers/molgraph/molecule.py`) adds the one field the MAB model needs beyond the standard cuik graph batch — `bond_batch`, derived as `batch[edge_index[0]]`. The message-passing/model layer itself required no changes.
- **`collate_cuik_mol_atom_bond_batch`** and a `_CuikmolmakerDatasetMixin` (shared no-cache / smiles-passthrough behavior, extracted from the existing `CuikmolmakerDataset`) round out the data pipeline.
- **`build_MAB_data_from_files`** (`chemprop/cli/utils/MAB_parsing.py`) skips eager `Chem.Mol` construction when `use_cuikmolmaker_featurization=True`, building `LazyMolAtomBondDatapoint`s instead. Molecule featurizers (`--molecule-featurizers`) still need a `Mol`, so they build one transiently when requested.
- Bond targets given as a full adjacency matrix (rather than a flat list ordered by RDKit bond index) are **rejected** under this flag with a clear error, since flattening them requires building an RDKit `Mol` per molecule — defeating the point of the lazy path.
- Existing cuik-molmaker restrictions (`--keep-h`, `--reorder-atoms`, `--ignore-stereo`, multi-component data) carry over unchanged for MAB.
- `chemprop hpopt` picks up the same support as a side effect, since it shares `build_splits` with `train` and the new dataset class classifies correctly under the shared `isinstance` checks. `chemprop fingerprint` still uses the pure-python path for MAB models (out of scope for this PR).

## Why this is safe

Atom and bond targets are matched **positionally** to rows of the feature matrices, so any ordering mismatch between the cuik and pure-python featurizers would train silently on misaligned data. The new tests (`tests/unit/data/test_cuik_MAB_dataset.py`) pin `V`/`E`/`edge_index`/`rev_edge_index`/`batch`/`bond_batch`, targets, weights, and masks against the existing pure-python path, including:

- zero-bond and single-bond molecules (the batching edge cases most likely to break `bond_batch`/weight-repeat logic)
- extra atom/bond features and descriptors, including the ×2-repeated `E_d` (bond descriptors are duplicated per direction at parse time to match cuik's duplicated edges)
- `--add-h`, since cuik appends hydrogens internally and their order must match RDKit's own `AddHs`

I mutation-tested these: reversing `E_d` ordering and dropping the SMILES-passthrough override each cause a specific test to fail, confirming the assertions aren't vacuous.

## Testing

- `tests/unit` — 942 passed
- `tests/cli/test_cli_MAB.py` (existing MAB suite, unaffected) — 29 passed, 2 skipped
- New tests: 15 dataset-level parity tests + 5 CLI end-to-end tests (train/predict, constrained targets, atom-only subset, matrix-target error path) — all passing
- `tests/integration` — 54 passed; 2 pre-existing failures in `test_classification_MAB.py` reproduce identically on `main` and are caused by `scatter_reduce_mps` lacking a deterministic implementation on this machine's Apple Silicon/MPS backend, unrelated to this change (should pass on Linux CI)
- Manual end-to-end `chemprop train` → `chemprop predict` run with `--use-cuikmolmaker-featurization` and real checkpoints

## Docs

Updated `docs/source/tutorial/cli/train.rst` and `docs/source/tutorial/cli/mol_atom_bond.rst` to note MAB support and the matrix-bond-target restriction. `hpopt.rst` doesn't currently document `--use-cuikmolmaker-featurization` at all (even for plain molecule training), so its docs gap is left as-is rather than expanded in this PR.
