### PR TITLE
Add v2 paper reference to docs homepage

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ This website contains documentation for Chemprop, a PyTorch-based framework for 
 To get started with Chemprop, check out the :ref:`quickstart` page, and for more detailed information, see the :ref:`installation`, :ref:`tutorial`, and :ref:`notebooks` pages.
 
 .. note::
-    Chemprop recently underwent a ground-up rewrite and new major release (v2.0.0). A helpful transition guide from Chemprop v1 to v2 can be found `here <https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml>`_. This includes a side-by-side comparison of CLI argument options, a list of which arguments will be implemented in later versions of v2, and a list of changes to default hyperparameters.
+    Chemprop recently underwent a ground-up rewrite and new major release (v2.0.0). A helpful transition guide from Chemprop v1 to v2 can be found `here <https://docs.google.com/spreadsheets/u/3/d/e/2PACX-1vRshySIknVBBsTs5P18jL4WeqisxDAnDE5VRnzxqYEhYrMe4GLS17w5KeKPw9sged6TmmPZ4eEZSTIy/pubhtml>`_. This includes a side-by-side comparison of CLI argument options, a list of which arguments will be implemented in later versions of v2, and a list of changes to default hyperparameters. Further information about the update can be found in :footcite:t:`chemprop_v2`.
 
 If you use Chemprop to train or develop a model in your own work, we would appreciate if you cite the following papers:
 

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -35,3 +35,20 @@
             https://doi.org/10.1021/acs.jcim.3c01250
     }
 }
+
+# this was downloaded from ACS:  https://pubs.acs.org/doi/10.1021/acs.jcim.5c02332
+@article{chemprop_v2,
+    author = {Graff, David E. and Morgan, Nathan K. and Burns, Jackson W. and Doner, Anna C. and Li, Brian and Li, Shih-Cheng and Manu, Joel and Menon, Angiras and Pang, Hao-Wei and Wu, Haoyang and Zalte, Akshat Shirish and Zheng, Jonathan W. and Coley, Connor W. and Green, William H. and Greenman, Kevin P.},
+    title = {Chemprop v2: An Efficient, Modular Machine Learning Package for Chemical Property Prediction},
+    journal = {Journal of Chemical Information and Modeling},
+    volume = {66},
+    number = {1},
+    pages = {28-33},
+    year = {2025},
+    month = {12},
+    issn = {1549-9596},
+    doi = {10.1021/acs.jcim.5c02332},
+    note ={PMID: 41453060},
+    url = {https://doi.org/10.1021/acs.jcim.5c02332},
+    eprint = {https://pubs.acs.org/jcisd8/article-pdf/66/1/28/63290340/ci5c02332.pdf},
+}


### PR DESCRIPTION
The docs homepage: https://chemprop.readthedocs.io/en/latest/index.html lists which papers to cite, but currently doesn't have the v2 paper. 