### PR TITLE
Update citation for CheMeleon

### DIFF
--- a/chemprop/cli/train.py
+++ b/chemprop/cli/train.py
@@ -1479,7 +1479,7 @@ def build_model(
                     else:
                         logger.info(f"Loading cached CheMeleon from {model_path}")
                     logger.info(
-                        "Please cite DOI: 10.48550/arXiv.2506.15792 when using CheMeleon in published work"
+                        "Please cite DOI: 10.1021/acs.jcim.6c01546 when using CheMeleon in published work"
                     )
                     chemeleon_mp = torch.load(model_path, weights_only=True)
                     if is_multi:

--- a/examples/chemeleon_foundation_finetuning.ipynb
+++ b/examples/chemeleon_foundation_finetuning.ipynb
@@ -7,7 +7,8 @@
                 "# `CheMeleon` Foundation Finetuning\n",
                 "\n",
                 "This notebook demonstrates how to use the `CheMeleon` foundation model with Chemprop to achieve accurate prediction on small datasets.\n",
-                "One can also use this functionality from the Command Line Interface by using `--from-foundation chemeleon`."
+                "One can also use this functionality from the Command Line Interface by using `--from-foundation chemeleon`.\n",
+                "Read more about CheMeleon in the [companion manuscript](https://doi.org/10.1021/acs.jcim.6c01546)."
             ]
         },
         {


### PR DESCRIPTION
New paper for CheMeleon ( https://doi.org/10.1021/acs.jcim.6c01546) is peer-reviewed and out -- updating citation requested by the `chemprop train` CLI to match.