### PR TITLE
Fix hpopt default save dir bug

### DIFF
--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -150,6 +150,7 @@ class HpoptSubcommand(Subcommand):
         args = process_hpopt_args(args)
         validate_common_args(args)
         validate_train_args(args)
+        args.output_dir.mkdir(exist_ok=True, parents=True)
         main(args)
 
 

--- a/chemprop/cli/hpopt.py
+++ b/chemprop/cli/hpopt.py
@@ -275,7 +275,7 @@ def add_hpopt_args(parser: ArgumentParser) -> ArgumentParser:
 
 def process_hpopt_args(args: Namespace) -> Namespace:
     if args.hpopt_save_dir is None:
-        args.hpopt_save_dir = Path(f"chemprop_hpopt/{args.data_path.stem}")
+        args.hpopt_save_dir = Path(f"chemprop_hpopt/{args.data_path[0].stem}")
 
     args.hpopt_save_dir.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
There are two bugs in hpopt that don't get caught by our tests. 

The first is
```
chemprop hpopt -i tests/data/regression/mol/mol.csv 
  File "/home/knathan/chemprop/chemprop/cli/hpopt.py", line 278, in process_hpopt_args
    args.hpopt_save_dir = Path(f"chemprop_hpopt/{args.data_path.stem}")
                                                 ^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'stem'
```
This doesn't get caught because all our tests supply a value for `--hpopt-save-dir`. I don't think we need to change this because normally for tests you use the pytest temporary directories. I could be wrong and maybe we should change one of the tests.

The second is something like
```
chemprop hpopt -i tests/data/regression/mol/mol.csv 

with open(Path(args.output_dir) / "splits.json", "w") as f:
...
FileNotFoundError: [Errno 2] No such file or directory: 'chemprop_training/mol/2026-07-31T15-22-29/splits.json'
```
The output_dir is made in `TrainSubcommand.func` which isn't run during hpopt. But in our tests we first run training and then hpopt all within the same python call so the default dir `CHEMPROP_TRAIN_DIR / args.data_path[0].stem / NOW` keeps the same value (NOW is fixed once imported), so the directory can be reused in hpopt. 
This works on main:
```
pytest tests/cli/test_cli_regression_mol.py::test_train_quick tests/cli/test_cli_regression_mol.py::test_hyperopt_quick
```
While this doesn't:
```
pytest tests/cli/test_cli_regression_mol.py::test_hyperopt_quick
```
My solution is just to port the dir creation to `HpoptSubcommand.func`. Though I am very surprised this hasn't been opened as an issue before? An undergrad student I was working with showed me these errors, so I would think other users have run into them. They can both be overcome by just specifying `--hpopt-save-dir` and `--output-dir`, but still, wouldn't have someone opened an issue?