### PR TITLE
Clear molecule molgraph cache on reset

### DIFF
--- a/chemprop/data/datasets.py
+++ b/chemprop/data/datasets.py
@@ -214,8 +214,8 @@ class MoleculeDataset(_MolGraphDatasetMixin, MolGraphDataset):
         if self.data is None:
             raise ValueError("Data cannot be None!")
 
-        self.reset()
         self.cache = False
+        self.reset()
 
     def __getitem__(self, idx: int) -> Datum:
         d = self.data[idx]

--- a/chemprop/data/datasets.py
+++ b/chemprop/data/datasets.py
@@ -361,6 +361,7 @@ class MoleculeDataset(_MolGraphDatasetMixin, MolGraphDataset):
         self.__V_fs = self._V_fs
         self.__E_fs = self._E_fs
         self.__V_ds = self._V_ds
+        self._init_cache()
 
 
 @dataclass


### PR DESCRIPTION
`MoleculeDataset` has a `reset` method that un-does any potential scaling to the extra atom/bond features/descriptors. It is used in `__post_init__` to populate the public versions. We don't really use it elsewhere. 

But the other day, I was testing if a model could overfit to some data. I had a single dataset that had extra atom features. I had scaled them and given the scaler to the model. During training, chemprop expects scaled extra atom features, but during prediction, it expects them to be not scaled and will automatically scale them. Rather than make my dataset again, I tried calling `reset` on it to undo the scaling to use it as a test set. This didn't work though because I had also cached the molgraphs and the cached molgraphs had the scaled extra atom features. 

I therefore propose that `reset` also refreshes the molgraph cache, similar to what happens when you try to set the V_f and E_f directly. 

We don't need to call `_init_cache` in `MolAtomBondDataset` because it calls `super().reset()` and the other properties it resets are not saved in the molgraphs. `ReactionDataset` doesn't take V_f and E_f, so we don't need to worry about this for it. 