### PR TITLE
Fix model with graph transform mutates input batch molgraph

### DIFF
--- a/chemprop/nn/transforms.py
+++ b/chemprop/nn/transforms.py
@@ -1,3 +1,5 @@
+import copy
+
 from numpy.typing import ArrayLike
 from sklearn.preprocessing import StandardScaler
 import torch
@@ -64,6 +66,8 @@ class GraphTransform(nn.Module):
         if self.training:
             return bmg
 
+        # Avoid mutating the input by using a shallow copy
+        bmg = copy.copy(bmg)
         bmg.V = self.V_transform(bmg.V)
         bmg.E = self.E_transform(bmg.E)
 

--- a/tests/integration/test_regression_mol.py
+++ b/tests/integration/test_regression_mol.py
@@ -3,12 +3,15 @@ data. A small enough dataset should be memorizable by even a moderately sized mo
 should generally pass."""
 
 from lightning import pytorch as pl
+import numpy as np
 import pytest
 import torch
 from torch.utils.data import DataLoader
 
-from chemprop import models, nn
+from chemprop import nn
 from chemprop.data import MoleculeDatapoint, MoleculeDataset, collate_batch
+from chemprop.featurizers import SimpleMoleculeMolGraphFeaturizer
+from chemprop.models import MPNN
 
 
 @pytest.fixture
@@ -137,30 +140,87 @@ def test_quantile_quick(regression_mpnn_quantile, dataloader):
     trainer.fit(regression_mpnn_quantile, dataloader, None)
 
 
-def test_input_not_mutated(dataloader):
-    V_f_transform = nn.ScaleTransform(mean=[1.0, 2.0], scale=[3.0, 4.0], pad=70)
-    E_f_transform = nn.ScaleTransform(mean=[0.0, 1.0], scale=[2.0, 3.0], pad=12)
+def test_input_not_mutated():
+    smis = ["CC", "CN", "CO", "CF", "CP", "CS", "CI"]
+    ys = np.random.rand(len(smis), 1) * 100
+
+    n_datapoints = len(smis)
+    n_atoms = 2
+    n_bonds = 1
+    n_extra_atom_features = 3
+    n_extra_bond_features = 4
+    n_extra_atom_descriptors = 5
+    n_extra_datapoint_descriptors = 6
+
+    extra_atom_features = np.random.rand(n_datapoints, n_atoms, n_extra_atom_features)
+    extra_bond_features = np.random.rand(n_datapoints, n_bonds, n_extra_bond_features)
+    extra_atom_descriptors = np.random.rand(n_datapoints, n_atoms, n_extra_atom_descriptors)
+    extra_datapoint_descriptors = np.random.rand(n_datapoints, n_extra_datapoint_descriptors)
+
+    datapoints = [
+        MoleculeDatapoint.from_smi(smi, y, x_d=x_d, V_f=V_f, E_f=E_f, V_d=V_d)
+        for smi, y, x_d, V_f, E_f, V_d in zip(
+            smis,
+            ys,
+            extra_datapoint_descriptors,
+            extra_atom_features,
+            extra_bond_features,
+            extra_atom_descriptors,
+        )
+    ]
+    featurizer = SimpleMoleculeMolGraphFeaturizer(
+        extra_atom_fdim=n_extra_atom_features, extra_bond_fdim=n_extra_bond_features
+    )
+    dset = MoleculeDataset(datapoints, featurizer=featurizer)
+    dataloader = DataLoader(dset, 32, collate_fn=collate_batch)
+
+    V_f_transform = nn.ScaleTransform(
+        mean=np.random.rand(n_extra_atom_features),
+        scale=np.random.rand(n_extra_atom_features),
+        pad=72,
+    )
+    E_f_transform = nn.ScaleTransform(
+        mean=np.random.rand(n_extra_bond_features),
+        scale=np.random.rand(n_extra_bond_features),
+        pad=14,
+    )
     graph_transform = nn.GraphTransform(V_transform=V_f_transform, E_transform=E_f_transform)
-    V_d_transform = nn.ScaleTransform(mean=[4.0, 5.0], scale=[6.0, 7.0])
-    mp = nn.BondMessagePassing(graph_transform=graph_transform, V_d_transform=V_d_transform)
+    V_d_transform = nn.ScaleTransform(
+        mean=np.random.rand(n_extra_atom_descriptors),
+        scale=np.random.rand(n_extra_atom_descriptors),
+    )
+    mp = nn.BondMessagePassing(
+        graph_transform=graph_transform,
+        V_d_transform=V_d_transform,
+        d_v=featurizer.atom_fdim,
+        d_e=featurizer.bond_fdim,
+        d_vd=n_extra_atom_descriptors,
+    )
 
-    output_transform = nn.UnscaleTransform(mean=[8.0, 9.0], scale=[10.0, 11.0])
-    ffn = nn.RegressionFFN(output_transform=output_transform)
+    output_transform = nn.UnscaleTransform(mean=np.random.rand(1), scale=np.random.rand(1))
+    ffn = nn.RegressionFFN(
+        output_transform=output_transform, input_dim=(mp.output_dim + n_extra_datapoint_descriptors)
+    )
 
-    X_d_transform = nn.ScaleTransform(mean=[13.0, 14.0], scale=[15.0, 16.0])
-    model = models.MPNN(mp, nn.NormAggregation(), ffn, X_d_transform=X_d_transform)
+    X_d_transform = nn.ScaleTransform(
+        mean=np.random.rand(n_extra_datapoint_descriptors),
+        scale=np.random.rand(n_extra_datapoint_descriptors),
+    )
+    model = MPNN(mp, nn.NormAggregation(), ffn, X_d_transform=X_d_transform)
 
     batch = next(iter(dataloader))
-    bmg, *_ = batch
+    bmg, V_d, X_d, *_ = batch
 
     batch2 = next(iter(dataloader))
-    bmg2, *_ = batch2
+    bmg2, V_d2, X_d2, *_ = batch2
 
     model.eval()
-    _ = model(bmg)
+    _ = model(bmg, V_d, X_d)
 
     assert torch.allclose(bmg.V, bmg2.V)
     assert torch.allclose(bmg.E, bmg2.E)
     assert torch.allclose(bmg.edge_index, bmg2.edge_index)
     assert torch.allclose(bmg.rev_edge_index, bmg2.rev_edge_index)
     assert torch.allclose(bmg.batch, bmg2.batch)
+    assert torch.allclose(V_d, V_d2)
+    assert torch.allclose(X_d, X_d2)

--- a/tests/integration/test_regression_mol.py
+++ b/tests/integration/test_regression_mol.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 from torch.utils.data import DataLoader
 
-from chemprop import nn
+from chemprop import models, nn
 from chemprop.data import MoleculeDatapoint, MoleculeDataset, collate_batch
 
 
@@ -135,3 +135,32 @@ def test_quantile_quick(regression_mpnn_quantile, dataloader):
         fast_dev_run=True,
     )
     trainer.fit(regression_mpnn_quantile, dataloader, None)
+
+
+def test_input_not_mutated(dataloader):
+    V_f_transform = nn.ScaleTransform(mean=[1.0, 2.0], scale=[3.0, 4.0], pad=70)
+    E_f_transform = nn.ScaleTransform(mean=[0.0, 1.0], scale=[2.0, 3.0], pad=12)
+    graph_transform = nn.GraphTransform(V_transform=V_f_transform, E_transform=E_f_transform)
+    V_d_transform = nn.ScaleTransform(mean=[4.0, 5.0], scale=[6.0, 7.0])
+    mp = nn.BondMessagePassing(graph_transform=graph_transform, V_d_transform=V_d_transform)
+
+    output_transform = nn.UnscaleTransform(mean=[8.0, 9.0], scale=[10.0, 11.0])
+    ffn = nn.RegressionFFN(output_transform=output_transform)
+
+    X_d_transform = nn.ScaleTransform(mean=[13.0, 14.0], scale=[15.0, 16.0])
+    model = models.MPNN(mp, nn.NormAggregation(), ffn, X_d_transform=X_d_transform)
+
+    batch = next(iter(dataloader))
+    bmg, *_ = batch
+
+    batch2 = next(iter(dataloader))
+    bmg2, *_ = batch2
+
+    model.eval()
+    _ = model(bmg)
+
+    assert torch.allclose(bmg.V, bmg2.V)
+    assert torch.allclose(bmg.E, bmg2.E)
+    assert torch.allclose(bmg.edge_index, bmg2.edge_index)
+    assert torch.allclose(bmg.rev_edge_index, bmg2.rev_edge_index)
+    assert torch.allclose(bmg.batch, bmg2.batch)


### PR DESCRIPTION
While working on https://github.com/chemprop/chemprop-contrib/pull/8, I found that passing a BatchMolGraph through a chemprop model twice gave different results. This is because the GraphTransform mutates the input. This isn't a big issue because I expect people usually just get the BatchMolGraph fresh from the dataloader. But I also think it is unexpected that the model mutates the input. In that PR, my `InteractionMPNN` class needs to reorder the nodes in the graph, but I didn't want it to mutate the input. I found that doing a shallow copy worked well because the underlying tensors are not duplicated (saves time and memory) and assigning a new tensor to one of the attributes (like V) doesn't make Python lose reference to the original input tensor. 

One question: I included a comment about this. Normally we try to limit the comments in the chemprop codebase. A user could look at the git blame to find this PR which describes why we use `copy.copy`. But in this case, I am slightly inclined to include a comment because someone might think copying the bmg is unusual. Open to thoughts on this though. 