### PR TITLE
Bump miniconda in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
       # use a version of the conda virtual environment manager to set up an
       # isolated environment with the Python version we want
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         if: matrix.os != 'windows-2022'
         with:
           python-version: ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ cython_debug/
 *.code-workspace
 *.csv
 *.pkl
+*.npz
 *.pt
 *.json
 *.sqlite3


### PR DESCRIPTION
bump the version of miniconda used in the CI. 

I also tacked on a commit that adds *.npz files to the gitignore. The example notebook `extra_features_descriptors.ipynb` creates .npz files. We do have some *.npz files in our tests/data, so maybe we don't want to ignore them. Not sure what best practice is here. 